### PR TITLE
Update service.ts to fix the errors with imports

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -85,30 +85,9 @@ export function createLanguageService(
         },
         getCurrentDirectory: () => workspacePath,
         getDefaultLibFileName: ts.getDefaultLibFilePath,
-
-        resolveModuleNames(moduleNames: string[], containingFile: string): ts.ResolvedModule[] {
-            return moduleNames.map(name => {
-                const resolved = ts.resolveModuleName(
-                    name,
-                    containingFile,
-                    compilerOptions,
-                    ts.sys,
-                );
-
-                if (!resolved.resolvedModule && isSvelte(name)) {
-                    return {
-                        resolvedFileName: resolve(dirname(containingFile), name),
-                        extension: extname(name),
-                    };
-                }
-
-                return resolved.resolvedModule!;
-            });
-        },
-
-        readFile(path: string, encoding?: string): string | undefined {
-            return ts.sys.readFile(path, encoding);
-        },
+        fileExists: ts.sys.fileExists,
+        readFile: ts.sys.readFile,
+        readDirectory: ts.sys.readDirectory,
     };
     let languageService = ts.createLanguageService(host);
 


### PR DESCRIPTION
This resolves the following problems that we've encountered.

**Problem 1**
When using `paths` in `tsconfig.json`, e.g

```json
"paths": {
      "@Components/*": ["components/*"]
 }
```

and then attempting to import a file in Svelte, e.g

```
import CoolComponent from '@Components/CoolComponent.svelte'
```

you receive a `2307 ("Cannot find module")` error.

**Problem 2**
When using this [type](https://github.com/pyoner/svelte-typescript/blob/master/packages/types/types/svelte/svelte.d.ts) on `tsconfig.json`

And then trying to import something like e.g

```
import Editor from '/.Editor.svelte'
```