### PR TITLE
(feat) add port option

### DIFF
--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -75,6 +75,13 @@ Path to the node executable you would like to use to run the language server.
 This is useful when you depend on native modules such as node-sass as without
 this they will run in the context of vscode, meaning v8 version mismatch is likely.
 
+##### `svelte.language-server.port`
+
+At which port to spawn the language server.
+Can be used for attaching to the process for debugging / profiling.
+If you experience crashes due to "port already in use", try setting the port.
+-1 = default port is used.
+
 ##### `svelte.plugin.typescript.enable`
 
 Enable the TypeScript plugin. _Default_: `true`

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -52,6 +52,12 @@
                     "title": "Language Server Runtime",
                     "description": "Path to the node executable to use to spawn the language server"
                 },
+                "svelte.language-server.port": {
+                    "type": "number",
+                    "title": "Language Server Port",
+                    "description": "At which port to spawn the language server. Can be used for attaching to the process for debugging / profiling. If you experience crashes due to \"port already in use\", try setting the port. -1 = default port is used.",
+                    "default": -1
+                },
                 "svelte.plugin.typescript.enable": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
At which port to spawn the language server.
Can be used for attaching to the process for debugging / profiling.
If someone experiences crashes due to "port already in use", he can try setting the port.
-1 = default port is used.