### PR TITLE
(feat) prepare for svelte-check

### DIFF
--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -1,1 +1,2 @@
 export * from './server';
+export { offsetAt } from './lib/documents';

--- a/packages/language-server/src/lib/documents/DocumentMapper.ts
+++ b/packages/language-server/src/lib/documents/DocumentMapper.ts
@@ -15,6 +15,7 @@ import {
 } from 'vscode-languageserver';
 import { TagInformation, offsetAt, positionAt } from './utils';
 import { SourceMapConsumer } from 'source-map';
+import { Logger } from '../../logger';
 
 export interface DocumentMapper {
     /**
@@ -117,7 +118,7 @@ export class SourceMapDocumentMapper implements DocumentMapper {
         }
 
         if (mapped.line === 0) {
-            console.warn('Got 0 mapped line from', generatedPosition, 'col was', mapped.column);
+            Logger.log('Got 0 mapped line from', generatedPosition, 'col was', mapped.column);
         }
 
         return {

--- a/packages/language-server/src/logger.ts
+++ b/packages/language-server/src/logger.ts
@@ -1,0 +1,16 @@
+export class Logger {
+    private static logErrorsOnly = false;
+    static setLogErrorsOnly(logErrorsOnly: boolean) {
+        Logger.logErrorsOnly = logErrorsOnly;
+    }
+
+    static log(...args: any) {
+        if (!Logger.logErrorsOnly) {
+            console.log(...args);
+        }
+    }
+
+    static error(...args: any) {
+        console.error(...args);
+    }
+}

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -21,6 +21,7 @@ import {
 import { LSConfig, LSConfigManager } from '../ls-config';
 import { DocumentManager } from '../lib/documents';
 import { LSProvider, Plugin, OnWatchFileChanges, AppCompletionItem } from './interfaces';
+import { Logger } from '../logger';
 
 enum ExecuteMode {
     None,
@@ -274,7 +275,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
         try {
             return await plugin[fnName](...args);
         } catch (e) {
-            console.error(e);
+            Logger.error(e);
             return failValue;
         }
     }

--- a/packages/language-server/src/plugins/importPackage.ts
+++ b/packages/language-server/src/plugins/importPackage.ts
@@ -2,6 +2,7 @@ import { dirname, resolve } from 'path';
 import * as prettier from 'prettier';
 import * as svelte from 'svelte/compiler';
 import sveltePreprocess from 'svelte-preprocess';
+import { Logger } from '../logger';
 
 export function getPackageInfo(packageName: string, fromPath: string) {
     const packageJSONPath = require.resolve(`${packageName}/package.json`, {
@@ -25,20 +26,20 @@ export function getPackageInfo(packageName: string, fromPath: string) {
 export function importPrettier(fromPath: string): typeof prettier {
     const pkg = getPackageInfo('prettier', fromPath);
     const main = resolve(pkg.path);
-    console.log('Using Prettier v' + pkg.version.full, 'from', main);
+    Logger.log('Using Prettier v' + pkg.version.full, 'from', main);
     return require(main);
 }
 
 export function importSvelte(fromPath: string): typeof svelte {
     const pkg = getPackageInfo('svelte', fromPath);
     const main = resolve(pkg.path, 'compiler');
-    console.log('Using Svelte v' + pkg.version.full, 'from', main);
+    Logger.log('Using Svelte v' + pkg.version.full, 'from', main);
     return require(main);
 }
 
 export function importSveltePreprocess(fromPath: string): typeof sveltePreprocess {
     const pkg = getPackageInfo('svelte-preprocess', fromPath);
     const main = resolve(pkg.path);
-    console.log('Using svelte-preprocess v' + pkg.version.full, 'from', main);
+    Logger.log('Using svelte-preprocess v' + pkg.version.full, 'from', main);
     return require(main);
 }

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -23,6 +23,7 @@ import {
 import { getCompletions } from './features/getCompletions';
 import { getHoverInfo } from './features/getHoverInfo';
 import { SvelteDocument } from './SvelteDocument';
+import { Logger } from '../../logger';
 
 interface SvelteConfig extends CompileOptions {
     preprocess?: PreprocessorGroup;
@@ -128,7 +129,7 @@ export class SveltePlugin
     }
 
     private async loadConfig(document: Document): Promise<SvelteConfig> {
-        console.log('loading config for', document.getFilePath());
+        Logger.log('loading config for', document.getFilePath());
         try {
             const explorer = cosmiconfig('svelte', { packageProp: 'svelte-ls' });
             const result = await explorer.search(document.getFilePath() || '');
@@ -146,7 +147,7 @@ export class SveltePlugin
             document.scriptInfo?.attributes.lang ||
             document.scriptInfo?.attributes.type
         ) {
-            console.log(
+            Logger.log(
                 'No svelte.config.js found but one is needed. ' +
                     'Using https://github.com/kaisermann/svelte-preprocess as fallback',
             );


### PR DESCRIPTION
- add options to turn off logging and to pass connection
- export a util used in svelte-check

Part of #68 

After this is merged and the npm package is updated, a PR with a new package Svelte-Check will land.