### PR TITLE
Fix and refactor setting/getting config

### DIFF
--- a/packages/language-server/src/api/interfaces.ts
+++ b/packages/language-server/src/api/interfaces.ts
@@ -27,9 +27,7 @@ import {
     TextDocumentIdentifier,
     VersionedTextDocumentIdentifier,
 } from 'vscode-languageserver-types';
-
-import { TextDocumentContentChangeEvent } from "vscode-languageserver-protocol"
-
+import { TextDocumentContentChangeEvent } from 'vscode-languageserver-protocol';
 import { Document } from './Document';
 
 export {
@@ -60,7 +58,7 @@ export {
     TextDocumentEdit,
     TextDocumentIdentifier,
     VersionedTextDocumentIdentifier,
-    TextDocumentContentChangeEvent
+    TextDocumentContentChangeEvent,
 };
 
 export type Resolvable<T> = T | Promise<T>;
@@ -222,8 +220,3 @@ export interface FragmentDetails {
 }
 
 export type FragmentPredicate = (fragment: Fragment) => boolean;
-
-export interface Plugin {
-    pluginId: string;
-    defaultConfig: any;
-}

--- a/packages/language-server/src/api/wrapFragmentPlugin.ts
+++ b/packages/language-server/src/api/wrapFragmentPlugin.ts
@@ -10,7 +10,6 @@ import {
     FormattingProvider,
     TextEdit,
     TextDocumentItem,
-    Plugin,
     DocumentColorsProvider,
     ColorInformation,
     ColorPresentationsProvider,
@@ -37,10 +36,7 @@ import {
 } from './fragmentPositions';
 import { Host, OnRegister } from './Host';
 
-export function wrapFragmentPlugin<P extends Plugin>(
-    plugin: P,
-    fragmentPredicate: FragmentPredicate,
-): P {
+export function wrapFragmentPlugin<P>(plugin: P, fragmentPredicate: FragmentPredicate): P {
     function getFragment(document: Document) {
         return document.findFragment(fragmentPredicate);
     }

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -1,0 +1,116 @@
+/**
+ * Default config for the language server.
+ */
+export const defaultLSConfig: LSConfig = {
+    typescript: {
+        enable: true,
+        diagnostics: { enable: true },
+        hover: { enable: true },
+        completions: { enable: true },
+        definitions: { enable: true },
+        documentSymbols: { enable: true },
+        codeActions: { enable: true },
+    },
+    css: {
+        enable: true,
+        diagnostics: { enable: true },
+        hover: { enable: true },
+        completions: { enable: true },
+        documentColors: { enable: true },
+        colorPresentations: { enable: true },
+        documentSymbols: { enable: true },
+    },
+    html: {
+        enable: true,
+        hover: { enable: true },
+        completions: { enable: true },
+        tagComplete: { enable: true },
+        documentSymbols: { enable: true },
+    },
+    svelte: {
+        enable: true,
+        diagnostics: { enable: true },
+        format: { enable: true },
+    },
+};
+
+/**
+ * Representation of the language server config.
+ * Should be kept in sync with infos in `packages/svelte-vscode/package.json`.
+ */
+export interface LSConfig {
+    typescript: LSTypescriptConfig;
+    css: LSCSSConfig;
+    html: LSHTMLConfig;
+    svelte: LSSvelteConfig;
+}
+
+export interface LSTypescriptConfig {
+    enable: boolean;
+    diagnostics: {
+        enable: boolean;
+    };
+    hover: {
+        enable: boolean;
+    };
+    documentSymbols: {
+        enable: boolean;
+    };
+    completions: {
+        enable: boolean;
+    };
+    definitions: {
+        enable: boolean;
+    };
+    codeActions: {
+        enable: boolean;
+    };
+}
+
+export interface LSCSSConfig {
+    enable: boolean;
+    diagnostics: {
+        enable: boolean;
+    };
+    hover: {
+        enable: boolean;
+    };
+    completions: {
+        enable: boolean;
+    };
+    documentColors: {
+        enable: boolean;
+    };
+    colorPresentations: {
+        enable: boolean;
+    };
+    documentSymbols: {
+        enable: boolean;
+    };
+}
+
+export interface LSHTMLConfig {
+    enable: boolean;
+    hover: {
+        enable: boolean;
+    };
+    completions: {
+        enable: boolean;
+    };
+    tagComplete: {
+        enable: boolean;
+    };
+    documentSymbols: {
+        enable: boolean;
+    };
+}
+
+export interface LSSvelteConfig {
+    enable: boolean;
+    diagnostics: {
+        enable: boolean;
+    };
+    format: {
+        enable: boolean;
+    };
+}

--- a/packages/language-server/src/plugins/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/CSSPlugin.ts
@@ -26,6 +26,7 @@ import {
     SymbolInformation,
 } from '../api';
 import { getEmmetCompletionParticipants } from 'vscode-emmet-helper';
+import { LSCSSConfig } from '../ls-config';
 
 export class CSSPlugin
     implements
@@ -36,21 +37,10 @@ export class CSSPlugin
         ColorPresentationsProvider,
         DocumentSymbolsProvider {
     private readonly triggerCharacters = ['/'];
-            
+
     public static matchFragment(fragment: Fragment) {
         return fragment.details.attributes.tag == 'style';
     }
-
-    public pluginId = 'css';
-    public defaultConfig = {
-        enable: true,
-        diagnostics: { enable: true },
-        hover: { enable: true },
-        completions: { enable: true },
-        documentColors: { enable: true },
-        colorPresentations: { enable: true },
-        documentSymbols: { enable: true },
-    };
 
     private host!: Host;
     private stylesheets = new WeakMap<Document, Stylesheet>();
@@ -67,7 +57,7 @@ export class CSSPlugin
     }
 
     getDiagnostics(document: Document): Diagnostic[] {
-        if (!this.host.getConfig<boolean>('css.diagnostics.enable')) {
+        if (!this.featureEnabled('diagnostics')) {
             return [];
         }
 
@@ -88,7 +78,7 @@ export class CSSPlugin
     }
 
     doHover(document: Document, position: Position): Hover | null {
-        if (!this.host.getConfig<boolean>('css.hover.enable')) {
+        if (!this.featureEnabled('hover')) {
             return null;
         }
 
@@ -104,13 +94,17 @@ export class CSSPlugin
         );
     }
 
-    getCompletions(document: Document, position: Position, triggerCharacter: string): CompletionList | null {
+    getCompletions(
+        document: Document,
+        position: Position,
+        triggerCharacter: string,
+    ): CompletionList | null {
         // TODO: Why did this need to be removed?
         // if (triggerCharacter != undefined && !this.triggerCharacters.includes(triggerCharacter)) {
         //     return null;
         // }
-        
-        if (!this.host.getConfig<boolean>('css.completions.enable')) {
+
+        if (!this.featureEnabled('completions')) {
             return null;
         }
 
@@ -136,7 +130,7 @@ export class CSSPlugin
     }
 
     getDocumentColors(document: Document): ColorInformation[] {
-        if (!this.host.getConfig<boolean>('css.documentColors.enable')) {
+        if (!this.featureEnabled('documentColors')) {
             return [];
         }
 
@@ -152,7 +146,7 @@ export class CSSPlugin
     }
 
     getColorPresentations(document: Document, range: Range, color: Color): ColorPresentation[] {
-        if (!this.host.getConfig<boolean>('css.colorPresentations.enable')) {
+        if (!this.featureEnabled('colorPresentations')) {
             return [];
         }
 
@@ -170,7 +164,7 @@ export class CSSPlugin
     }
 
     getDocumentSymbols(document: Document): SymbolInformation[] {
-        if (!this.host.getConfig<boolean>('css.documentColors.enable')) {
+        if (!this.featureEnabled('documentColors')) {
             return [];
         }
 
@@ -192,6 +186,13 @@ export class CSSPlugin
 
                 return symbol;
             });
+    }
+
+    private featureEnabled(feature: keyof LSCSSConfig) {
+        return (
+            this.host.getConfig<boolean>('css.enable') &&
+            this.host.getConfig<boolean>(`css.${feature}.enable`)
+        );
     }
 }
 

--- a/packages/language-server/src/plugins/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/HTMLPlugin.ts
@@ -11,18 +11,10 @@ import {
     SymbolInformation,
 } from '../api';
 import { svelteHtmlDataProvider } from './html/dataProvider';
+import { LSHTMLConfig } from '../ls-config';
 // import { svelteHtmlDataProvider } from './html/dataProvider';
 
 export class HTMLPlugin implements HoverProvider, CompletionsProvider {
-    public pluginId = 'html';
-    public defaultConfig = {
-        enable: true,
-        hover: { enable: true },
-        completions: { enable: true },
-        tagComplete: { enable: true },
-        documentSymbols: { enable: true },
-    };
-
     private host!: Host;
     private lang = getLanguageService({ customDataProviders: [svelteHtmlDataProvider] });
     private documents = new WeakMap<Document, HTMLDocument>();
@@ -36,7 +28,7 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
     }
 
     doHover(document: Document, position: Position): Hover | null {
-        if (!this.host.getConfig<boolean>('html.hover.enable')) {
+        if (!this.featureEnabled('hover')) {
             return null;
         }
 
@@ -49,7 +41,7 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
     }
 
     getCompletions(document: Document, position: Position): CompletionList | null {
-        if (!this.host.getConfig<boolean>('html.completions.enable')) {
+        if (!this.featureEnabled('completions')) {
             return null;
         }
 
@@ -70,7 +62,7 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
     }
 
     doTagComplete(document: Document, position: Position): string | null {
-        if (!this.host.getConfig<boolean>('html.tagComplete.enable')) {
+        if (!this.featureEnabled('tagComplete')) {
             return null;
         }
 
@@ -83,7 +75,7 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
     }
 
     getDocumentSymbols(document: Document): SymbolInformation[] {
-        if (!this.host.getConfig<boolean>('html.documentSymbols.enable')) {
+        if (!this.featureEnabled('documentSymbols')) {
             return [];
         }
 
@@ -94,6 +86,11 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
 
         return this.lang.findDocumentSymbols(document, html);
     }
+
+    private featureEnabled(feature: keyof LSHTMLConfig) {
+        return (
+            this.host.getConfig<boolean>('html.enable') &&
+            this.host.getConfig<boolean>(`html.${feature}.enable`)
+        );
+    }
 }
-
-

--- a/packages/language-server/src/plugins/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/SveltePlugin.ts
@@ -20,6 +20,7 @@ import { RawSourceMap, RawIndexMap, SourceMapConsumer } from 'source-map';
 import { CompileOptions, Warning } from 'svelte/types/compiler/interfaces';
 import { importSvelte } from './svelte/sveltePackage';
 import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
+import { LSSvelteConfig } from '../ls-config';
 
 interface SvelteConfig extends CompileOptions {
     preprocess?: PreprocessorGroup;
@@ -30,13 +31,6 @@ const DEFAULT_OPTIONS: CompileOptions = {
 };
 
 export class SveltePlugin implements DiagnosticsProvider, FormattingProvider {
-    public pluginId = 'svelte';
-    public defaultConfig = {
-        enable: true,
-        diagnostics: { enable: true },
-        format: { enable: true },
-    };
-
     private host!: Host;
 
     onRegister(host: Host) {
@@ -44,7 +38,7 @@ export class SveltePlugin implements DiagnosticsProvider, FormattingProvider {
     }
 
     async getDiagnostics(document: Document): Promise<Diagnostic[]> {
-        if (!this.host.getConfig<boolean>('svelte.diagnostics.enable')) {
+        if (!this.featureEnabled('diagnostics')) {
             return [];
         }
 
@@ -109,7 +103,7 @@ export class SveltePlugin implements DiagnosticsProvider, FormattingProvider {
     }
 
     async formatDocument(document: Document): Promise<TextEdit[]> {
-        if (!this.host.getConfig<boolean>('svelte.format.enable')) {
+        if (!this.featureEnabled('format')) {
             return [];
         }
 
@@ -126,6 +120,13 @@ export class SveltePlugin implements DiagnosticsProvider, FormattingProvider {
                 formattedCode,
             ),
         ];
+    }
+
+    private featureEnabled(feature: keyof LSSvelteConfig) {
+        return (
+            this.host.getConfig<boolean>('svelte.enable') &&
+            this.host.getConfig<boolean>(`svelte.${feature}.enable`)
+        );
     }
 }
 

--- a/packages/language-server/src/plugins/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/TypeScriptPlugin.ts
@@ -37,6 +37,7 @@ import {
 import { getLanguageServiceForDocument, CreateDocument } from './typescript/service';
 import { pathToUrl } from '../utils';
 import { TextDocument } from '../lib/documents/TextDocument';
+import { LSTypescriptConfig } from '../ls-config';
 
 export class TypeScriptPlugin
     implements
@@ -50,16 +51,6 @@ export class TypeScriptPlugin
     public static matchFragment(fragment: Fragment) {
         return fragment.details.attributes.tag == 'script';
     }
-
-    public pluginId = 'typescript';
-    public defaultConfig = {
-        enable: true,
-        diagnostics: { enable: true },
-        hover: { enable: true },
-        completions: { enable: true },
-        definitions: { enable: true },
-        documentSymbols: { enable: true },
-    };
 
     private host!: Host;
     private createDocument!: CreateDocument;
@@ -80,7 +71,7 @@ export class TypeScriptPlugin
     }
 
     getDiagnostics(document: Document): Diagnostic[] {
-        if (!this.host.getConfig<boolean>('typescript.diagnostics.enable')) {
+        if (!this.featureEnabled('diagnostics')) {
             return [];
         }
 
@@ -107,7 +98,7 @@ export class TypeScriptPlugin
     }
 
     doHover(document: Document, position: Position): Hover | null {
-        if (!this.host.getConfig<boolean>('typescript.hover.enable')) {
+        if (!this.featureEnabled('hover')) {
             return null;
         }
 
@@ -127,7 +118,7 @@ export class TypeScriptPlugin
     }
 
     getDocumentSymbols(document: Document): SymbolInformation[] {
-        if (!this.host.getConfig<boolean>('typescript.documentSymbols.enable')) {
+        if (!this.featureEnabled('documentSymbols')) {
             return [];
         }
 
@@ -180,7 +171,7 @@ export class TypeScriptPlugin
         position: Position,
         triggerCharacter?: string,
     ): CompletionList | null {
-        if (!this.host.getConfig<boolean>('typescript.completions.enable')) {
+        if (!this.featureEnabled('completions')) {
             return null;
         }
 
@@ -220,7 +211,7 @@ export class TypeScriptPlugin
     }
 
     getDefinitions(document: Document, position: Position): DefinitionLink[] {
-        if (!this.host.getConfig<boolean>('typescript.definitions.enable')) {
+        if (!this.featureEnabled('definitions')) {
             return [];
         }
 
@@ -263,7 +254,7 @@ export class TypeScriptPlugin
         range: Range,
         context: CodeActionContext,
     ): Resolvable<CodeAction[]> {
-        if (!this.host.getConfig<boolean>('typescript.codeActions.enable')) {
+        if (!this.featureEnabled('codeActions')) {
             return [];
         }
 
@@ -313,5 +304,12 @@ export class TypeScriptPlugin
                 fix.fixName,
             );
         });
+    }
+
+    private featureEnabled(feature: keyof LSTypescriptConfig) {
+        return (
+            this.host.getConfig<boolean>('typescript.enable') &&
+            this.host.getConfig<boolean>(`typescript.${feature}.enable`)
+        );
     }
 }

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -25,10 +25,9 @@ namespace TagCloseRequest {
 }
 
 export function startServer() {
-    const connection = process.argv.includes('--stdio') ? createConnection(process.stdin, process.stdout) : createConnection(
-        new IPCMessageReader(process),
-        new IPCMessageWriter(process),
-    );
+    const connection = process.argv.includes('--stdio')
+        ? createConnection(process.stdin, process.stdout)
+        : createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));
 
     const manager = new DocumentManager(
         textDocument => new SvelteDocument(textDocument.uri, textDocument.text),
@@ -40,13 +39,14 @@ export function startServer() {
     manager.register(wrapFragmentPlugin(new TypeScriptPlugin(), TypeScriptPlugin.matchFragment));
 
     connection.onInitialize(evt => {
+        manager.updateConfig(evt.initializationOptions.config);
         return {
             capabilities: {
                 textDocumentSync: {
                     openClose: true,
                     change: TextDocumentSyncKind.Incremental,
                 },
-                hoverProvider: manager.supports('doHover'),
+                hoverProvider: true,
                 completionProvider: {
                     triggerCharacters: [
                         '.',
@@ -83,7 +83,7 @@ export function startServer() {
     });
 
     connection.onDidChangeConfiguration(({ settings }) => {
-        manager.updateConfig(settings.svelte);
+        manager.updateConfig(settings.svelte?.plugin);
     });
 
     connection.onDidOpenTextDocument(evt => manager.openDocument(evt.textDocument));

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -25,9 +25,9 @@ export function activate(context: ExtensionContext) {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions },
     };
 
-    const lsConfig = workspace.getConfiguration('svelte.language-server');
+    const runtimeConfig = workspace.getConfiguration('svelte.language-server');
 
-    const serverRuntime = lsConfig.get<string>('runtime');
+    const serverRuntime = runtimeConfig.get<string>('runtime');
     if (serverRuntime) {
         serverOptions.run.runtime = serverRuntime;
         serverOptions.debug.runtime = serverRuntime;
@@ -38,8 +38,9 @@ export function activate(context: ExtensionContext) {
         documentSelector: [{ scheme: 'file', language: 'svelte' }],
         revealOutputChannelOn: RevealOutputChannelOn.Never,
         synchronize: {
-            configurationSection: ['svelte', 'html'],
+            configurationSection: ['svelte'],
         },
+        initializationOptions: { config: workspace.getConfiguration('svelte.plugin') },
     };
 
     let ls = createLanguageServer(serverOptions, clientOptions);


### PR DESCRIPTION
- Simplifying retrieval of capabilities
- Passing initial config to language server and reading it (was not done before).
- Refactor how config is accessed. Plugins no longer contain parts of the config, they now all request them from the PluginHost. Also typing config. Makes code clearer.