### PR TITLE
Fixing reactive values in typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ typings/
 
 # tdsx
 dist
+
+.DS_STORE

--- a/packages/language-server/.gitignore
+++ b/packages/language-server/.gitignore
@@ -1,3 +1,4 @@
 dist/
 .vscode/
 node_modules/
+.DS_STORE

--- a/packages/language-server/src/plugins/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/TypeScriptPlugin.ts
@@ -35,7 +35,7 @@ import {
     mapSeverity,
 } from './typescript/utils';
 import { getLanguageServiceForDocument, CreateDocument } from './typescript/service';
-import { pathToUrl } from '../utils';
+import { pathToUrl, isValidSvelteReactiveValueDiagnostic } from '../utils';
 import { TextDocument } from '../lib/documents/TextDocument';
 
 export class TypeScriptPlugin
@@ -103,7 +103,7 @@ export class TypeScriptPlugin
             source: isTypescript ? 'ts' : 'js',
             message: ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
             code: diagnostic.code,
-        }));
+        })).filter(diagnostic => isValidSvelteReactiveValueDiagnostic(diagnostic));
     }
 
     doHover(document: Document, position: Position): Hover | null {

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -19,3 +19,15 @@ export function pathToUrl(path: string) {
 export function flatten<T>(arr: T[][]): T[] {
     return arr.reduce((all, item) => [...all, ...item], []);
 }
+
+const TS2552_REGEX = /Cannot find name '\$([a-zA-Z0-9_]+)'. Did you mean '([a-zA-Z0-9_]+)'\?/i;
+export function isValidSvelteReactiveValueDiagnostic(diagnostic: any): boolean {
+  if (diagnostic.code !== 2552) return true;
+
+  /** if error message doesn't contain a reactive value, do nothing */
+  if (!diagnostic.message.includes('$')) return true;
+
+  const [, usedVar, proposedVar] = diagnostic.message.match(TS2552_REGEX) || [];
+
+  return !(usedVar && proposedVar && usedVar === proposedVar);
+} 

--- a/packages/svelte-vscode/.gitignore
+++ b/packages/svelte-vscode/.gitignore
@@ -1,2 +1,3 @@
 /dist
 /node_modules
+.DS_STORE


### PR DESCRIPTION
Hi there!

When using store reactive values that are prefix with $ sign, TypeScripts reports the 2552 error that states the following:

`'Cannot find name '{0}'. Did you mean '{1}'?'`

although the variable is declared and valid, so this PR will suppress those errors in case they are defined and start with $.

Please let me know your thoughts!