### PR TITLE
fix regex in finding the last opened svelte tag

### DIFF
--- a/packages/language-server/src/plugins/svelte/features/getCompletions.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCompletions.ts
@@ -150,12 +150,12 @@ function getLatestOpeningTag(svelteDoc: SvelteDocument, offset: number) {
  * Get the last tag and its index that is opened but not closed.
  */
 function idxOfLastOpeningTag(content: string, tag: SvelteTag) {
-    const nrOfEndingTags = content.match(new RegExp(`{\s*/${tag}`, 'g'))?.length ?? 0;
+    const nrOfEndingTags = content.match(new RegExp(`{\\s*/${tag}`, 'g'))?.length ?? 0;
 
     let lastIdx = -1;
     let nrOfOpeningTags = 0;
     let match: RegExpExecArray | null;
-    const regexp = new RegExp(`{\s*#${tag}`, 'g');
+    const regexp = new RegExp(`{\\s*#${tag}`, 'g');
     while ((match = regexp.exec(content)) != null) {
         nrOfOpeningTags += 1;
         lastIdx = match.index;

--- a/packages/language-server/test/plugins/svelte/features/getCompletions.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCompletions.test.ts
@@ -73,6 +73,10 @@ describe('SveltePlugin#getCompletions', () => {
         it('when only completed tag before that', () => {
             expectCompletionsFor('{#if}{/if}{/').toEqual(null);
         });
+
+        it('when the only completed tag before it has white space before close symbol', () => {
+            expectCompletionsFor('{#if}{ /if}{/').toEqual(null)
+        })
     });
 
     describe('should return completion for :', () => {


### PR DESCRIPTION
I found this while fixing linting errors. The regex for finding last opened and last closed tag escape `s` instead of `\s`