### PR TITLE
Add note to README about needing a preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,13 @@ There are two ways to work on this project: either by working against an existin
 
 ## Running the Dev Language Server Against Your App
 
-To run the developer version of both the language server and the vscode extension:
+To run the developer version of both the language server and the VSCode extension:
 
-- open the root of this repo in VS Code
+- open the root of this repo in VSCode
 - Go to the debugging panel
 - Make sure "Run VSCode Extension" is selected, and hit run
 
-This launches a new vscode window and a watcher for your changes. 
-In this dev window you can choose an existing Svelte project to work against, when you make changes to the extension or language server you can use the command "Reload Window" in the VS Code command palette to see you changes.
+This launches a new VSCode window and a watcher for your changes. In this dev window you can choose an existing Svelte project to work against. Your project will need a Svelte preprocessor setup such as [svelte-preprocess](https://github.com/kaisermann/svelte-preprocess). When you make changes to the extension or language server you can use the command "Reload Window" in the VSCode command palette to see your changes.
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To run the developer version of both the language server and the VSCode extensio
 - Go to the debugging panel
 - Make sure "Run VSCode Extension" is selected, and hit run
 
-This launches a new VSCode window and a watcher for your changes. In this dev window you can choose an existing Svelte project to work against. Your project will need a Svelte preprocessor setup such as [svelte-preprocess](https://github.com/kaisermann/svelte-preprocess). When you make changes to the extension or language server you can use the command "Reload Window" in the VSCode command palette to see your changes.
+This launches a new VSCode window and a watcher for your changes. In this dev window you can choose an existing Svelte project to work against. If you don't use pure Javascript and CSS, but languages like Typescript or SCSS, your project will need a [Svelte preprocessor setup](https://github.com/sveltejs/language-tools/tree/master/packages/svelte-vscode#using-with-preprocessors). When you make changes to the extension or language server you can use the command "Reload Window" in the VSCode command palette to see your changes.
 
 ### Running Tests
 


### PR DESCRIPTION
Thanks for providing this info in https://github.com/sveltejs/language-tools/issues/63. Do you think it's appropriate to add it to the README to help the next person?

I also cleaned up a couple other things I noticed like inconsistent ways of saying VSCode, a run-on sentence, and a missing word