### PR TITLE
Revert "fix code action with non-empty next line"

### DIFF
--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -12,6 +12,7 @@ import {
     Range,
     SymbolInformation,
     TextDocumentEdit,
+    TextEdit,
     VersionedTextDocumentIdentifier,
     FileChangeType,
 } from 'vscode-languageserver';
@@ -312,10 +313,10 @@ export class TypeScriptPlugin
                                     null,
                                 ),
                                 change.textChanges.map(edit => {
-                                    return {
-                                        range: convertRange(doc!, edit.span),
-                                        newText: edit.newText,
-                                    };
+                                    return TextEdit.replace(
+                                        convertRange(doc!, edit.span),
+                                        edit.newText,
+                                    );
                                 }),
                             );
                         }),


### PR DESCRIPTION
Reverts sveltejs/language-tools#52

Sorry! This turns out to not fix anything. The issue itself is a kind of luck. 
~~Maybe it has something to do with the order when code action edit get executed~~
ts sometimes send back code action with no changes