### PR TITLE
Set the languageId to svelte

### DIFF
--- a/packages/language-server/src/lib/documents/Document.ts
+++ b/packages/language-server/src/lib/documents/Document.ts
@@ -118,7 +118,7 @@ export abstract class Document implements TextDocument {
         return this.getText().split(/\r?\n/).length;
     }
 
-    languageId = '';
+    abstract languageId: string;
 }
 
 /**

--- a/packages/language-server/src/lib/documents/ManagedDocument.ts
+++ b/packages/language-server/src/lib/documents/ManagedDocument.ts
@@ -5,6 +5,9 @@ import { WritableDocument } from './Document';
  * Represents a text document that contains a svelte component.
  */
 export class ManagedDocument extends WritableDocument {
+
+    public languageId = 'svelte';
+
     constructor(public url: string, public content: string) {
         super();
     }

--- a/packages/language-server/src/lib/documents/TextDocument.ts
+++ b/packages/language-server/src/lib/documents/TextDocument.ts
@@ -2,6 +2,9 @@ import { urlToPath } from '../../utils';
 import { WritableDocument } from './Document';
 
 export class TextDocument extends WritableDocument {
+
+    public languageId = 'svelte';
+
     constructor(public url: string, public content: string) {
         super();
     }

--- a/packages/language-server/src/plugins/css/CSSDocument.ts
+++ b/packages/language-server/src/plugins/css/CSSDocument.ts
@@ -66,6 +66,7 @@ export class CSSFragment {
 export class CSSDocument extends Document implements Fragment {
     private cssFragment: CSSFragment;
     public stylesheet: Stylesheet;
+    public languageId = 'css';
 
     constructor(private parent: Document) {
         super();

--- a/packages/language-server/src/plugins/svelte/SvelteDocument.ts
+++ b/packages/language-server/src/plugins/svelte/SvelteDocument.ts
@@ -8,6 +8,7 @@ import { urlToPath } from '../../utils';
 export class SvelteDocument extends WritableDocument {
     public script: SvelteFragment;
     public style: SvelteFragment;
+    public languageId = 'svelte';
 
     constructor(public url: string, public content: string) {
         super();

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResovler.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResovler.ts
@@ -5,10 +5,10 @@ import { TypescriptDocument } from './TypescriptDocument';
 
 export class LSAndTSDocResovler {
     constructor(private readonly docManager: DocumentManager) { }
-    createDocument = (fileName: string, content: string) => {
+    private createDocument = (fileName: string, content: string) => {
         const uri = pathToUrl(fileName);
         const document = this.docManager.openDocument({
-            languageId: '',
+            languageId: 'typescript',
             text: content,
             uri,
             version: 0,

--- a/packages/language-server/src/plugins/typescript/TypescriptDocument.ts
+++ b/packages/language-server/src/plugins/typescript/TypescriptDocument.ts
@@ -63,6 +63,7 @@ export class TypescriptFragment {
 
 export class TypescriptDocument extends Document implements Fragment {
     private typescriptFragment: TypescriptFragment;
+    public languageId = 'typescript';
 
     constructor(private parent: Document) {
         super();

--- a/packages/language-server/test/lib/documents/DocumentManager.test.ts
+++ b/packages/language-server/test/lib/documents/DocumentManager.test.ts
@@ -7,7 +7,7 @@ describe('Document Manager', () => {
     const textDocument: TextDocumentItem = {
         uri: 'file:///hello.svelte',
         version: 0,
-        languageId: '',
+        languageId: 'svelte',
         text: 'Hello, world!',
     };
 

--- a/packages/language-server/test/plugins/PluginHost.test.ts
+++ b/packages/language-server/test/plugins/PluginHost.test.ts
@@ -7,7 +7,7 @@ describe('PluginHost', () => {
     const textDocument: TextDocumentItem = {
         uri: 'file:///hello.svelte',
         version: 0,
-        languageId: '',
+        languageId: 'svelte',
         text: 'Hello, world!',
     };
 


### PR DESCRIPTION
I'm guessing the `languageId` shouldn't be empty and was only set that way to get things off the ground

https://code.visualstudio.com/docs/languages/identifiers suggests it should match the package.json:
https://github.com/sveltejs/language-tools/blob/98fc363d079a095b54c8d5c304cdbc6cb62c9d76/packages/svelte-vscode/package.json#L197

This is the first step of https://github.com/sveltejs/language-tools/issues/68