### PR TITLE
remove end brackets from completion trigger character

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -66,9 +66,7 @@ export function startServer() {
                         '+',
                         '^',
                         '(',
-                        ')',
                         '[',
-                        ']',
                         '@',
                         '-',
 


### PR DESCRIPTION
The `)` and `]` are listed as completion trigger characters for language-server. But this causes ts to give competition at weird places.

for example:
```ts
Promise.resolve()
``` 
This end parentheses would trigger completion and ts would give back global objects as completion then if you type `.`, the completion will be committed causing unwanted completion.
![圖片](https://user-images.githubusercontent.com/36730922/81424181-232db800-9188-11ea-86a5-eb4fb54da98e.png)
![圖片](https://user-images.githubusercontent.com/36730922/81424214-2e80e380-9188-11ea-9e3e-0c9d11595068.png)


The comment said it's for emmet, but I don't know any emmet completion that should be trigger by these two. So I think we could safely remove both of them. If anyone knows any, you could point out for me. I would change it be only filter out by the ts completion.