### PR TITLE
(test) remove mocks from TypescriptPlugin tests

### DIFF
--- a/packages/language-server/test/plugins/typescript/testfiles/codeactions.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/codeactions.svelte
@@ -1,0 +1,1 @@
+<script>let a = true</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/completions.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions.svelte
@@ -1,0 +1,1 @@
+<script>class A { b() { return true; } } new A().</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/definitions.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/definitions.svelte
@@ -1,0 +1,1 @@
+<script lang="typescript">import {blubb} from './definitions'; function bla() {return true;} bla(); blubb();</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/definitions.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/definitions.ts
@@ -1,0 +1,3 @@
+export function blubb() {
+    return true;
+}

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics.svelte
@@ -1,0 +1,1 @@
+<script lang="typescript">const asd: string = true</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/documentsymbols.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/documentsymbols.svelte
@@ -1,0 +1,1 @@
+<script>function bla() {return true;} bla();</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/hoverinfo.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/hoverinfo.svelte
@@ -1,0 +1,1 @@
+<script>const a = true</script>


### PR DESCRIPTION
- makes them less dependent on internals
- since they are more like integration tests now, there is more safety that errors are caught by these tests