### PR TITLE
only extract attribute until tag end

### DIFF
--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -24,7 +24,7 @@ function parseAttributes(str: string): Record<string, string> {
  * @param tag the tag to extract
  */
 export function extractTag(source: string, tag: 'script' | 'style') {
-    const exp = new RegExp(`(<!--.*-->)|(<${tag}(\\s[\\S\\s]*)?>)([\\S\\s]*?)<\\/${tag}>`, 'igs');
+    const exp = new RegExp(`(<!--.*-->)|(<${tag}(\\s[\\S\\s]*?)?>)([\\S\\s]*?)<\\/${tag}>`, 'igs');
     let match = exp.exec(source);
 
     while (match && match[0].startsWith('<!--')) {

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -27,6 +27,16 @@ describe('document/utils', () => {
             `;
             assert.deepStrictEqual(extractTag(text, 'style'), null);
         });
+        it('only extract attribute until tag ends', () => {
+            const text = `
+            <script type="typescript">
+            () => abc
+            </script>
+            `;
+            const extracted = extractTag(text, 'script');
+            const attributes = extracted?.attributes;
+            assert.deepStrictEqual(attributes , { type: 'typescript' });
+        });
         it('extracts style tag', () => {
             const text = `
                 <p>bla</p>


### PR DESCRIPTION
fix the issue where the attribute group of the extract tag would end at `>` in the script
example: 
```svelte
<script type="typescript">
let a = () => 'a'
</script>
```