### PR TITLE
Fix misconfigured attribute matching regex in tag extraction

### DIFF
--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -23,8 +23,9 @@ function parseAttributes(str: string): Record<string, string> {
  * @param source text content to extract tag from
  * @param tag the tag to extract
  */
+
 export function extractTag(source: string, tag: 'script' | 'style') {
-    const exp = new RegExp(`(<!--.*-->)|(<${tag}([\\S\\s]*?)>)([\\S\\s]*?)<\\/${tag}>`, 'igs');
+    const exp = new RegExp(`(<!--.*-->)|(<${tag}( [\\S\\s]*)?>)([\\S\\s]*?)<\\/${tag}>`, 'igs');
     let match = exp.exec(source);
 
     while (match && match[0].startsWith('<!--')) {
@@ -35,7 +36,7 @@ export function extractTag(source: string, tag: 'script' | 'style') {
         return null;
     }
 
-    const attributes = parseAttributes(match[3]);
+    const attributes = parseAttributes(match[3] || '');
     const content = match[4];
     const start = match.index + match[2].length;
     const end = start + content.length;

--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -23,9 +23,8 @@ function parseAttributes(str: string): Record<string, string> {
  * @param source text content to extract tag from
  * @param tag the tag to extract
  */
-
 export function extractTag(source: string, tag: 'script' | 'style') {
-    const exp = new RegExp(`(<!--.*-->)|(<${tag}( [\\S\\s]*)?>)([\\S\\s]*?)<\\/${tag}>`, 'igs');
+    const exp = new RegExp(`(<!--.*-->)|(<${tag}(\\s[\\S\\s]*)?>)([\\S\\s]*?)<\\/${tag}>`, 'igs');
     let match = exp.exec(source);
 
     while (match && match[0].startsWith('<!--')) {

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -30,5 +30,15 @@ describe('document/utils', () => {
                 container: { start: 44, end: 76 },
             });
         });
+        it('does not extract tags starting with style/script', () => {
+            // https://github.com/sveltejs/language-tools/issues/43
+            // this would previously match <styles>....</style> due to misconfigured attribute matching regex
+            const text = `
+            <styles>p{ color: blue; }</styles>
+            <p>bla</p>
+            ></style>
+            `;
+            assert.deepStrictEqual(extractTag(text, 'style'), null);
+        });
     });
 });

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -17,6 +17,16 @@ describe('document/utils', () => {
                 container: { start: 101, end: 133 },
             });
         });
+        it('does not extract tags starting with style/script', () => {
+            // https://github.com/sveltejs/language-tools/issues/43
+            // this would previously match <styles>....</style> due to misconfigured attribute matching regex
+            const text = `
+            <styles>p{ color: blue; }</styles>
+            <p>bla</p>
+            ></style>
+            `;
+            assert.deepStrictEqual(extractTag(text, 'style'), null);
+        });
         it('extracts style tag', () => {
             const text = `
                 <p>bla</p>
@@ -30,15 +40,29 @@ describe('document/utils', () => {
                 container: { start: 44, end: 76 },
             });
         });
-        it('does not extract tags starting with style/script', () => {
-            // https://github.com/sveltejs/language-tools/issues/43
-            // this would previously match <styles>....</style> due to misconfigured attribute matching regex
+        it('extracts style tag with attributes', () => {
             const text = `
-            <styles>p{ color: blue; }</styles>
-            <p>bla</p>
-            ></style>
+                <style lang="scss">p{ color: blue; }</style>
             `;
-            assert.deepStrictEqual(extractTag(text, 'style'), null);
+            assert.deepStrictEqual(extractTag(text, 'style'), {
+                content: 'p{ color: blue; }',
+                attributes: { lang: 'scss' },
+                start: 36,
+                end: 53,
+                container: { start: 17, end: 61 },
+            });
+        });
+        it('extracts style tag with attributes and extra whitespace', () => {
+            const text = `
+                <style     lang="scss"    >  p{ color: blue; }  </style>
+            `;
+            assert.deepStrictEqual(extractTag(text, 'style'), {
+                content: '  p{ color: blue; }  ',
+                attributes: { lang: 'scss' },
+                start: 44,
+                end: 65,
+                container: { start: 17, end: 73 },
+            });
         });
     });
 });


### PR DESCRIPTION
Fix bug where `extractTag` would wrongfully extract tags starting with script/style (https://github.com/sveltejs/language-tools/issues/43).

example:

```html
<styles>p{ color: blue; }</styles>
<p>bla</p>
 ></style>
```

would incorrectly match `<styles>....</style>`