### PR TITLE
(feat) add new package svelte-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,48 +12,50 @@
   </a>
 </p>
 
-
 ## What is Svelte Language Tools?
 
-Svelte Language Tools contains a library implementing the Language Server Protocol (LSP). LSP powers the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode), which is also hosted in this repository. Additionally, LSP is capable of powering plugins for [numerous other IDEs](https://microsoft.github.io/language-server-protocol/implementors/tools/
-).
+Svelte Language Tools contains a library implementing the Language Server Protocol (LSP). LSP powers the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode), which is also hosted in this repository. Additionally, LSP is capable of powering plugins for [numerous other IDEs](https://microsoft.github.io/language-server-protocol/implementors/tools/).
 
 A `.svelte` file would look something like this:
 
 ```html
 <script>
-  let count = 1;
+    let count = 1;
 
-  // the `$:` means 're-run whenever these values change'
-  $: doubled = count * 2;
-  $: quadrupled = doubled * 2;
+    // the `$:` means 're-run whenever these values change'
+    $: doubled = count * 2;
+    $: quadrupled = doubled * 2;
 
-  function handleClick() {
-    count += 1;
-  }
+    function handleClick() {
+        count += 1;
+    }
 </script>
 
-<button on:click={handleClick}>
-  Count: {count}
+<button on:click="{handleClick}">
+    Count: {count}
 </button>
 
 <p>{count} * 2 = {doubled}</p>
 <p>{doubled} * 2 = {quadrupled}</p>
 ```
 
-Which is a mix of [HTMLx](https://github.com/htmlx-org/HTMLx) and vanilla JavaScript (but with additional runtime behavior coming from the svelte compiler). 
+Which is a mix of [HTMLx](https://github.com/htmlx-org/HTMLx) and vanilla JavaScript (but with additional runtime behavior coming from the svelte compiler).
 
 This repo contains the tools which provide editor integrations for Svelte files like this.
 
 ## Packages
 
-This repo uses [`yarn workspaces`](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), which TLDR means if you want to run a commands in each project then you can either `cd` to that directory and run the command, or use `yarn workspace [package_name] [command]`. 
+This repo uses [`yarn workspaces`](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/), which TLDR means if you want to run a commands in each project then you can either `cd` to that directory and run the command, or use `yarn workspace [package_name] [command]`.
 
 For example `yarn workspace svelte-language-server test`.
 
 #### [`svelte-language-server`](packages/language-server)
 
 The language server for Svelte. Built from [UnwrittenFun/svelte-language-server](https://github.com/UnwrittenFun/svelte-language-server) to become the official language server for the language.
+
+#### [`svelte-check`](packages/svelte-check)
+
+A command line tool to check your svelte files for type errors, unused css, and more.
 
 #### [`svelte-vscode`](packages/svelte-vscode)
 
@@ -91,9 +93,9 @@ There are two ways to work on this project: either by working against an existin
 
 To run the developer version of both the language server and the VSCode extension:
 
-- open the root of this repo in VSCode
-- Go to the debugging panel
-- Make sure "Run VSCode Extension" is selected, and hit run
+-   open the root of this repo in VSCode
+-   Go to the debugging panel
+-   Make sure "Run VSCode Extension" is selected, and hit run
 
 This launches a new VSCode window and a watcher for your changes. In this dev window you can choose an existing Svelte project to work against. If you don't use pure Javascript and CSS, but languages like Typescript or SCSS, your project will need a [Svelte preprocessor setup](packages/svelte-vscode#using-with-preprocessors). When you make changes to the extension or language server you can use the command "Reload Window" in the VSCode command palette to see your changes.
 
@@ -107,7 +109,7 @@ This means it's easy to write tests for your changes:
 yarn test
 ```
 
-For tricker issues, you can run the tests with a debugger in VSCode by setting a breakpoint (or adding `debugger` in the code)  and launching the task: "Run tests with debugger".
+For tricker issues, you can run the tests with a debugger in VSCode by setting a breakpoint (or adding `debugger` in the code) and launching the task: "Run tests with debugger".
 
 ## License
 

--- a/packages/svelte-check/.gitignore
+++ b/packages/svelte-check/.gitignore
@@ -1,0 +1,3 @@
+dist/
+.vscode/
+node_modules/

--- a/packages/svelte-check/.npmignore
+++ b/packages/svelte-check/.npmignore
@@ -1,0 +1,2 @@
+/node_modules
+/src

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -1,0 +1,51 @@
+# Check your code with Svelte-Check
+
+Provides diagnostics for things such as
+
+-   unused css
+-   Svelte A11y hints
+-   Javascript/Typescript diagnostics
+
+### Usage:
+
+#### Global
+
+Installation:
+
+`npm i svelte-check -g`
+
+Usage:
+
+1. Go to folder where to start checking
+2. `svelte-check`
+
+#### Local / in your project
+
+Installation:
+
+`npm i svelte-check --save-dev`
+
+Package.json:
+
+```json
+{
+    // ...
+    "scripts": {
+        "svelte-check": "svelte-check"
+        // ...
+    },
+    // ...
+    "devDependencies": {
+        "svelte-check": "..."
+        // ...
+    }
+}
+```
+
+Usage:
+
+`npm run svelte-check`
+
+### Args:
+
+`--workspace <path to your workspace, where checking starts>`

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -4,7 +4,7 @@ Provides diagnostics for things such as
 
 -   unused css
 -   Svelte A11y hints
--   Javascript/Typescript diagnostics
+-   JavaScript/TypeScript diagnostics
 
 ### Usage:
 

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -1,4 +1,4 @@
-# Check your code with Svelte-Check
+# Check your code with svelte-check
 
 Provides diagnostics for things such as
 

--- a/packages/svelte-check/bin/svelte-check
+++ b/packages/svelte-check/bin/svelte-check
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../dist/src/index.js');

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "svelte-check",
+    "description": "Svelte Code Checker Terminal Interface",
+    "version": "0.1.0",
+    "main": "./dist/src/index.js",
+    "bin": "./bin/svelte-check",
+    "author": "The Svelte Community",
+    "license": "MIT",
+    "dependencies": {
+        "chalk": "^4.0.0",
+        "glob": "^7.1.6",
+        "minimist": "^1.2.5",
+        "svelte-language-server": "*",
+        "vscode-languageserver": "6.1.1",
+        "vscode-languageserver-protocol": "3.15.3",
+        "vscode-languageserver-types": "3.15.1",
+        "vscode-uri": "2.1.1"
+    },
+    "scripts": {
+        "build": "tsc"
+    },
+    "devDependencies": {
+        "@types/glob": "^7.1.1",
+        "@types/minimist": "^1.2.0",
+        "typescript": "*"
+    }
+}

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -17,7 +17,8 @@
         "vscode-uri": "2.1.1"
     },
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "test": "npm --version"
     },
     "devDependencies": {
         "@types/glob": "^7.1.1",

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -128,10 +128,10 @@ async function getDiagnostics(workspaceUri: URI) {
         if (!path.isAbsolute(workspacePath)) {
             workspacePath = path.resolve(process.cwd(), workspacePath);
         }
-        console.log(`Loading Svelte-Check in workspace path: ${workspacePath}`);
+        console.log(`Loading svelte-check in workspace path: ${workspacePath}`);
         workspaceUri = URI.file(workspacePath);
     } else {
-        console.log(`Loading Svelte-Check in current directory: ${process.cwd()}`);
+        console.log(`Loading svelte-check in current directory: ${process.cwd()}`);
         workspaceUri = URI.file(process.cwd());
     }
 
@@ -142,15 +142,15 @@ async function getDiagnostics(workspaceUri: URI) {
     console.log('====================================');
 
     if (errCount === 0) {
-        console.log(chalk.green(`Svelte-Check found no error`));
+        console.log(chalk.green(`svelte-check found no errors`));
         process.exit(0);
     } else {
         console.log(
-            chalk.red(`Svelte-Check found ${errCount} ${errCount === 1 ? 'error' : 'errors'}`),
+            chalk.red(`svelte-check found ${errCount} ${errCount === 1 ? 'error' : 'errors'}`),
         );
         process.exit(1);
     }
 })().catch((_err) => {
     console.error(_err);
-    console.error('Svelte-Check failed');
+    console.error('svelte-check failed');
 });

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -1,0 +1,154 @@
+import * as chalk from 'chalk';
+import * as fs from 'fs';
+import * as glob from 'glob';
+import * as argv from 'minimist';
+import * as path from 'path';
+import { Duplex } from 'stream';
+import { offsetAt, startServer } from 'svelte-language-server';
+import { createConnection } from 'vscode-languageserver';
+import {
+    createProtocolConnection,
+    Diagnostic,
+    DiagnosticSeverity,
+    DidOpenTextDocumentNotification,
+    Logger,
+    StreamMessageReader,
+    StreamMessageWriter,
+} from 'vscode-languageserver-protocol';
+import { URI } from 'vscode-uri';
+
+class NullLogger implements Logger {
+    error(_message: string): void {}
+    warn(_message: string): void {}
+    info(_message: string): void {}
+    log(_message: string): void {}
+}
+
+class TestStream extends Duplex {
+    _write(chunk: string, _encoding: string, done: () => void) {
+        this.emit('data', chunk);
+        done();
+    }
+
+    _read(_size: number) {}
+}
+
+async function prepareClientConnection() {
+    const up = new TestStream();
+    const down = new TestStream();
+    const logger = new NullLogger();
+
+    const clientConnection = createProtocolConnection(
+        new StreamMessageReader(down),
+        new StreamMessageWriter(up),
+        logger,
+    );
+
+    const serverConnection = createConnection(
+        new StreamMessageReader(up),
+        new StreamMessageWriter(down),
+    );
+    startServer({ connection: serverConnection, logErrorsOnly: true });
+
+    clientConnection.listen();
+    return clientConnection;
+}
+
+async function getDiagnostics(workspaceUri: URI) {
+    const clientConnection = await prepareClientConnection();
+
+    const files = glob.sync('**/*.svelte', {
+        cwd: workspaceUri.fsPath,
+        ignore: ['node_modules/**'],
+    });
+    const absFilePaths = files.map((f) => path.resolve(workspaceUri.fsPath, f));
+
+    console.log('');
+    let errCount = 0;
+
+    for (const absFilePath of absFilePaths) {
+        const text = fs.readFileSync(absFilePath, 'utf-8');
+        clientConnection.sendNotification(DidOpenTextDocumentNotification.type, {
+            textDocument: {
+                languageId: 'svelte',
+                uri: URI.file(absFilePath).toString(),
+                version: 1,
+                text,
+            },
+        });
+
+        try {
+            const res = (await clientConnection.sendRequest('$/getDiagnostics', {
+                uri: URI.file(absFilePath).toString(),
+            })) as Diagnostic[];
+            if (res.length > 0) {
+                console.log('');
+                console.log(`${chalk.green('File')} : ${chalk.green(absFilePath)}`);
+                res.forEach((d) => {
+                    const source = d.source ? `(${d.source})` : '';
+                    const position = `Line: ${d.range.start.line}, Character: ${d.range.start.character}`;
+
+                    // Show some context around diagnostic range
+                    const startOffset = offsetAt(d.range.start, text);
+                    const endOffset = offsetAt(d.range.end, text);
+                    const codePrev = chalk.cyan(
+                        text.substring(Math.max(startOffset - 10, 0), startOffset),
+                    );
+                    const codeHighlight = chalk.magenta(text.substring(startOffset, endOffset));
+                    const codePost = chalk.cyan(text.substring(endOffset, endOffset + 10));
+                    const code = codePrev + codeHighlight + codePost;
+
+                    const msg = `${d.message} ${source}\n${position}\n${chalk.cyan(code)}`;
+
+                    if (d.severity === DiagnosticSeverity.Error) {
+                        console.log(`${chalk.red('Error')}: ${msg}`);
+                        errCount++;
+                    } else {
+                        console.log(`${chalk.yellow('Warn')} : ${msg}`);
+                    }
+                });
+                console.log('');
+            }
+        } catch (err) {
+            console.log(err);
+        }
+    }
+
+    return errCount;
+}
+
+(async () => {
+    const myArgs = argv(process.argv.slice(1));
+    let workspaceUri;
+
+    let workspacePath = myArgs['workspace'];
+    if (workspacePath) {
+        if (!path.isAbsolute(workspacePath)) {
+            workspacePath = path.resolve(process.cwd(), workspacePath);
+        }
+        console.log(`Loading Svelte-Check in workspace path: ${workspacePath}`);
+        workspaceUri = URI.file(workspacePath);
+    } else {
+        console.log(`Loading Svelte-Check in current directory: ${process.cwd()}`);
+        workspaceUri = URI.file(process.cwd());
+    }
+
+    console.log('');
+    console.log('Getting Svelte diagnostics...');
+    console.log('====================================');
+    const errCount = await getDiagnostics(workspaceUri);
+    console.log('====================================');
+
+    if (errCount === 0) {
+        console.log(chalk.green(`Svelte-Check found no error`));
+        process.exit(0);
+    } else {
+        console.log(
+            chalk.red(`Svelte-Check found ${errCount} ${errCount === 1 ? 'error' : 'errors'}`),
+        );
+        process.exit(1);
+    }
+})().catch((_err) => {
+    console.error(_err);
+    console.error('Svelte-Check failed');
+});

--- a/packages/svelte-check/tsconfig.json
+++ b/packages/svelte-check/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "lib": ["es6", "es2016.array.include"],
+        "strict": true,
+        "declaration": true,
+        "outDir": "dist",
+        "composite": true
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "references": [
-    { "path": "./packages/language-server" },
-    { "path": "./packages/svelte-vscode" }
-  ],
-  "files": [],
-  "include": [],
-  "exclude": ["**/node_modules"]
+    "references": [
+        { "path": "./packages/language-server" },
+        { "path": "./packages/svelte-vscode" },
+        { "path": "./packages/svelte-check" }
+    ],
+    "files": [],
+    "include": [],
+    "exclude": ["**/node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,6 +102,20 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.42.tgz#8d0c1f480339efedb3e46070e22dd63e0430dd11"
   integrity sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==
 
+"@types/events@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
+  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/glob@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -111,6 +125,16 @@
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+
+"@types/minimist@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
+  integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
 "@types/mocha@^7.0.2":
   version "7.0.2"
@@ -361,6 +385,14 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -1808,7 +1840,7 @@ vscode-languageclient@^6.1.1:
     semver "^6.3.0"
     vscode-languageserver-protocol "^3.15.3"
 
-vscode-languageserver-protocol@^3.15.3:
+vscode-languageserver-protocol@3.15.3, vscode-languageserver-protocol@^3.15.3:
   version "3.15.3"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
   integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==


### PR DESCRIPTION
This PR adds a command line tool `svelte-check`. To test it locally, check out the branch, switch to `packages/svelte-check` run `yarn build`, then `npm link` and you can use `svelte-check` globally. @orta could you do the "publish npm package" stuff? 😄 

Closes #68 