### PR TITLE
Only extract top level script

### DIFF
--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -26,6 +26,14 @@ function parseAttributes(str: string): Record<string, string> {
     return attrs;
 }
 
+const EXTRACT_TAG_EXCLUSIONS = [
+    '{#if[\\s\\S]*{\\/if}',
+    '<!--[\\s\\S]*-->',
+    '{#each[\\s\\S]*{\\/each}',
+    '{#await[\\s\\S]*{\\/await}',
+    '{@html[\\s\\S]+}',
+];
+const EXTRACT_TAG_EXCLUSION_EXPS = EXTRACT_TAG_EXCLUSIONS.map(exp => new RegExp(exp));
 /**
  * Extracts a tag (style or script) from the given text
  * and returns its start, end and the attributes on that tag.
@@ -35,12 +43,14 @@ function parseAttributes(str: string): Record<string, string> {
  */
 export function extractTag(source: string, tag: 'script' | 'style') {
     const exp = new RegExp(
-        // eslint-disable-next-line max-len
-        `({#if[\\s\\S]*{\\/if})|(<!--[\\s\\S]*-->)|(<${tag}(\\s[\\S\\s]*?)?>)([\\S\\s]*?)<\\/${tag}>`,
+        `(${EXTRACT_TAG_EXCLUSIONS.join(')|(')})|(<${tag}(\\s[\\S\\s]*?)?>)([\\S\\s]*?)<\\/${tag}>`,
         'igs',
     );
     let match = exp.exec(source);
-    while (match && (match[0].startsWith('<!--') || match[0].startsWith('{#if'))) {
+    while (
+        match &&
+        EXTRACT_TAG_EXCLUSION_EXPS.some(exclusionExp => exclusionExp.exec(match?.[0] ?? ''))
+    ) {
         match = exp.exec(source);
     }
 
@@ -48,9 +58,9 @@ export function extractTag(source: string, tag: 'script' | 'style') {
         return null;
     }
 
-    const attributes = parseAttributes(match[4] || '');
-    const content = match[5];
-    const start = match.index + match[3].length;
+    const attributes = parseAttributes(match[7] || '');
+    const content = match[8];
+    const start = match.index + match[6].length;
     const end = start + content.length;
     const startPos = positionAt(start, source);
     const endPos = positionAt(end, source);

--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -35,6 +35,7 @@ function parseAttributes(str: string): Record<string, string> {
  */
 export function extractTag(source: string, tag: 'script' | 'style') {
     const exp = new RegExp(
+        // eslint-disable-next-line max-len
         `({#if[\\s\\S]*{\\/if})|(<!--[\\s\\S]*-->)|(<${tag}(\\s[\\S\\s]*?)?>)([\\S\\s]*?)<\\/${tag}>`,
         'igs',
     );

--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -19,7 +19,7 @@ function parseAttributes(str: string): Record<string, string> {
     const attrs: Record<string, string> = {};
     str.split(/\s+/)
         .filter(Boolean)
-        .forEach((attr) => {
+        .forEach(attr => {
             const [name, value] = attr.split('=');
             attrs[name] = value ? parseAttributeValue(value) : name;
         });
@@ -33,11 +33,13 @@ function parseAttributes(str: string): Record<string, string> {
  * @param source text content to extract tag from
  * @param tag the tag to extract
  */
-export function extractTag(source: string, tag: 'script' | 'style'): TagInformation | null {
-    const exp = new RegExp(`(<!--.*-->)|(<${tag}(\\s[\\S\\s]*?)?>)([\\S\\s]*?)<\\/${tag}>`, 'igs');
+export function extractTag(source: string, tag: 'script' | 'style') {
+    const exp = new RegExp(
+        `({#if[\\s\\S]*{\\/if})|(<!--[\\s\\S]*-->)|(<${tag}(\\s[\\S\\s]*?)?>)([\\S\\s]*?)<\\/${tag}>`,
+        'igs',
+    );
     let match = exp.exec(source);
-
-    while (match && match[0].startsWith('<!--')) {
+    while (match && (match[0].startsWith('<!--') || match[0].startsWith('{#if'))) {
         match = exp.exec(source);
     }
 
@@ -45,9 +47,9 @@ export function extractTag(source: string, tag: 'script' | 'style'): TagInformat
         return null;
     }
 
-    const attributes = parseAttributes(match[3] || '');
-    const content = match[4];
-    const start = match.index + match[2].length;
+    const attributes = parseAttributes(match[4] || '');
+    const content = match[5];
+    const start = match.index + match[3].length;
     const end = start + content.length;
     const startPos = positionAt(start, source);
     const endPos = positionAt(end, source);

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -90,45 +90,47 @@ describe('document/utils', () => {
         });
         it('extracts top level script tag only', () => {
             const text = `
-            {#if name}
-                <script>
-                    console.log('not top level')
-                </script>
-            {/if}
-            <ul>
-                {#each cats as cat}
+                {#if name}
                     <script>
                         console.log('not top level')
                     </script>
-                {/each}
-            </ul>
-            {#await promise}
-                <script>
-                    console.log('not top level')
-                </script>
-            {:then number}
-                <script>
-                    console.log('not top level')
-                </script>
-            {:catch error}
-                <script>
-                    console.log('not top level')
-                </script>
-            {/await}
-            <p>{@html <script> consolelog('not top level')</script>}</p>
-            <!-- p{ color: blue; }</script> -->
-            <!--<script lang="scss">
-            p{ color: blue; }
-            </script> -->
-            <scrit>blah</script>
-            <script>top level script</script>
+                {/if}
+                <ul>
+                    {#each cats as cat}
+                        <script>
+                            console.log('not top level')
+                        </script>
+                    {/each}
+                </ul>
+                {#await promise}
+                    <script>
+                        console.log('not top level')
+                    </script>
+                {:then number}
+                    <script>
+                        console.log('not top level')
+                    </script>
+                {:catch error}
+                    <script>
+                        console.log('not top level')
+                    </script>
+                {/await}
+                <p>{@html <script> consolelog('not top level')</script>}</p>
+                <!-- p{ color: blue; }</script> -->
+                <!--<script lang="scss">
+                p{ color: blue; }
+                </script> -->
+                <scrit>blah</script>
+                <script>top level script</script>
             `;
             assert.deepStrictEqual(extractTag(text, 'script'), {
                 content: 'top level script',
                 attributes: {},
-                start: 1020,
-                end: 1036,
-                container: { start: 1012, end: 1045 },
+                start: 1148,
+                end: 1164,
+                startPos: Position.create(32, 24),
+                endPos: Position.create(32, 40),
+                container: { start: 1140, end: 1173 },
             });
         });
     });

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -99,15 +99,15 @@ describe('document/utils', () => {
             <!--<script lang="scss">
             p{ color: blue; }
             </script> -->
-            <scrit>asdasda</script>
-            <script>p{ color: blue; }</script>
+            <scrit>blah</script>
+            <script>top level script</script>
             `;
             assert.deepStrictEqual(extractTag(text, 'script'), {
-                content: 'p{ color: blue; }',
+                content: 'top level script',
                 attributes: {},
-                start: 362,
-                end: 379,
-                container: { start: 354, end: 388 },
+                start: 359,
+                end: 375,
+                container: { start: 351, end: 384 },
             });
         });
     });

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -92,9 +92,30 @@ describe('document/utils', () => {
             const text = `
             {#if name}
                 <script>
-                    console.log('I should not be treated as top level')
+                    console.log('not top level')
                 </script>
             {/if}
+            <ul>
+                {#each cats as cat}
+                    <script>
+                        console.log('not top level')
+                    </script>
+                {/each}
+            </ul>
+            {#await promise}
+                <script>
+                    console.log('not top level')
+                </script>
+            {:then number}
+                <script>
+                    console.log('not top level')
+                </script>
+            {:catch error}
+                <script>
+                    console.log('not top level')
+                </script>
+            {/await}
+            <p>{@html <script> consolelog('not top level')</script>}</p>
             <!-- p{ color: blue; }</script> -->
             <!--<script lang="scss">
             p{ color: blue; }
@@ -105,9 +126,9 @@ describe('document/utils', () => {
             assert.deepStrictEqual(extractTag(text, 'script'), {
                 content: 'top level script',
                 attributes: {},
-                start: 359,
-                end: 375,
-                container: { start: 351, end: 384 },
+                start: 1020,
+                end: 1036,
+                container: { start: 1012, end: 1045 },
             });
         });
     });

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -88,5 +88,27 @@ describe('document/utils', () => {
                 container: { start: 17, end: 73 },
             });
         });
+        it('extracts top level script tag only', () => {
+            const text = `
+            {#if name}
+                <script>
+                    console.log('I should not be treated as top level')
+                </script>
+            {/if}
+            <!-- p{ color: blue; }</script> -->
+            <!--<script lang="scss">
+            p{ color: blue; }
+            </script> -->
+            <scrit>asdasda</script>
+            <script>p{ color: blue; }</script>
+            `;
+            assert.deepStrictEqual(extractTag(text, 'script'), {
+                content: 'p{ color: blue; }',
+                attributes: {},
+                start: 362,
+                end: 379,
+                container: { start: 354, end: 388 },
+            });
+        });
     });
 });


### PR DESCRIPTION
Fix for: https://github.com/sveltejs/language-tools/issues/42

This PR changes `extractTag` such that `{#if xx }` statements are ignored. 

But I'm not sure all of these statements should be ignored (for example, `{#if true}`). I'm also not sure if this covers all the possibilities where a script tag should not be considered top level. 

Let me know what you guys think.

