### PR TITLE
Adds a weekly task to deploy a beta version of the extension

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: "10.x"
           registry-url: "https://registry.npmjs.org"
 
+      # Ensure everything is compiling
+      - run: "yarn install"
       - run: "yarn build"
 
       # Lets us use one-liner JSON manipulations the package.json files
@@ -32,9 +34,10 @@ jobs:
       # So, remove the workspace
       - run: "rm package.json yarn.lock"
 
-      # Re-run the  yarn isntall outside of the workspace
+      # Re-run the  yarn install outside of the workspace
       - run: "cd packages/svelte-vscode"
       - run: "yarn install"
+      - run: "mv ../packages/language-server node_modules/svelte-language-server"
 
       # Just a hard constraint from azure
       - run: 'echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"'

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -1,13 +1,12 @@
 name: Weekly builds of the Svelte Language Tools Beta
 
 # For testing
-on: push
+# on: push
 
 # For production
-# on:
-  # schedule:
-  #   # Monday once a week
-  #   - cron: "0 4 * * 0"
+on:
+  schedule:
+    - cron: "0 4 * * *"
 
 jobs:
   deploy:
@@ -29,7 +28,7 @@ jobs:
 
       # Setup the environment
       - run: 'json -I -f packages/svelte-vscode/package.json -e "this.dependencies[\`svelte-language-server\`]=\`file:../language-server\`"'
-      - run: 'json -I -f packages/svelte-vscode/package.json -e "this.version=\`99.0.0-\` + (new Date()).toISOString().substr(0, 10)"'
+      - run: 'json -I -f packages/svelte-vscode/package.json -e "this.version=\`99.0.0\`"'
 
       # To deploy we need a node_modules folder which isn't in the yarn 
       # So, remove the workspace
@@ -49,7 +48,7 @@ jobs:
          # Just a hard constraint from azure
          echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"
         
-         npx vsce publish --yarn -p $VSCE_TOKEN
+         npx vsce publish patch --yarn -p $VSCE_TOKEN
       
         env:
           VSCE_TOKEN: ${{ secrets.AZURE_PAN_TOKEN }}

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -1,0 +1,45 @@
+name: Weekly builds of the Svelte Language Tools Beta
+
+# For testing
+on: push
+
+# For production
+# on:
+  # schedule:
+  #   # Monday once a week
+  #   - cron: "0 4 * * 0"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "10.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: "yarn build"
+
+      # Lets us use one-liner JSON manipulations the package.json files
+      - run: "npm install -g json"
+
+      # Version as semver 
+      - run: "json -I -f packages/language-server/package.json -e "this.version=`99.0.0-${(new Date()).toISOString().substr(0, 10)}`"
+
+      # To deploy we need a node_modules folder which isn't in the yarn 
+      # So, remove the workspace
+      - run: rm package.json yarn.lock
+
+      # Re-run the  yarn isntall outside of the workspace
+      - run: cd packages/svelte-vscode
+      - run: yarn install
+
+      # Just a hard constraint from azure
+      - run: echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"
+      
+      - run: npx vsce publish --yarn -p $VSCE_TOKEN
+        env:
+          VSCE_TOKEN: ${{ secrets.AZURE_PAN_TOKEN }}
+

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -25,21 +25,21 @@ jobs:
       # Lets us use one-liner JSON manipulations the package.json files
       - run: "npm install -g json"
 
-      # Version as semver 
-      - run: "json -I -f packages/language-server/package.json -e "this.version=`99.0.0-${(new Date()).toISOString().substr(0, 10)}`"
+      # Version as semver
+      - run: "json -I -f packages/language-server/package.json -e \"this.version=`99.0.0-${(new Date()).toISOString().substr(0, 10)}`\""
 
       # To deploy we need a node_modules folder which isn't in the yarn 
       # So, remove the workspace
-      - run: rm package.json yarn.lock
+      - run: "rm package.json yarn.lock"
 
       # Re-run the  yarn isntall outside of the workspace
-      - run: cd packages/svelte-vscode
-      - run: yarn install
+      - run: "cd packages/svelte-vscode"
+      - run: "yarn install"
 
       # Just a hard constraint from azure
-      - run: echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"
-      
-      - run: npx vsce publish --yarn -p $VSCE_TOKEN
+      - run: 'echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"'
+
+      - run: "npx vsce publish --yarn -p $VSCE_TOKEN"
         env:
           VSCE_TOKEN: ${{ secrets.AZURE_PAN_TOKEN }}
 

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - run: "npm install -g json"
 
       # Version as semver
-      - run: "json -I -f packages/language-server/package.json -e \"this.version=`99.0.0-${(new Date()).toISOString().substr(0, 10)}`\""
+      - run: 'json -I -f packages/language-server/package.json -e "this.version=\`99.0.0-\` + (new Date()).toISOString().substr(0, 10)"'
 
       # To deploy we need a node_modules folder which isn't in the yarn 
       # So, remove the workspace
@@ -37,7 +37,7 @@ jobs:
       # Re-run the  yarn install outside of the workspace
       - run: "cd packages/svelte-vscode"
       - run: "yarn install"
-      - run: "mv ../packages/language-server node_modules/svelte-language-server"
+      - run: "mv ../language-server node_modules/svelte-language-server"
 
       # Just a hard constraint from azure
       - run: 'echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"'

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -10,7 +10,7 @@ on: push
   #   - cron: "0 4 * * 0"
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,22 +27,30 @@ jobs:
       # Lets us use one-liner JSON manipulations the package.json files
       - run: "npm install -g json"
 
-      # Version as semver
-      - run: 'json -I -f packages/language-server/package.json -e "this.version=\`99.0.0-\` + (new Date()).toISOString().substr(0, 10)"'
+      # Setup the environment
+      - run: 'json -I -f packages/svelte-vscode/package.json -e "this.dependencies[\`svelte-language-server\`]=\`file:../language-server\`"'
+      - run: 'json -I -f packages/svelte-vscode/package.json -e "this.version=\`99.0.0-\` + (new Date()).toISOString().substr(0, 10)"'
 
       # To deploy we need a node_modules folder which isn't in the yarn 
       # So, remove the workspace
       - run: "rm package.json yarn.lock"
 
+      # Re-run the yarn install outside of the workspaceSetup the language server
+      - run: |
+         cd packages/language-server
+         yarn install
+         cd ..
+
       # Re-run the  yarn install outside of the workspace
-      - run: "cd packages/svelte-vscode"
-      - run: "yarn install"
-      - run: "mv ../language-server node_modules/svelte-language-server"
+      - run: |
+         cd packages/svelte-vscode
+         yarn install
 
-      # Just a hard constraint from azure
-      - run: 'echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"'
-
-      - run: "npx vsce publish --yarn -p $VSCE_TOKEN"
+         # Just a hard constraint from azure
+         echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"
+        
+         npx vsce publish --yarn -p $VSCE_TOKEN
+      
         env:
           VSCE_TOKEN: ${{ secrets.AZURE_PAN_TOKEN }}
 

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -1,6 +1,6 @@
 {
     "name": "svelte-vscode",
-    "version": "0.9.3",
+    "version": "0.5.0",
     "description": "Svelte language support for VS Code",
     "main": "dist/src/extension.js",
     "scripts": {
@@ -23,11 +23,11 @@
         "url": "https://github.com/sveltejs/language-tools/issues"
     },
     "homepage": "https://github.com/sveltejs/language-tools#readme",
-    "displayName": "Svelte",
-    "publisher": "JamesBirtles",
+    "displayName": "Svelte Beta",
+    "publisher": "svelte",
     "icon": "icons/logo.png",
     "galleryBanner": {
-        "color": "#333333",
+        "color": "#FF3E00",
         "theme": "dark"
     },
     "categories": [


### PR DESCRIPTION
Creates a "Svelte Beta" extension, which is shipped once a week automatically

<img width="1483" alt="Screen Shot 2020-03-26 at 10 34 47 PM" src="https://user-images.githubusercontent.com/49038/77715484-16774b00-6fb2-11ea-8356-cb9ca2b31658.png">

Fixes #15 