### PR TITLE
Add launch and attach svelte-vscode extension settings to launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,19 +1,36 @@
 {
-  "version": "0.2.0",
-  "configurations": [
-      {
-          "type": "node",
-          "request": "launch",
-          "name": "Run tests with debugger",
-          "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-          "args": [
-            "-r",
-            "ts-node/register",
-            "--colors",
-            "${workspaceFolder}/packages/*/test/**/*.ts",
-          ],
-          "console": "integratedTerminal",
-          "internalConsoleOptions": "neverOpen"
-      }
-  ]
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Run tests with debugger",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "-r",
+                "ts-node/register",
+                "--colors",
+                "${workspaceFolder}/packages/*/test/**/*.ts"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to svelte-vscode client",
+            "port": 6009,
+            "skipFiles": ["<node_internals>/**"]
+        },
+        {
+            "name": "Launch svelte-vscode client",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}/packages/svelte-vscode"],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": ["${workspaceRoot}/dist/**/*.js"]
+        }
+    ]
 }

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -1,5 +1,3 @@
-import * as path from 'path';
-
 import { workspace, ExtensionContext, TextDocument, Position, commands, window } from 'vscode';
 import {
     LanguageClient,
@@ -19,9 +17,7 @@ namespace TagCloseRequest {
 }
 
 export function activate(context: ExtensionContext) {
-    let serverModule = context.asAbsolutePath(
-        path.join('./', 'node_modules', 'svelte-language-server', 'bin', 'server.js'),
-    );
+    let serverModule = require.resolve('svelte-language-server/bin/server.js');
 
     let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
     let serverOptions: ServerOptions = {


### PR DESCRIPTION
Also fix language server module path in extension debugging, the origin method doesn't seems to work with yarn's dependencies hoisting.