### PR TITLE
(feat) add svelte-preprocess as fallback

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -55,6 +55,7 @@
         "source-map": "^0.7.3",
         "svelte": "3.19.2",
         "svelte2tsx": "~0.1.4",
+        "svelte-preprocess": "~3.7.4",
         "typescript": "*",
         "vscode-css-languageservice": "4.1.0",
         "vscode-emmet-helper": "1.2.17",

--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -1,5 +1,5 @@
-import { clamp } from '../../utils';
-import { Position } from 'vscode-languageserver';
+import { clamp, isInRange } from '../../utils';
+import { Position, Range } from 'vscode-languageserver';
 
 export interface TagInformation {
     content: string;
@@ -19,7 +19,7 @@ function parseAttributes(str: string): Record<string, string> {
     const attrs: Record<string, string> = {};
     str.split(/\s+/)
         .filter(Boolean)
-        .forEach(attr => {
+        .forEach((attr) => {
             const [name, value] = attr.split('=');
             attrs[name] = value ? parseAttributeValue(value) : name;
         });
@@ -33,7 +33,7 @@ const EXTRACT_TAG_EXCLUSIONS = [
     '{#await[\\s\\S]*{\\/await}',
     '{@html[\\s\\S]+}',
 ];
-const EXTRACT_TAG_EXCLUSION_EXPS = EXTRACT_TAG_EXCLUSIONS.map(exp => new RegExp(exp));
+const EXTRACT_TAG_EXCLUSION_EXPS = EXTRACT_TAG_EXCLUSIONS.map((exp) => new RegExp(exp));
 /**
  * Extracts a tag (style or script) from the given text
  * and returns its start, end and the attributes on that tag.
@@ -49,7 +49,7 @@ export function extractTag(source: string, tag: 'script' | 'style') {
     let match = exp.exec(source);
     while (
         match &&
-        EXTRACT_TAG_EXCLUSION_EXPS.some(exclusionExp => exclusionExp.exec(match?.[0] ?? ''))
+        EXTRACT_TAG_EXCLUSION_EXPS.some((exclusionExp) => exclusionExp.exec(match?.[0] ?? ''))
     ) {
         match = exp.exec(source);
     }
@@ -148,4 +148,8 @@ function getLineOffsets(text: string) {
     }
 
     return lineOffsets;
+}
+
+export function isInTag(position: Position, tagInfo: TagInformation | null): boolean {
+    return !!tagInfo && isInRange(Range.create(tagInfo.startPos, tagInfo.endPos), position);
 }

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -78,9 +78,9 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
                 [document, position, completionContext],
                 ExecuteMode.Collect,
             )
-        ).filter(completion => completion != null);
+        ).filter((completion) => completion != null);
 
-        const flattenedCompletions = flatten(completions.map(completion => completion.items));
+        const flattenedCompletions = flatten(completions.map((completion) => completion.items));
         return CompletionList.create(
             flattenedCompletions,
             completions.reduce(
@@ -92,7 +92,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
 
     async resolveCompletion(
         textDocument: TextDocumentIdentifier,
-        completionItem: AppCompletionItem
+        completionItem: AppCompletionItem,
     ): Promise<CompletionItem> {
         const document = this.getDocument(textDocument.uri);
 
@@ -103,12 +103,11 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
         const result = await this.execute<CompletionItem>(
             'resolveCompletion',
             [document, completionItem],
-            ExecuteMode.FirstNonNull
+            ExecuteMode.FirstNonNull,
         );
 
         return result ?? completionItem;
     }
-
 
     async formatDocument(textDocument: TextDocumentIdentifier): Promise<TextEdit[]> {
         const document = this.getDocument(textDocument.uri);
@@ -249,7 +248,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
         args: any[],
         mode: ExecuteMode,
     ): Promise<(T | null) | T[] | void> {
-        const plugins = this.plugins.filter(plugin => typeof plugin[name] === 'function');
+        const plugins = this.plugins.filter((plugin) => typeof plugin[name] === 'function');
 
         switch (mode) {
             case ExecuteMode.FirstNonNull:
@@ -262,11 +261,11 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
                 return null;
             case ExecuteMode.Collect:
                 return Promise.all(
-                    plugins.map(plugin => this.tryExecutePlugin(plugin, name, args, [])),
+                    plugins.map((plugin) => this.tryExecutePlugin(plugin, name, args, [])),
                 );
             case ExecuteMode.None:
                 await Promise.all(
-                    plugins.map(plugin => this.tryExecutePlugin(plugin, name, args, null)),
+                    plugins.map((plugin) => this.tryExecutePlugin(plugin, name, args, null)),
                 );
                 return;
         }
@@ -276,6 +275,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
         try {
             return await plugin[fnName](...args);
         } catch (e) {
+            console.error(e);
             return failValue;
         }
     }

--- a/packages/language-server/src/plugins/importPackage.ts
+++ b/packages/language-server/src/plugins/importPackage.ts
@@ -1,6 +1,7 @@
 import { dirname, resolve } from 'path';
 import * as prettier from 'prettier';
 import * as svelte from 'svelte/compiler';
+import sveltePreprocess from 'svelte-preprocess';
 
 export function getPackageInfo(packageName: string, fromPath: string) {
     const packageJSONPath = require.resolve(`${packageName}/package.json`, {
@@ -32,5 +33,12 @@ export function importSvelte(fromPath: string): typeof svelte {
     const pkg = getPackageInfo('svelte', fromPath);
     const main = resolve(pkg.path, 'compiler');
     console.log('Using Svelte v' + pkg.version.full, 'from', main);
+    return require(main);
+}
+
+export function importSveltePreprocess(fromPath: string): typeof sveltePreprocess {
+    const pkg = getPackageInfo('svelte-preprocess', fromPath);
+    const main = resolve(pkg.path);
+    console.log('Using svelte-preprocess v' + pkg.version.full, 'from', main);
     return require(main);
 }

--- a/packages/language-server/tsconfig.json
+++ b/packages/language-server/tsconfig.json
@@ -9,6 +9,7 @@
         "outDir": "dist",
         "esModuleInterop": true,
         "sourceMap": true,
-        "composite":true
+        "composite": true,
+        "skipLibCheck": true
     }
 }

--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -34,7 +34,7 @@ Provides syntax highlighting and rich intellisense for Svelte components in VS C
 
 #### Language specific setup
 
--   [SCSS](docs/preprocessors/scss.md)
+-   [SCSS/Less](docs/preprocessors/scss.md)
 -   [TypeScript](docs/preprocessors/typescript.md)
 
 #### Generic setup
@@ -162,3 +162,11 @@ Enable diagnostic messages for Svelte. _Default_: `true`
 ##### `svelte.plugin.svelte.format.enable`
 
 Enable formatting for Svelte (includes css & js). _Default_: `true`
+
+##### `svelte.plugin.svelte.hover.enable`
+
+Enable hover info for Svelte (for tags like #if/#each). _Default_: `true`
+
+##### `svelte.plugin.svelte.completions.enable`
+
+Enable autocompletion for Svelte (for tags like #if/#each). _Default_: `true`

--- a/packages/svelte-vscode/docs/preprocessors/scss.md
+++ b/packages/svelte-vscode/docs/preprocessors/scss.md
@@ -1,4 +1,6 @@
-# SCSS Support
+# SCSS/Less Support
+
+The following document talks about SCSS, but the same applies for Less.
 
 ## Syntax Highlighting
 
@@ -67,3 +69,7 @@ module.exports = {
 You will need to tell svelte-vscode to restart the svelte language server in order to pick up the new configuration.
 
 Hit `ctrl-shift-p` or `cmd-shift-p` on mac, type `svelte restart`, and select `Svelte: Restart Language Server`. Any errors you were seeing should now go away and you're now all set up!
+
+## SCSS: Still having errors?
+
+The `node-sass` package is very sensitive to node versions. It may be possible that this plugin runs on a different version than your application. Then it is necessary to set the `svelte.language-server.runtime` setting to the path of your node runtime.

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,6 +117,11 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
   integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
 
+"@types/node@*":
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.1.tgz#5d93e0a099cd0acd5ef3d5bde3c086e1f49ff68c"
+  integrity sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==
+
 "@types/node@^13.9.0":
   version "13.9.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.0.tgz#5b6ee7a77faacddd7de719017d0bc12f52f81589"
@@ -131,6 +136,18 @@
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.0.tgz#a2502fb7ce9b6626fdbfc2e2a496f472de1bdd05"
   integrity sha512-gDE8JJEygpay7IjA/u3JiIURvwZW08f0cZSZLAzFoX/ZmeqvS0Sqv+97aKuHpNsalAMMhwPe+iAS6fQbfmbt7A==
+
+"@types/pug@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.4.tgz#8772fcd0418e3cd2cc171555d73007415051f4b2"
+  integrity sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI=
+
+"@types/sass@^1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.16.0.tgz#b41ac1c17fa68ffb57d43e2360486ef526b3d57d"
+  integrity sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/sinon@^7.5.2":
   version "7.5.2"
@@ -493,6 +510,11 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+detect-indent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
+  integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
 
 diff@3.5.0:
   version "3.5.0"
@@ -1087,6 +1109,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+min-indent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
+  integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
+
 minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -1585,6 +1612,13 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
 strip-json-comments@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -1615,6 +1649,16 @@ supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+svelte-preprocess@~3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-3.7.4.tgz#d10cf9b7c96c2b123da90438a3e9814737347e8d"
+  integrity sha512-0nW7TIjbav2nmw1Y7EAFRRkhNVwJ3zKN85/eITLQMkPuhqHO2i2IK0O3y4YXsSXlc0VGI5jQDVXkcXpga6zzew==
+  dependencies:
+    "@types/pug" "^2.0.4"
+    "@types/sass" "^1.16.0"
+    detect-indent "^6.0.0"
+    strip-indent "^3.0.0"
 
 svelte2tsx@~0.1.4:
   version "0.1.4"


### PR DESCRIPTION
#86 

No preprocessor apart from ts supported yet

We have to discuss what to support out of the box and what not, because the preprocessor (rightfully) says it is your responsibility to install `less` / `babel` etc. So if we would support all of them, we would add quite a lot of dependencies to our project and also bloat the package size.

So what would be the subset we support?

For me mandatory:
- `typescript` (already supported)

Optional:
- `babel`
- `less`
- `sass` (does that work? There are some very system specific things going on with that package..)


As an alternative, we could [maybe do some hacks](https://gist.github.com/branneman/8048520) to reroute the module resolution of `svelte-preprocess` to the user workspace. Chances are very high the user would have installed the needed preprocessors because he needs them either way to get the project to compile.

Another alternative would be to not add this dependency to our project but instead try to find the dependency inside the user's workspace. I think most users use `svelte-preprocess` in their webpack/rollup config, so there is a high chance they have it (and all required other dependencies) installed.

Opinions?

Side note: I added `skipLibCheck` to `tsConfig` because `svelte-preprocess` fails the strict type checks, and also because of the peer dependency types. I hope that is okay for you?