### PR TITLE
Add a link to production version of VSCode plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 ## What is Svelte Language Tools?
 
+This repository contains the code that powers the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+
 A `.svelte` file would look something like this:
 
 ```html
@@ -40,7 +42,7 @@ A `.svelte` file would look something like this:
 
 Which is a mix of [HTMLx](https://github.com/htmlx-org/HTMLx) and vanilla JavaScript (but with additional runtime behavior coming from the svelte compiler). 
 
-This repo contains the tools which provide editor integrations for Svelte files like this.
+This repo contains the VSCode integration for Svelte files like this.
 
 ## Packages
 
@@ -50,7 +52,7 @@ For example `yarn workspace svelte-language-server test`.
 
 #### [`svelte-language-server`](packages/language-server)
 
-The language server for Svelte. Built from [UnwrittenFun/svelte-language-server](https://github.com/UnwrittenFun/svelte-language-server) to become the official language server for the language.
+The VSCode language server for Svelte. Built from [UnwrittenFun/svelte-language-server](https://github.com/UnwrittenFun/svelte-language-server) to become the official language server for the language.
 
 #### [`svelte-vscode`](packages/svelte-vscode)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 ## What is Svelte Language Tools?
 
-This repository contains the code that powers the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+Svelte Language Tools contains a library implementing the Language Server Protocol (LSP). LSP powers the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode), which is also hosted in this repository. Additionally, LSP is capable of powering plugins for [numerous other IDEs](https://microsoft.github.io/language-server-protocol/implementors/tools/
+).
 
 A `.svelte` file would look something like this:
 
@@ -42,7 +43,7 @@ A `.svelte` file would look something like this:
 
 Which is a mix of [HTMLx](https://github.com/htmlx-org/HTMLx) and vanilla JavaScript (but with additional runtime behavior coming from the svelte compiler). 
 
-This repo contains the VSCode integration for Svelte files like this.
+This repo contains the tools which provide editor integrations for Svelte files like this.
 
 ## Packages
 
@@ -52,7 +53,7 @@ For example `yarn workspace svelte-language-server test`.
 
 #### [`svelte-language-server`](packages/language-server)
 
-The VSCode language server for Svelte. Built from [UnwrittenFun/svelte-language-server](https://github.com/UnwrittenFun/svelte-language-server) to become the official language server for the language.
+The language server for Svelte. Built from [UnwrittenFun/svelte-language-server](https://github.com/UnwrittenFun/svelte-language-server) to become the official language server for the language.
 
 #### [`svelte-vscode`](packages/svelte-vscode)
 


### PR DESCRIPTION
It's hard to make your way from this repo to the plugin. We should make it easier to navigate by adding a link.

I originally was going to put the link in https://github.com/sveltejs/language-tools/blob/master/packages/svelte-vscode/README.md in https://github.com/sveltejs/language-tools/pull/76 but it appears that README is used directly in https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode so then I decided that wasn't the best place to put it

I also am clarifying in this PR that this repo is for a VSCode language server and that language servers aren't generic across IDEs. This was confusing to me and others. E.g. see https://github.com/sveltejs/language-tools/issues/74#issuecomment-625913226