### PR TITLE
(feat) resolve svelte module names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ typings/
 
 # tdsx
 dist
+
+# VSCode history extension
+.history

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/packkages/svelte-vscode/dist/**/*.js"],
-			"preLaunchTask": "npm: watch"
+            "preLaunchTask": "npm: watch"
         },
         {
             "type": "node",
@@ -23,6 +23,9 @@
                 "--colors",
                 "${workspaceFolder}/packages/*/test/**/*.ts"
             ],
+            "env": {
+                "TS_NODE_COMPILER_OPTIONS": "{\"esModuleInterop\":true}"
+            },
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         },

--- a/packages/language-server/src/api/wrapFragmentPlugin.ts
+++ b/packages/language-server/src/api/wrapFragmentPlugin.ts
@@ -61,7 +61,9 @@ export function wrapFragmentPlugin<P>(plugin: P, fragmentPredicate: FragmentPred
                     });
                 },
 
-                openDocument: (document: TextDocumentItem) => host.openDocument(document),
+                openDocument: (document: TextDocumentItem) => {
+                    return getFragment(host.openDocument(document))! as Document;
+                },
                 lockDocument: (uri: string) => host.lockDocument(uri),
                 getConfig: (key: string) => host.getConfig(key),
             });

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -1,0 +1,110 @@
+import ts from 'typescript';
+import { isVirtualSvelteFilePath, ensureRealSvelteFilePath, isSvelteFilePath } from './utils';
+import { isAbsolute } from 'path';
+import { DocumentSnapshot } from './DocumentSnapshot';
+import { createSvelteSys } from './svelte-sys';
+
+/**
+ * Caches resolved modules.
+ */
+class ModuleResolutionCache {
+    private cache = new Map<string, ts.ResolvedModule>();
+
+    /**
+     * Tries to get a cached module.
+     */
+    get(moduleName: string, containingFile: string): ts.ResolvedModule | undefined {
+        return this.cache.get(this.getKey(moduleName, containingFile));
+    }
+
+    /**
+     * Caches resolved module, if it is not undefined.
+     */
+    set(moduleName: string, containingFile: string, resolvedModule: ts.ResolvedModule | undefined) {
+        if (!resolvedModule) {
+            return;
+        }
+        this.cache.set(this.getKey(moduleName, containingFile), resolvedModule);
+    }
+
+    private getKey(moduleName: string, containingFile: string) {
+        return containingFile + ':::' + ensureRealSvelteFilePath(moduleName);
+    }
+}
+
+/**
+ * Creates a module loader specifically for `.svelte` files.
+ *
+ * The typescript language service tries to look up other files that are referenced in the currently open svelte file.
+ * For `.ts`/`.js` files this works, for `.svelte` files it does not by default.
+ * Reason: The typescript language service does not know about the `.svelte` file ending,
+ * so it assumes it's a normal typescript file and searches for files like `../Component.svelte.ts`, which is wrong.
+ * In order to fix this, we need to wrap typescript's module resolution and reroute all `.svelte.ts` file lookups to .svelte.
+ *
+ * @param getSvelteSnapshot A function which returns a fully preprocessed typescript/javascript snapshot
+ * @param compilerOptions The typescript compiler options
+ */
+export function createSvelteModuleLoader(
+    getSvelteSnapshot: (fileName: string) => DocumentSnapshot | undefined,
+    compilerOptions: ts.CompilerOptions,
+) {
+    const svelteSys = createSvelteSys(getSvelteSnapshot);
+    const moduleCache = new ModuleResolutionCache();
+
+    return {
+        fileExists: svelteSys.fileExists,
+        readFile: svelteSys.readFile,
+        resolveModuleNames,
+    };
+
+    function resolveModuleNames(
+        moduleNames: string[],
+        containingFile: string,
+    ): (ts.ResolvedModule | undefined)[] {
+        return moduleNames.map(moduleName => {
+            const cachedModule = moduleCache.get(moduleName, containingFile);
+            if (cachedModule) {
+                return cachedModule;
+            }
+
+            const resolvedModule = resolveModuleName(moduleName, containingFile);
+            moduleCache.set(moduleName, containingFile, resolvedModule);
+            return resolvedModule;
+        });
+    }
+
+    function resolveModuleName(
+        name: string,
+        containingFile: string,
+    ): ts.ResolvedModule | undefined {
+        // In the normal case, delegate to ts.resolveModuleName.
+        // In the relative-imported.svelte case, delegate to our own svelte module loader.
+        if (isAbsolute(name) || !isSvelteFilePath(name)) {
+            return ts.resolveModuleName(name, containingFile, compilerOptions, ts.sys)
+                .resolvedModule;
+        }
+
+        const tsResolvedModule = ts.resolveModuleName(
+            name,
+            containingFile,
+            compilerOptions,
+            svelteSys,
+        ).resolvedModule;
+        if (!tsResolvedModule || !isVirtualSvelteFilePath(tsResolvedModule.resolvedFileName)) {
+            return tsResolvedModule;
+        }
+
+        const resolvedFileName = ensureRealSvelteFilePath(tsResolvedModule.resolvedFileName);
+        const snapshot = getSvelteSnapshot(resolvedFileName);
+        const extension: ts.Extension =
+            snapshot && snapshot.scriptKind === ts.ScriptKind.TS
+                ? ts.Extension.Ts
+                : ts.Extension.Js;
+
+        const resolvedSvelteModule: ts.ResolvedModuleFull = {
+            extension,
+            resolvedFileName,
+        };
+        return resolvedSvelteModule;
+    }
+}

--- a/packages/language-server/src/plugins/typescript/svelte-sys.ts
+++ b/packages/language-server/src/plugins/typescript/svelte-sys.ts
@@ -1,0 +1,38 @@
+import { DocumentSnapshot } from './DocumentSnapshot';
+import ts from 'typescript';
+import { ensureRealSvelteFilePath, isVirtualSvelteFilePath, toRealSvelteFilePath } from './utils';
+
+/**
+ * This should only be accessed by TS svelte module resolution.
+ */
+export function createSvelteSys(
+    getSvelteSnapshot: (fileName: string) => DocumentSnapshot | undefined,
+) {
+    const svelteSys: ts.System = {
+        ...ts.sys,
+        fileExists(path: string) {
+            return ts.sys.fileExists(ensureRealSvelteFilePath(path));
+        },
+        readFile(path, encoding) {
+            if (isVirtualSvelteFilePath(path)) {
+                const fileText = ts.sys.readFile(toRealSvelteFilePath(path), encoding);
+                const snapshot = getSvelteSnapshot(fileText!);
+                return fileText ? snapshot?.getText(0, snapshot.getLength()) : fileText;
+            }
+            const fileText = ts.sys.readFile(path, encoding);
+            return fileText;
+        },
+    };
+
+    if (ts.sys.realpath) {
+        const realpath = ts.sys.realpath;
+        svelteSys.realpath = function(path) {
+            if (isVirtualSvelteFilePath(path)) {
+                return realpath(toRealSvelteFilePath(path)) + '.ts';
+            }
+            return realpath(path);
+        };
+    }
+
+    return svelteSys;
+}

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -19,7 +19,9 @@ export function getScriptKindFromFileName(fileName: string): ts.ScriptKind {
     }
 }
 
-export function getScriptKindFromAttributes(attrs: Record<string, string>): ts.ScriptKind {
+export function getScriptKindFromAttributes(
+    attrs: Record<string, string>,
+): ts.ScriptKind.TS | ts.ScriptKind.JS {
     const type = attrs.lang || attrs.type;
 
     switch (type) {
@@ -33,8 +35,20 @@ export function getScriptKindFromAttributes(attrs: Record<string, string>): ts.S
     }
 }
 
-export function isSvelte(filePath: string) {
+export function isSvelteFilePath(filePath: string) {
     return filePath.endsWith('.svelte');
+}
+
+export function isVirtualSvelteFilePath(filePath: string) {
+    return filePath.endsWith('.svelte.ts');
+}
+
+export function toRealSvelteFilePath(filePath: string) {
+    return filePath.slice(0, -'.ts'.length);
+}
+
+export function ensureRealSvelteFilePath(filePath: string) {
+    return isVirtualSvelteFilePath(filePath) ? toRealSvelteFilePath(filePath) : filePath;
 }
 
 export function convertRange(

--- a/packages/language-server/test/plugins/typescript/module-loader.ts
+++ b/packages/language-server/test/plugins/typescript/module-loader.ts
@@ -1,0 +1,113 @@
+import * as assert from 'assert';
+import sinon from 'sinon';
+import ts from 'typescript';
+import * as svS from '../../../src/plugins/typescript/svelte-sys';
+import { DocumentSnapshot } from '../../../src/plugins/typescript/DocumentSnapshot';
+import { createSvelteModuleLoader } from '../../../src/plugins/typescript/module-loader';
+
+describe('createSvelteModuleLoader', () => {
+    afterEach(function() {
+        sinon.restore();
+    });
+
+    function setup(resolvedModule: ts.ResolvedModuleFull) {
+        const svelteFile = 'const a = "svelte file";';
+        const snapshot: DocumentSnapshot = {
+            getText: (_, __) => svelteFile,
+            getLength: () => svelteFile.length,
+            getChangeRange: () => undefined,
+            scriptKind: ts.ScriptKind.TS,
+            version: 0,
+        };
+        const getSvelteSnapshotStub = sinon.stub().returns(snapshot);
+
+        const resolveStub = sinon.stub().returns(<ts.ResolvedModuleWithFailedLookupLocations>{
+            resolvedModule,
+        });
+        sinon.replace(ts, 'resolveModuleName', resolveStub);
+
+        const svelteSys = <any>'svelteSys';
+        sinon.stub(svS, 'createSvelteSys').returns(svelteSys);
+
+        const compilerOptions: ts.CompilerOptions = { strict: true };
+        const moduleResolver = createSvelteModuleLoader(getSvelteSnapshotStub, compilerOptions);
+
+        return {
+            getSvelteSnapshotStub,
+            resolveStub,
+            compilerOptions,
+            moduleResolver,
+            svelteSys,
+        };
+    }
+
+    it('uses tsSys for normal files', async () => {
+        const resolvedModule: ts.ResolvedModuleFull = {
+            extension: ts.Extension.Ts,
+            resolvedFileName: 'filename.ts',
+        };
+        const { resolveStub, moduleResolver, compilerOptions } = setup(resolvedModule);
+        const result = moduleResolver.resolveModuleNames(
+            ['./normal.ts'],
+            'C:/somerepo/somefile.svelte',
+        );
+
+        assert.deepStrictEqual(result, [resolvedModule]);
+        assert.deepStrictEqual(resolveStub.getCall(0).args, [
+            './normal.ts',
+            'C:/somerepo/somefile.svelte',
+            compilerOptions,
+            ts.sys,
+        ]);
+    });
+
+    it('uses svelte module loader for virtual svelte files', async () => {
+        const resolvedModule: ts.ResolvedModuleFull = {
+            extension: ts.Extension.Ts,
+            resolvedFileName: 'filename.svelte.ts',
+        };
+        const {
+            resolveStub,
+            svelteSys,
+            moduleResolver,
+            compilerOptions,
+            getSvelteSnapshotStub,
+        } = setup(resolvedModule);
+        const result = moduleResolver.resolveModuleNames(
+            ['./svelte.svelte'],
+            'C:/somerepo/somefile.svelte',
+        );
+
+        assert.deepStrictEqual(result, [
+            <ts.ResolvedModuleFull>{
+                extension: ts.Extension.Ts,
+                resolvedFileName: 'filename.svelte',
+            },
+        ]);
+        assert.deepStrictEqual(resolveStub.getCall(0).args, [
+            './svelte.svelte',
+            'C:/somerepo/somefile.svelte',
+            compilerOptions,
+            svelteSys,
+        ]);
+        assert.deepStrictEqual(getSvelteSnapshotStub.getCall(0).args, ['filename.svelte']);
+    });
+
+    it('uses cache if module was already resolved before', async () => {
+        const resolvedModule: ts.ResolvedModuleFull = {
+            extension: ts.Extension.Ts,
+            resolvedFileName: 'filename.ts',
+        };
+        const { resolveStub, moduleResolver } = setup(resolvedModule);
+        // first call
+        moduleResolver.resolveModuleNames(['./normal.ts'], 'C:/somerepo/somefile.svelte');
+        // second call, which should be from cache
+        const result = moduleResolver.resolveModuleNames(
+            ['./normal.ts'],
+            'C:/somerepo/somefile.svelte',
+        );
+
+        assert.deepStrictEqual(result, [resolvedModule]);
+        assert.deepStrictEqual(resolveStub.callCount, 1);
+    });
+});

--- a/packages/language-server/test/plugins/typescript/svelte-sys.ts
+++ b/packages/language-server/test/plugins/typescript/svelte-sys.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+import sinon from 'sinon';
+import ts from 'typescript';
+import { DocumentSnapshot } from '../../../src/plugins/typescript/DocumentSnapshot';
+import { createSvelteSys } from '../../../src/plugins/typescript/svelte-sys';
+
+describe('Svelte Sys', () => {
+    afterEach(function() {
+        sinon.restore();
+    });
+
+    function setupLoader() {
+        const tsFile = 'const a = "ts file";';
+        const svelteFile = 'const a = "svelte file";';
+        const snapshot: DocumentSnapshot = {
+            getText: (_, __) => svelteFile,
+            getLength: () => svelteFile.length,
+            getChangeRange: () => undefined,
+            scriptKind: ts.ScriptKind.TS,
+            version: 0,
+        };
+        const fileExistsStub = sinon.stub().returns(true);
+        const readFileStub = sinon.stub().returns(tsFile);
+        const getSvelteSnapshotStub = sinon.stub().returns(snapshot);
+
+        sinon.replace(ts.sys, 'fileExists', fileExistsStub);
+        sinon.replace(ts.sys, 'readFile', readFileStub);
+        const loader = createSvelteSys(getSvelteSnapshotStub);
+
+        return {
+            tsFile,
+            svelteFile,
+            snapshot,
+            fileExistsStub,
+            readFileStub,
+            getSvelteSnapshotStub,
+            loader,
+        };
+    }
+
+    describe('#fileExists', () => {
+        it('should leave files with no .svelte.ts-ending as is', async () => {
+            const { loader, fileExistsStub } = setupLoader();
+            loader.fileExists('../file.ts');
+
+            assert.strictEqual(fileExistsStub.getCall(0).args[0], '../file.ts');
+        });
+
+        it('should convert .svelte.ts-endings', async () => {
+            const { loader, fileExistsStub } = setupLoader();
+            loader.fileExists('../file.svelte.ts');
+
+            assert.strictEqual(fileExistsStub.getCall(0).args[0], '../file.svelte');
+        });
+    });
+
+    describe('#readFile', () => {
+        it('should delegate read to ts.sys for files with no .svelte.ts-ending as is', async () => {
+            const { loader, readFileStub, getSvelteSnapshotStub, tsFile } = setupLoader();
+            const code = loader.readFile('../file.ts')!;
+
+            assert.strictEqual(readFileStub.getCall(0).args[0], '../file.ts');
+            assert.strictEqual(getSvelteSnapshotStub.called, false);
+            assert.strictEqual(code, tsFile);
+        });
+
+        it('should convert .svelte.ts-endings and invoke getSvelteSnapshot', async () => {
+            const { loader, readFileStub, getSvelteSnapshotStub, svelteFile } = setupLoader();
+            const code = loader.readFile('../file.svelte.ts')!;
+
+            assert.strictEqual(readFileStub.getCall(0).args[0], '../file.svelte');
+            assert.strictEqual(getSvelteSnapshotStub.called, true);
+            assert.strictEqual(code, svelteFile);
+        });
+    });
+});


### PR DESCRIPTION
Enables the language server to walk the svelte files (load other svelte files from the open one). Makes it possible to navigate from one svelte file to the other by clicking on its uri.

Heavily inspired by how vetur does it.