### PR TITLE
Also processes markup in transpile.

### DIFF
--- a/packages/language-server/src/plugins/svelte/SvelteDocument.ts
+++ b/packages/language-server/src/plugins/svelte/SvelteDocument.ts
@@ -220,6 +220,8 @@ async function transpile(document: Document, preprocessors: PreprocessorGroup = 
     let processedScript: Processed | undefined;
     let processedStyle: Processed | undefined;
 
+    preprocessor.markup = preprocessors.markup;
+
     if (preprocessors.script) {
         preprocessor.script = async (args: any) => {
             const res = await preprocessors.script!(args);


### PR DESCRIPTION
Like how the Svelte compiler works, we should first process the markup,
before we can process the script and style, to make sure we get a
representative result.

This fixes an issue where the TypeScript preprocessor needs to look at 
the markup to update the code 
(see this PR: https://github.com/sveltejs/svelte-preprocess/pull/155).

Since the mentioned PR is not merged yet, I did not create an issue,  but
I think the language server should expose the same behavior as the 
Svelte compiler.