### PR TITLE
Fix import completion and add better completion documentaion

### DIFF
--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -100,7 +100,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
         }
 
         const result = await this.execute<CompletionItem>(
-            "resolveCompletion",
+            'resolveCompletion',
             [document, completionItem],
             ExecuteMode.FirstNonNull
         );

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -15,10 +15,11 @@ import {
     TextDocumentIdentifier,
     TextEdit,
     FileChangeType,
+    CompletionItem,
 } from 'vscode-languageserver';
 import { LSConfig, LSConfigManager } from '../ls-config';
 import { DocumentManager } from '../lib/documents';
-import { LSProvider, Plugin, OnWatchFileChanges } from './interfaces';
+import { LSProvider, Plugin, OnWatchFileChanges, AppCompletionItem } from './interfaces';
 
 enum ExecuteMode {
     None,
@@ -87,6 +88,26 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
             ),
         );
     }
+
+    async resolveCompletion(
+        textDocument: TextDocumentIdentifier,
+        completionItem: AppCompletionItem
+    ): Promise<CompletionItem> {
+        const document = this.getDocument(textDocument.uri);
+
+        if (!document) {
+            throw new Error('Cannot call methods on an unopened document');
+        }
+
+        const result = await this.execute<CompletionItem>(
+            "resolveCompletion",
+            [document, completionItem],
+            ExecuteMode.FirstNonNull
+        );
+
+        return result ?? completionItem;
+    }
+
 
     async formatDocument(textDocument: TextDocumentIdentifier): Promise<TextEdit[]> {
         const document = this.getDocument(textDocument.uri);

--- a/packages/language-server/src/plugins/interfaces.ts
+++ b/packages/language-server/src/plugins/interfaces.ts
@@ -12,12 +12,26 @@ import {
     Range,
     SymbolInformation,
     TextEdit,
+    CompletionItem,
+    TextDocumentIdentifier,
 } from 'vscode-languageserver-types';
 import { FileChangeType } from 'vscode-languageserver';
 import { DocumentManager, Document } from '../lib/documents';
 import { LSConfigManager } from '../ls-config';
 
 export type Resolvable<T> = T | Promise<T>;
+
+export interface AppCompletionItem<
+        T extends TextDocumentIdentifier = any
+    > extends CompletionItem {
+    data?: T;
+}
+
+export interface AppCompletionList<
+        T extends TextDocumentIdentifier = any
+    > extends CompletionList {
+    items: AppCompletionItem<T>[];
+}
 
 export interface DiagnosticsProvider {
     getDiagnostics(document: Document): Resolvable<Diagnostic[]>;
@@ -27,12 +41,15 @@ export interface HoverProvider {
     doHover(document: Document, position: Position): Resolvable<Hover | null>;
 }
 
-export interface CompletionsProvider {
+export interface CompletionsProvider<T extends TextDocumentIdentifier = any> {
     getCompletions(
         document: Document,
         position: Position,
         triggerCharacter?: string,
-    ): Resolvable<CompletionList | null>;
+    ): Resolvable<AppCompletionList<T> | null>;
+
+    resolveCompletion?(document: Document, completionItem: AppCompletionItem<T>):
+        Resolvable<AppCompletionItem<T>>;
 }
 
 export interface FormattingProvider {

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResovler.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResovler.ts
@@ -1,0 +1,29 @@
+import { DocumentManager, Document } from '../../lib/documents';
+import { pathToUrl } from '../../utils';
+import { getLanguageServiceForDocument } from './service';
+import { TypescriptDocument } from './TypescriptDocument';
+
+export class LSAndTSDocResovler {
+    constructor(private readonly docManager: DocumentManager) { }
+    createDocument = (fileName: string, content: string) => {
+        const uri = pathToUrl(fileName);
+        const document = this.docManager.openDocument({
+            languageId: '',
+            text: content,
+            uri,
+            version: 0,
+        });
+        this.docManager.lockDocument(uri);
+        return new TypescriptDocument(document);
+    };
+    private documents = new Map<Document, TypescriptDocument>();
+    public getLSAndTSDoc(document: Document) {
+        let tsDoc = this.documents.get(document);
+        if (!tsDoc) {
+            tsDoc = new TypescriptDocument(document);
+            this.documents.set(document, tsDoc);
+        }
+        const lang = getLanguageServiceForDocument(tsDoc, this.createDocument);
+        return { tsDoc, lang };
+    }
+}

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -26,7 +26,6 @@ import {
 } from '../../lib/documents';
 import { LSConfigManager, LSTypescriptConfig } from '../../ls-config';
 import { pathToUrl } from '../../utils';
-import { getLanguageServiceForDocument } from './service';
 import {
     convertRange,
     getScriptKindFromAttributes,
@@ -35,7 +34,6 @@ import {
     findTsConfigPath,
     getScriptKindFromFileName,
 } from './utils';
-import { TypescriptDocument } from './TypescriptDocument';
 import {
     CodeActionsProvider,
     DefinitionsProvider,
@@ -52,6 +50,7 @@ import {
 import { SnapshotManager } from './SnapshotManager';
 import { DocumentSnapshot, INITIAL_VERSION } from './DocumentSnapshot';
 import { CompletionEntryWithIdentifer, CompletionsProviderImpl } from './features/CompletionProvider';
+import { LSAndTSDocResovler } from './LSAndTSDocResovler';
 
 export class TypeScriptPlugin
     implements
@@ -348,34 +347,3 @@ export class TypeScriptPlugin
     }
 }
 
-export class LSAndTSDocResovler {
-    constructor(
-        private readonly docManager: DocumentManager
-    ) { }
-
-    createDocument = (fileName: string, content: string) => {
-        const uri = pathToUrl(fileName);
-        const document = this.docManager.openDocument({
-            languageId: '',
-            text: content,
-            uri,
-            version: 0,
-        });
-        this.docManager.lockDocument(uri);
-        return new TypescriptDocument(document);
-    };
-
-    private documents = new Map<Document, TypescriptDocument>();
-
-    public getLSAndTSDoc(document: Document) {
-        let tsDoc = this.documents.get(document);
-        if (!tsDoc) {
-            tsDoc = new TypescriptDocument(document);
-            this.documents.set(document, tsDoc);
-        }
-
-        const lang = getLanguageServiceForDocument(tsDoc, this.createDocument);
-
-        return { tsDoc, lang };
-    }
-}

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -258,9 +258,11 @@ export class TypeScriptPlugin
         uri: string,
         position: Position
     ): AppCompletionItem<CompletionEntryWithIdentifer> {
+        const { label, insertText } = this.getCompletionLableAndInsert(comp);
 
         return {
-            label: this.getCompletionLabel(comp),
+            label,
+            insertText,
             kind: scriptElementKindToCompletionItemKind(comp.kind),
             sortText: comp.sortText,
             commitCharacters: getCommitCharactersForScriptElement(comp.kind),
@@ -284,15 +286,20 @@ export class TypeScriptPlugin
         }));
     }
 
-    private getCompletionLabel(comp: ts.CompletionEntry) {
+    private getCompletionLableAndInsert(comp: ts.CompletionEntry) {
         const { kind, kindModifiers, name } = comp;
         const isScriptElement = kind === ts.ScriptElementKind.scriptElement;
         const hasModifier = Boolean(comp.kindModifiers);
 
         if (isScriptElement && hasModifier) {
-            return name + kindModifiers;
+            return {
+                insertText: name,
+                label: name + kindModifiers
+            };
         }
-        return name;
+        return {
+            label: name
+        };
     }
 
     resolveCompletion(

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -2,7 +2,7 @@ import ts from 'typescript';
 import { Position, TextDocumentIdentifier, TextEdit, CompletionList } from 'vscode-languageserver';
 import { CompletionsProvider, AppCompletionList, AppCompletionItem, Resolvable } from '../../interfaces';
 import { Document, mapCompletionItemToParent } from '../../../lib/documents';
-import { LSAndTSDocResovler } from '../TypeScriptPlugin';
+import { LSAndTSDocResovler } from "../LSAndTSDocResovler";
 import {
     scriptElementKindToCompletionItemKind,
     getCommitCharactersForScriptElement,

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -90,6 +90,7 @@ export function createLanguageService(
         readFile: svelteModuleLoader.readFile,
         resolveModuleNames: svelteModuleLoader.resolveModuleNames,
         readDirectory: ts.sys.readDirectory,
+        getDirectories: ts.sys.getDirectories,
         getScriptKind: (fileName: string) => {
             const doc = getSvelteSnapshot(fileName);
             if (doc) {

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -91,6 +91,8 @@ export function createLanguageService(
         resolveModuleNames: svelteModuleLoader.resolveModuleNames,
         readDirectory: ts.sys.readDirectory,
         getDirectories: ts.sys.getDirectories,
+        // vscode's uri is all lowercase
+        useCaseSensitiveFileNames: () => false,
         getScriptKind: (fileName: string) => {
             const doc = getSvelteSnapshot(fileName);
             if (doc) {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -35,7 +35,7 @@ export function startServer() {
     pluginHost.register(new SveltePlugin());
     pluginHost.register(new HTMLPlugin());
     pluginHost.register(new CSSPlugin());
-    pluginHost.register(new TypeScriptPlugin());
+    pluginHost.register(new TypeScriptPlugin(docManager));
 
     connection.onInitialize(evt => {
         pluginHost.updateConfig(evt.initializationOptions.config);

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -1,11 +1,8 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import { dirname, join } from 'path';
-import { mkdirSync, rmdirSync } from 'fs';
 import ts from 'typescript';
 import {
-    CompletionItem,
-    CompletionItemKind,
     FileChangeType,
     Hover,
     Position,
@@ -107,117 +104,6 @@ describe('TypescriptPlugin', () => {
                 name: 'bla',
             },
         ]);
-    });
-
-    it('provides completions', async () => {
-        const { plugin, document } = setup('completions.svelte');
-
-        const completions = plugin.getCompletions(document, Position.create(0, 49), '.');
-
-        assert.ok(
-            Array.isArray(completions && completions.items),
-            'Expected completion items to be an array',
-        );
-        assert.ok(completions!.items.length > 0, 'Expected completions to have length');
-
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { data, ...withoutData } = completions!.items[0];
-
-        assert.deepStrictEqual(withoutData, <CompletionItem>{
-            label: 'b',
-            insertText: undefined,
-            kind: CompletionItemKind.Method,
-            sortText: '0',
-            commitCharacters: ['.', ',', '('],
-            preselect: undefined,
-        });
-    });
-
-    it('provides completion resolve info', async () => {
-        const { plugin, document } = setup('completions.svelte');
-
-        const completions = plugin.getCompletions(document, Position.create(0, 49), '.');
-
-        const { data } = completions!.items[0];
-
-        // uri would not be the same, so only check if exist;
-        assert.notEqual(data, null);
-        const { uri, ...withoutUri } = data!;
-        assert.ok(uri);
-
-        assert.deepStrictEqual(withoutUri, {
-            hasAction: undefined,
-            insertText: undefined,
-            isRecommended: undefined,
-            kind: 'method',
-            kindModifiers: '',
-            name: 'b',
-            position: {
-                character: 49,
-                line: 0
-            },
-            replacementSpan: undefined,
-            sortText: '0',
-            source: undefined,
-        });
-    });
-
-    it('resolve completion and provide documentation', async () => {
-        const { plugin, document } = setup('documentation.svelte');
-
-        const completions = plugin.getCompletions(document, Position.create(4, 8), '(');
-
-        const { documentation, detail } = await plugin.resolveCompletion(
-            document,
-            completions?.items[0]!
-        );
-
-        assert.deepStrictEqual(detail, '(alias) function foo(): boolean\nimport foo');
-        assert.deepStrictEqual(documentation, 'bars');
-    });
-
-    it('provides import completions for directory', async () => {
-        const { plugin, document } = setup('importcompletions.svelte');
-        const mockDirName = 'foo';
-        const mockDirPath = path.join(__dirname, 'testfiles', mockDirName);
-
-        mkdirSync(mockDirPath);
-
-        try {
-            const completions = plugin.getCompletions(document, Position.create(0, 27), '/');
-            const mockedDirImportCompletion = completions?.items
-                .find(item => item.label === mockDirName);
-
-            assert.notEqual(
-                mockedDirImportCompletion,
-                undefined,
-                `can't provides completions on directory`
-            );
-            assert.equal(mockedDirImportCompletion?.kind, CompletionItemKind.Folder);
-        } finally {
-            rmdirSync(mockDirPath);
-        }
-    });
-
-    it('resolve auto import completion', async () => {
-        const { plugin, document } = setup('importcompletions.svelte');
-
-        const completions = plugin.getCompletions(document, Position.create(0, 40));
-        document.version++;
-
-        const item = completions?.items.find(item => item.label === 'blubb');
-
-        assert.equal(item?.additionalTextEdits, undefined);
-        assert.equal(item?.detail, undefined);
-
-        const { additionalTextEdits, detail } = await plugin.resolveCompletion(document, item!);
-
-        assert.strictEqual(detail, 'Auto import from ./definitions\nfunction blubb(): boolean');
-
-        assert.strictEqual(
-            additionalTextEdits![0]?.newText.replace('\r', '').replace('\n', ''),
-            `import { blubb } from './definitions'`,
-        );
     });
 
     it('provides definitions within svelte doc', () => {

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -26,10 +26,10 @@ describe('TypescriptPlugin', () => {
     }
 
     function setup(filename: string) {
-        const plugin = new TypeScriptPlugin();
+        const docManager = new DocumentManager(() => document);
+        const plugin = new TypeScriptPlugin(docManager);
         const filePath = path.join(__dirname, 'testfiles', filename);
         const document = new TextDocument(pathToUrl(filePath), ts.sys.readFile(filePath)!);
-        const docManager = new DocumentManager(() => document);
         const pluginManager = new LSConfigManager();
         plugin.onRegister(docManager, pluginManager);
         docManager.openDocument(<any>'some doc');

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -125,6 +125,7 @@ describe('TypescriptPlugin', () => {
 
         assert.deepStrictEqual(withoutData, <CompletionItem>{
             label: 'b',
+            insertText: undefined,
             kind: CompletionItemKind.Method,
             sortText: '0',
             commitCharacters: ['.', ',', '('],

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import { dirname, join } from 'path';
+import { mkdirSync, rmdirSync } from 'fs';
 import ts from 'typescript';
 import {
     CompletionItem,
@@ -125,6 +126,30 @@ describe('TypescriptPlugin', () => {
             commitCharacters: ['.', ',', '('],
             preselect: undefined,
         });
+    });
+
+    it('provides import completions for directory', async () => {
+        const { plugin, document } = setup('importcompletions.svelte');
+        const mockDirName = 'foo';
+        const mockDirPath = path.join(__dirname, 'testfiles', mockDirName);
+
+        mkdirSync(mockDirPath);
+
+        try {
+            const completions = plugin.getCompletions(document, Position.create(0, 27), '/');
+            const mockedDirImportCompletion = completions?.items
+                .find(item => item.label === mockDirName);
+
+            assert.notEqual(
+                mockedDirImportCompletion,
+                undefined,
+                `can't provides completions on directory`
+            );
+            assert.equal(mockedDirImportCompletion?.kind, CompletionItemKind.Folder);
+        } finally {
+            rmdirSync(mockDirPath);
+        }
+
     });
 
     it('provides definitions within svelte doc', () => {

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1,0 +1,145 @@
+import { join } from 'path';
+import ts from 'typescript';
+import assert from 'assert';
+
+import { DocumentManager, TextDocument } from '../../../../src/lib/documents';
+import { pathToUrl } from '../../../../src/utils';
+import { CompletionItem, CompletionItemKind, Position } from 'vscode-languageserver';
+import { rmdirSync, mkdirSync } from 'fs';
+import {
+    CompletionsProviderImpl
+} from '../../../../src/plugins/typescript/features/CompletionProvider';
+import { LSAndTSDocResovler } from '../../../../src/plugins/typescript/LSAndTSDocResovler';
+
+const testFilesDir = join(__dirname, '..', 'testfiles');
+
+describe('CompletionProviderImpl', () => {
+    function setup(filename: string) {
+        const docManager = new DocumentManager(() => document);
+        const lsAndTsDocResolver = new LSAndTSDocResovler(docManager);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const filePath = join(testFilesDir, filename);
+        const document = new TextDocument(pathToUrl(filePath), ts.sys.readFile(filePath)!);
+        docManager.openDocument(<any>'some doc');
+        return { completionProvider, document };
+    }
+
+
+    it('provides completions', async () => {
+
+
+        const { completionProvider, document } = setup('completions.svelte');
+
+        const completions = completionProvider.getCompletions(document, Position.create(0, 49), '.');
+
+        assert.ok(
+            Array.isArray(completions && completions.items),
+            'Expected completion items to be an array',
+        );
+        assert.ok(completions!.items.length > 0, 'Expected completions to have length');
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { data, ...withoutData } = completions!.items[0];
+
+        assert.deepStrictEqual(withoutData, <CompletionItem>{
+            label: 'b',
+            insertText: undefined,
+            kind: CompletionItemKind.Method,
+            sortText: '0',
+            commitCharacters: ['.', ',', '('],
+            preselect: undefined,
+        });
+    })
+        // initial build might take longer
+        .timeout(8000);
+
+    it('provides completion resolve info', async () => {
+        const { completionProvider, document } = setup('completions.svelte');
+
+        const completions = completionProvider.getCompletions(document, Position.create(0, 49), '.');
+
+        const { data } = completions!.items[0];
+
+        // uri would not be the same, so only check if exist;
+        assert.notEqual(data, null);
+        const { uri, ...withoutUri } = data!;
+        assert.ok(uri);
+
+        assert.deepStrictEqual(withoutUri, {
+            hasAction: undefined,
+            insertText: undefined,
+            isRecommended: undefined,
+            kind: 'method',
+            kindModifiers: '',
+            name: 'b',
+            position: {
+                character: 49,
+                line: 0
+            },
+            replacementSpan: undefined,
+            sortText: '0',
+            source: undefined,
+        });
+    });
+
+    it('resolve completion and provide documentation', async () => {
+        const { completionProvider, document } = setup('documentation.svelte');
+
+        const completions = completionProvider.getCompletions(document, Position.create(4, 8), '(');
+
+        const { documentation, detail } = await completionProvider.resolveCompletion(
+            document,
+            completions?.items[0]!
+        );
+
+        assert.deepStrictEqual(detail, '(alias) function foo(): boolean\nimport foo');
+        assert.deepStrictEqual(documentation, 'bars');
+    });
+
+    it('provides import completions for directory', async () => {
+        const { completionProvider, document } = setup('importcompletions.svelte');
+        const mockDirName = 'foo';
+        const mockDirPath = join(testFilesDir, mockDirName);
+
+        mkdirSync(mockDirPath);
+
+        try {
+            const completions = completionProvider.getCompletions(document, Position.create(0, 27), '/');
+            const mockedDirImportCompletion = completions?.items
+                .find(item => item.label === mockDirName);
+
+            assert.notEqual(
+                mockedDirImportCompletion,
+                undefined,
+                `can't provides completions on directory`
+            );
+            assert.equal(mockedDirImportCompletion?.kind, CompletionItemKind.Folder);
+        } finally {
+            rmdirSync(mockDirPath);
+        }
+    });
+
+    it('resolve auto import completion', async () => {
+        const { completionProvider, document } = setup('importcompletions.svelte');
+
+        const completions = completionProvider.getCompletions(document, Position.create(0, 40));
+        document.version++;
+
+        const item = completions?.items.find(item => item.label === 'blubb');
+
+        assert.equal(item?.additionalTextEdits, undefined);
+        assert.equal(item?.detail, undefined);
+
+        const {
+            additionalTextEdits,
+            detail
+        } = await completionProvider.resolveCompletion(document, item!);
+
+        assert.strictEqual(detail, 'Auto import from ./definitions\nfunction blubb(): boolean');
+
+        assert.strictEqual(
+            additionalTextEdits![0]?.newText.replace('\r', '').replace('\n', ''),
+            `import { blubb } from './definitions'`,
+        );
+    });
+});

--- a/packages/language-server/test/plugins/typescript/testfiles/documentation.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/documentation.svelte
@@ -1,0 +1,5 @@
+<script>
+    import { foo } from './documentation'
+
+    foo
+</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/documentation.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/documentation.ts
@@ -1,0 +1,4 @@
+/**
+ * bars
+ */
+export function foo() { return false; }

--- a/packages/language-server/test/plugins/typescript/testfiles/importcompletions.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/importcompletions.svelte
@@ -1,0 +1,1 @@
+<script>import {} from '../testfiles/'</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/importcompletions.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/importcompletions.svelte
@@ -1,1 +1,1 @@
-<script>import {} from '../testfiles/'</script>
+<script>import {} from '../testfiles/' blu</script>


### PR DESCRIPTION
feature:
1. Previously, completion for import statement only show file, now it would show directory and file with the extension (so that it'll have icon before it).
![圖片](https://user-images.githubusercontent.com/36730922/81149713-51a56a80-8fb1-11ea-9472-25968202f1a8.png)
2. Add auto-import capability, it'll now show a message suggesting completion item would be auto imported
![圖片](https://user-images.githubusercontent.com/36730922/81149767-6bdf4880-8fb1-11ea-95e7-8eeca1151af8.png)
3. Show documentation of completion item
![圖片](https://user-images.githubusercontent.com/36730922/81150096-f0ca6200-8fb1-11ea-810e-37217760fc59.png)


code structure:
1. Add `resolveCompletion` to `CompletionsProvider`
2. type `CompletionItem`'s data property