### PR TITLE
fix #80, filtering completion trigger character

### DIFF
--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -16,6 +16,7 @@ import {
     TextEdit,
     FileChangeType,
     CompletionItem,
+    CompletionContext,
 } from 'vscode-languageserver';
 import { LSConfig, LSConfigManager } from '../ls-config';
 import { DocumentManager } from '../lib/documents';
@@ -64,7 +65,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
     async getCompletions(
         textDocument: TextDocumentIdentifier,
         position: Position,
-        triggerCharacter?: string,
+        completionContext?: CompletionContext,
     ): Promise<CompletionList> {
         const document = this.getDocument(textDocument.uri);
         if (!document) {
@@ -74,7 +75,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
         const completions = (
             await this.execute<CompletionList>(
                 'getCompletions',
-                [document, position, triggerCharacter],
+                [document, position, completionContext],
                 ExecuteMode.Collect,
             )
         ).filter(completion => completion != null);

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -9,6 +9,8 @@ import {
     Position,
     Range,
     SymbolInformation,
+    CompletionContext,
+    CompletionTriggerKind,
 } from 'vscode-languageserver';
 import {
     DocumentManager,
@@ -46,6 +48,7 @@ export class CSSPlugin
 
     private configManager!: LSConfigManager;
     private cssDocuments = new WeakMap<Document, CSSDocument>();
+    private triggerCharacters = ['.', ':', '-', '/'];
 
     onRegister(docManager: DocumentManager, configManager: LSConfigManager) {
         this.configManager = configManager;
@@ -98,12 +101,19 @@ export class CSSPlugin
     getCompletions(
         document: Document,
         position: Position,
-        _triggerCharacter: string,
+        completionContext?: CompletionContext
     ): CompletionList | null {
-        // TODO: Why did this need to be removed?
-        // if (triggerCharacter != undefined && !this.triggerCharacters.includes(triggerCharacter)) {
-        //     return null;
-        // }
+        const triggerCharacter = completionContext?.triggerCharacter;
+        const triggerKind = completionContext?.triggerKind;
+        const isCustomTriggerCharater = triggerKind === CompletionTriggerKind.TriggerCharacter;
+
+        if (
+            isCustomTriggerCharater &&
+            triggerCharacter &&
+            !this.triggerCharacters.includes(triggerCharacter)
+        ) {
+            return null;
+        }
 
         if (!this.featureEnabled('completions')) {
             return null;

--- a/packages/language-server/src/plugins/interfaces.ts
+++ b/packages/language-server/src/plugins/interfaces.ts
@@ -15,7 +15,7 @@ import {
     CompletionItem,
     TextDocumentIdentifier,
 } from 'vscode-languageserver-types';
-import { FileChangeType } from 'vscode-languageserver';
+import { FileChangeType, CompletionContext } from 'vscode-languageserver';
 import { DocumentManager, Document } from '../lib/documents';
 import { LSConfigManager } from '../ls-config';
 
@@ -45,7 +45,7 @@ export interface CompletionsProvider<T extends TextDocumentIdentifier = any> {
     getCompletions(
         document: Document,
         position: Position,
-        triggerCharacter?: string,
+        completionContext?: CompletionContext,
     ): Resolvable<AppCompletionList<T> | null>;
 
     resolveCompletion?(document: Document, completionItem: AppCompletionItem<T>):

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -13,6 +13,7 @@ import {
     TextEdit,
     VersionedTextDocumentIdentifier,
     FileChangeType,
+    CompletionContext,
 } from 'vscode-languageserver';
 import {
     DocumentManager,
@@ -178,7 +179,7 @@ export class TypeScriptPlugin
     getCompletions(
         document: Document,
         position: Position,
-        triggerCharacter?: string,
+        completionContext?: CompletionContext,
     ): AppCompletionList<CompletionEntryWithIdentifer> | null {
         if (!this.featureEnabled('completions')) {
             return null;
@@ -187,7 +188,7 @@ export class TypeScriptPlugin
         return this.completionProvider.getCompletions(
             document,
             position,
-            triggerCharacter
+            completionContext
         );
     }
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -97,7 +97,7 @@ export function startServer() {
         pluginHost.getCompletions(
             evt.textDocument,
             evt.position,
-            evt.context && evt.context.triggerCharacter,
+            evt.context,
         ),
     );
     connection.onDocumentFormatting(evt => pluginHost.formatDocument(evt.textDocument));

--- a/packages/language-server/test/plugins/PluginHost.test.ts
+++ b/packages/language-server/test/plugins/PluginHost.test.ts
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 import { Position, TextDocumentItem } from 'vscode-languageserver-types';
 import { DocumentManager, TextDocument } from '../../src/lib/documents';
 import { PluginHost } from '../../src/plugins';
+import { CompletionTriggerKind } from 'vscode-languageserver';
 
 describe('PluginHost', () => {
     const textDocument: TextDocumentItem = {
@@ -60,9 +61,15 @@ describe('PluginHost', () => {
         const document = docManager.openDocument(textDocument);
         const pos = Position.create(0, 0);
 
-        await pluginHost.getCompletions(textDocument, pos, '.');
+        await pluginHost.getCompletions(textDocument, pos, {
+            triggerKind: CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter: '.'
+        });
 
         sinon.assert.calledOnce(plugin.getCompletions);
-        sinon.assert.calledWithExactly(plugin.getCompletions, document, pos, '.');
+        sinon.assert.calledWithExactly(plugin.getCompletions, document, pos, {
+            triggerKind: CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter: '.'
+        });
     });
 });

--- a/packages/language-server/test/plugins/css/CSSPlugin.test.ts
+++ b/packages/language-server/test/plugins/css/CSSPlugin.test.ts
@@ -6,6 +6,7 @@ import {
     CompletionItem,
     CompletionItemKind,
     TextEdit,
+    CompletionContext,
 } from 'vscode-languageserver';
 import { TextDocument, DocumentManager } from '../../../src/lib/documents';
 import { CSSPlugin } from '../../../src/plugins';
@@ -39,7 +40,9 @@ describe('CSS Plugin', () => {
     it('provides completions', async () => {
         const { plugin, document } = setup('<style></style>');
 
-        const completions = plugin.getCompletions(document, Position.create(0, 7), ' ');
+        const completions = plugin.getCompletions(document, Position.create(0, 7), {
+            triggerCharacter: '.'
+        } as CompletionContext);
         assert.ok(
             Array.isArray(completions && completions.items),
             'Expected completion items to be an array',
@@ -63,7 +66,9 @@ describe('CSS Plugin', () => {
     it('provides completions for :global modifier', async () => {
         const { plugin, document } = setup('<style>:g</style>');
 
-        const completions = plugin.getCompletions(document, Position.create(0, 9), ' ');
+        const completions = plugin.getCompletions(document, Position.create(0, 9), {
+            triggerCharacter: ':'
+        } as CompletionContext);
         const globalCompletion = completions?.items.find(item => item.label === ':global()');
         assert.ok(globalCompletion);
     });

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -4,7 +4,7 @@ import assert from 'assert';
 
 import { DocumentManager, TextDocument } from '../../../../src/lib/documents';
 import { pathToUrl } from '../../../../src/utils';
-import { CompletionItem, CompletionItemKind, Position } from 'vscode-languageserver';
+import { CompletionItem, CompletionItemKind, Position, CompletionTriggerKind } from 'vscode-languageserver';
 import { rmdirSync, mkdirSync } from 'fs';
 import {
     CompletionsProviderImpl
@@ -30,7 +30,10 @@ describe('CompletionProviderImpl', () => {
 
         const { completionProvider, document } = setup('completions.svelte');
 
-        const completions = completionProvider.getCompletions(document, Position.create(0, 49), '.');
+        const completions = completionProvider.getCompletions(document, Position.create(0, 49), {
+            triggerKind: CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter: '.'
+        });
 
         assert.ok(
             Array.isArray(completions && completions.items),
@@ -56,7 +59,10 @@ describe('CompletionProviderImpl', () => {
     it('provides completion resolve info', async () => {
         const { completionProvider, document } = setup('completions.svelte');
 
-        const completions = completionProvider.getCompletions(document, Position.create(0, 49), '.');
+        const completions = completionProvider.getCompletions(document, Position.create(0, 49), {
+            triggerKind: CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter: '.'
+        });
 
         const { data } = completions!.items[0];
 
@@ -85,7 +91,10 @@ describe('CompletionProviderImpl', () => {
     it('resolve completion and provide documentation', async () => {
         const { completionProvider, document } = setup('documentation.svelte');
 
-        const completions = completionProvider.getCompletions(document, Position.create(4, 8), '(');
+        const completions = completionProvider.getCompletions(document, Position.create(4, 8), {
+            triggerKind: CompletionTriggerKind.Invoked,
+            triggerCharacter: 'o'
+        });
 
         const { documentation, detail } = await completionProvider.resolveCompletion(
             document,
@@ -104,7 +113,11 @@ describe('CompletionProviderImpl', () => {
         mkdirSync(mockDirPath);
 
         try {
-            const completions = completionProvider.getCompletions(document, Position.create(0, 27), '/');
+            const completions = completionProvider.getCompletions(
+                document, Position.create(0, 27), {
+                triggerKind: CompletionTriggerKind.TriggerCharacter,
+                triggerCharacter: '/'
+            });
             const mockedDirImportCompletion = completions?.items
                 .find(item => item.label === mockDirName);
 

--- a/packages/language-server/test/plugins/typescript/testfiles/documentation.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/documentation.svelte
@@ -1,5 +1,5 @@
 <script>
     import { foo } from './documentation'
 
-    foo
+    fo
 </script>


### PR DESCRIPTION
1. `getCompletions` now use CompletionContext instead of just `triggerCharacter`
2. TS and CSS now only allow specific trigger characters and will not try to get global completion if completion is invoked by a trigger character in which specified in server capability(https://github.com/sveltejs/language-tools/blob/4a8bdd7f9fb04ba6e11fd1d6a87120fb0d9f4fb9/packages/language-server/src/server.ts#L51)