### PR TITLE
Deploy nightly improvements

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -1,4 +1,4 @@
-name: Weekly builds of the Svelte Language Tools Beta
+name: Daily builds of the Svelte Language Tools Beta
 
 # For testing
 # on: push
@@ -50,7 +50,10 @@ jobs:
 
          # Have commits been added in the last day?
          if [[ $(git log --pretty=format: --name-only --since="1 days ago") ]]; then
-            npx vsce publish patch --yarn -p $VSCE_TOKEN
+            # Bump the version  
+            yarn workspace svelte-vscode update:package:beta
+            # Ship it
+            npx vsce publish --yarn -p $VSCE_TOKEN
          fi
       
         env:

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -47,8 +47,11 @@ jobs:
 
          # Just a hard constraint from azure
          echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"
-        
-         npx vsce publish patch --yarn -p $VSCE_TOKEN
+
+         # Have commits been added in the last day?
+         if [[ $(git log --pretty=format: --name-only --since="1 days ago") ]]; then
+            npx vsce publish patch --yarn -p $VSCE_TOKEN
+         fi
       
         env:
           VSCE_TOKEN: ${{ secrets.AZURE_PAN_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "build": "tsc -b",
     "test": "CI=true yarn workspaces run test",
     "watch": "tsc -b -watch"
+  },
+  "dependencies": {
+    "axios": "0.19.2"
   }
 }

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -7,7 +7,8 @@
         "vscode:prepublish": "tsc -p ./",
         "build": "tsc -p ./",
         "watch": "tsc -w -p ./",
-        "test": "echo 'NOOP'"
+        "test": "echo 'NOOP'",
+        "update:package:beta": "node scripts/bump-beta-version.js"
     },
     "repository": {
         "type": "git",

--- a/packages/svelte-vscode/scripts/bump-beta-version.js
+++ b/packages/svelte-vscode/scripts/bump-beta-version.js
@@ -1,0 +1,67 @@
+// @ts-check
+
+const { writeFileSync, readFileSync } = require("fs")
+const { join } = require("path")
+
+const axios = require("axios").default
+
+
+const getBetaExtension = async () => {
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: "application/json;api-version=5.2-preview.1;excludeUrls=true",
+    Host: "marketplace.visualstudio.com",
+    Origin: "https://marketplace.visualstudio.com",
+    Referer:
+      // prettier-ignore
+      `https://marketplace.visualstudio.com/search?term=svelte&category=All%20categories&vsVersion=&sortBy=Relevance`,
+    "User-Agent":
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15",
+    "Content-Length": "1082",
+    Connection: "keep-alive",
+    "X-TFS-Session": "e16c1b5b-850f-42ee-ab7c-519c79f6e356",
+    "X-Requested-With": "XMLHttpRequest",
+    "X-VSS-ReauthenticationAction": "Suppress",
+  }
+
+  const query = name =>
+    `{"assetTypes":["Microsoft.VisualStudio.Services.Icons.Default","Microsoft.VisualStudio.Services.Icons.Branding","Microsoft.VisualStudio.Services.Icons.Small"],"filters":[{"criteria":[{"filterType":10,"value":"${name}"},{"filterType":12,"value":"37888"}],"direction":2,"pageSize":54,"pageNumber":1,"sortBy":0,"sortOrder":0,"pagingToken":null}],"flags":870}`
+
+  const extensionSearchResults = await axios({
+    url:
+      "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery",
+    method: "POST",
+    headers: headers,
+    data: query(`svelte`),
+  })
+
+  if (!extensionSearchResults.data || !extensionSearchResults.data.results) {
+    throw new Error("Got a bad response from VS marketplace")
+  }
+
+  const extensions = extensionSearchResults.data.results[0].extensions
+
+  const officialExtensions = extensions.find(
+    e => e.publisher.publisherId === "c3bf51ad-baaa-466c-952c-9c3ca9bfabed"
+  )
+  return officialExtensions
+}
+
+
+const go = async () => {
+  const ext = await getBetaExtension()
+  if (!ext) throw new Error("Could not find the beta extension in the vscode marketplace")
+
+  const latestVersion = ext.versions[0].version
+  const semverMarkers = latestVersion.split(".")
+  const newVersion = `${semverMarkers[0]}.${semverMarkers[1]}.${Number(semverMarkers[2]) + 1}`
+
+  const pkgPath = join(__dirname, "..", "package.json")
+  const oldPackageJSON = JSON.parse(readFileSync(pkgPath, "utf8"))
+  oldPackageJSON.version = newVersion
+  writeFileSync(pkgPath, JSON.stringify(oldPackageJSON))
+
+  console.log("Updated to " + newVersion)
+}
+
+go()

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,6 +162,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+axios@0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -291,6 +298,13 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -391,6 +405,13 @@ flat@^4.1.0:
   integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
   dependencies:
     is-buffer "~2.0.3"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -675,6 +696,11 @@ mocha@^7.1.0:
     yargs "13.3.0"
     yargs-parser "13.1.1"
     yargs-unparser "1.6.0"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Deploys:

 - were happening nightly even though I expected them to be weekly
 - weren't working because the 'patch' option only uses the package.json for reference and doesn't change

This PR:
 - Makes it deploy nightly, but _only_ if there are new commits in the last day
 - Takes responsibility for finding the new version via the vscode marketplace response and does the bump  