### PR TITLE
refine eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 **/dist/*
 node_modules
-**/scripts/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,9 @@ module.exports = {
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
     ],
+    env: {
+        node: true,
+    },
     rules: {
         semi: ['error', 'always'],
         'keyword-spacing': ['error', { before: true, after: true }],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc -b",
     "test": "CI=true yarn workspaces run test",
     "watch": "tsc -b -watch",
-    "lint": "eslint \"packages/**/{src,test}/**/*.{ts,js}\""
+    "lint": "eslint \"packages/**/*.{ts,js}\""
   },
   "dependencies": {
     "axios": "0.19.2"

--- a/packages/language-server/bin/server.js
+++ b/packages/language-server/bin/server.js
@@ -1,5 +1,6 @@
 #! /usr/bin/env node
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { startServer } = require('../dist/src/server');
 
 startServer();

--- a/packages/language-server/scripts/.eslintrc.js
+++ b/packages/language-server/scripts/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    root: false,
+    rules: {
+        "@typescript-eslint/no-var-requires": 'off'
+    }
+}

--- a/packages/language-server/scripts/bump-release-version.js
+++ b/packages/language-server/scripts/bump-release-version.js
@@ -1,33 +1,33 @@
 // @ts-check
 
-const { writeFileSync, readFileSync } = require("fs")
-const { join } = require("path")
+const { writeFileSync, readFileSync } = require("fs");
+const { join } = require("path");
 
-const axios = require("axios").default
+const axios = require("axios").default;
 
 const getPackageVersion = async () => {
-  const npmInfo = await axios({ url:"https://registry.npmjs.org/svelte-language-server", method: "GET" })
+  const npmInfo = await axios({ url:"https://registry.npmjs.org/svelte-language-server", method: "GET" });
   if (!npmInfo.data || !npmInfo.data._id) {
-    throw new Error("Got a bad response from NPM")
+    throw new Error("Got a bad response from NPM");
   }
 
-  return npmInfo.data['dist-tags'].latest
-}
+  return npmInfo.data['dist-tags'].latest;
+};
 
 
 const go = async () => {
-  const version = await getPackageVersion()
-  if (!version) throw new Error("Could not find the npm version in the registry")
+  const version = await getPackageVersion();
+  if (!version) throw new Error("Could not find the npm version in the registry");
 
-  const semverMarkers = version.split(".")
-  const newVersion = `${semverMarkers[0]}.${semverMarkers[1]}.${Number(semverMarkers[2]) + 1}`
+  const semverMarkers = version.split(".");
+  const newVersion = `${semverMarkers[0]}.${semverMarkers[1]}.${Number(semverMarkers[2]) + 1}`;
 
-  const pkgPath = join(__dirname, "..", "package.json")
-  const oldPackageJSON = JSON.parse(readFileSync(pkgPath, "utf8"))
-  oldPackageJSON.version = newVersion
-  writeFileSync(pkgPath, JSON.stringify(oldPackageJSON))
+  const pkgPath = join(__dirname, "..", "package.json");
+  const oldPackageJSON = JSON.parse(readFileSync(pkgPath, "utf8"));
+  oldPackageJSON.version = newVersion;
+  writeFileSync(pkgPath, JSON.stringify(oldPackageJSON));
 
-  console.log("Updated to " + newVersion)
-}
+  console.log("Updated to " + newVersion);
+};
 
-go()
+go();

--- a/packages/language-server/test/.eslintrc.js
+++ b/packages/language-server/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    root: false,
+    rules: {
+        '@typescript-eslint/no-non-null-assertion': 'off'
+    }
+}

--- a/packages/language-server/wallaby.js
+++ b/packages/language-server/wallaby.js
@@ -1,4 +1,4 @@
-module.exports = function(w) {
+module.exports = function(_w) {
     return {
         files: ['src/**/*.ts'],
         tests: ['test/**/*.ts'],

--- a/packages/svelte-vscode/scripts/.eslintrc.js
+++ b/packages/svelte-vscode/scripts/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    root: false,
+    rules: {
+        "@typescript-eslint/no-var-requires": 'off',
+    }
+}

--- a/packages/svelte-vscode/scripts/bump-beta-version.js
+++ b/packages/svelte-vscode/scripts/bump-beta-version.js
@@ -1,9 +1,10 @@
+/* eslint-disable max-len */
 // @ts-check
 
-const { writeFileSync, readFileSync } = require("fs")
-const { join } = require("path")
+const { writeFileSync, readFileSync } = require("fs");
+const { join } = require("path");
 
-const axios = require("axios").default
+const axios = require("axios").default;
 
 
 const getBetaExtension = async () => {
@@ -22,10 +23,10 @@ const getBetaExtension = async () => {
     "X-TFS-Session": "e16c1b5b-850f-42ee-ab7c-519c79f6e356",
     "X-Requested-With": "XMLHttpRequest",
     "X-VSS-ReauthenticationAction": "Suppress",
-  }
+  };
 
   const query = name =>
-    `{"assetTypes":["Microsoft.VisualStudio.Services.Icons.Default","Microsoft.VisualStudio.Services.Icons.Branding","Microsoft.VisualStudio.Services.Icons.Small"],"filters":[{"criteria":[{"filterType":10,"value":"${name}"},{"filterType":12,"value":"37888"}],"direction":2,"pageSize":54,"pageNumber":1,"sortBy":0,"sortOrder":0,"pagingToken":null}],"flags":870}`
+    `{"assetTypes":["Microsoft.VisualStudio.Services.Icons.Default","Microsoft.VisualStudio.Services.Icons.Branding","Microsoft.VisualStudio.Services.Icons.Small"],"filters":[{"criteria":[{"filterType":10,"value":"${name}"},{"filterType":12,"value":"37888"}],"direction":2,"pageSize":54,"pageNumber":1,"sortBy":0,"sortOrder":0,"pagingToken":null}],"flags":870}`;
 
   const extensionSearchResults = await axios({
     url:
@@ -33,35 +34,35 @@ const getBetaExtension = async () => {
     method: "POST",
     headers: headers,
     data: query(`svelte`),
-  })
+  });
 
   if (!extensionSearchResults.data || !extensionSearchResults.data.results) {
-    throw new Error("Got a bad response from VS marketplace")
+    throw new Error("Got a bad response from VS marketplace");
   }
 
-  const extensions = extensionSearchResults.data.results[0].extensions
+  const extensions = extensionSearchResults.data.results[0].extensions;
 
   const officialExtensions = extensions.find(
     e => e.publisher.publisherId === "c3bf51ad-baaa-466c-952c-9c3ca9bfabed"
-  )
-  return officialExtensions
-}
+  );
+  return officialExtensions;
+};
 
 
 const go = async () => {
-  const ext = await getBetaExtension()
-  if (!ext) throw new Error("Could not find the beta extension in the vscode marketplace")
+  const ext = await getBetaExtension();
+  if (!ext) throw new Error("Could not find the beta extension in the vscode marketplace");
 
-  const latestVersion = ext.versions[0].version
-  const semverMarkers = latestVersion.split(".")
-  const newVersion = `${semverMarkers[0]}.${semverMarkers[1]}.${Number(semverMarkers[2]) + 1}`
+  const latestVersion = ext.versions[0].version;
+  const semverMarkers = latestVersion.split(".");
+  const newVersion = `${semverMarkers[0]}.${semverMarkers[1]}.${Number(semverMarkers[2]) + 1}`;
 
-  const pkgPath = join(__dirname, "..", "package.json")
-  const oldPackageJSON = JSON.parse(readFileSync(pkgPath, "utf8"))
-  oldPackageJSON.version = newVersion
-  writeFileSync(pkgPath, JSON.stringify(oldPackageJSON))
+  const pkgPath = join(__dirname, "..", "package.json");
+  const oldPackageJSON = JSON.parse(readFileSync(pkgPath, "utf8"));
+  oldPackageJSON.version = newVersion;
+  writeFileSync(pkgPath, JSON.stringify(oldPackageJSON));
 
-  console.log("Updated to " + newVersion)
-}
+  console.log("Updated to " + newVersion);
+};
 
-go()
+go();


### PR DESCRIPTION
1. disable `no-non-null-assertion` on test
2. lint bin, scripts and disable `no-var-requires`
    on these files
3. disable `max-len` on bump-beta-version.js
4. fix lint errors in node scripts

Rather than disable lint on node scripts, I would like to change it to have custom lint rules.
About the `no-non-null-assertion` rule, I don't think it makes sense in test files. Rather than fixing them and use another assert to test it, I would just disable it.