### PR TITLE
fix code action with non-empty next line

### DIFF
--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -12,7 +12,6 @@ import {
     Range,
     SymbolInformation,
     TextDocumentEdit,
-    TextEdit,
     VersionedTextDocumentIdentifier,
     FileChangeType,
 } from 'vscode-languageserver';
@@ -313,10 +312,10 @@ export class TypeScriptPlugin
                                     null,
                                 ),
                                 change.textChanges.map(edit => {
-                                    return TextEdit.replace(
-                                        convertRange(doc!, edit.span),
-                                        edit.newText,
-                                    );
+                                    return {
+                                        range: convertRange(doc!, edit.span),
+                                        newText: edit.newText,
+                                    };
                                 }),
                             );
                         }),


### PR DESCRIPTION
Fix bug where code-action-changes with non-empty next line will not be executed.

example:
```js
function Foo() {
    this.bar = 1;
}
const foo = new Foo();
```
When chose the code action to convert to es2015 class, nothing will happen.
※This code action will only appear in js not in ts