### PR TITLE
All props ($$props) issue

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -543,7 +543,7 @@ function createRenderFunction(
     uses$$props: boolean,
 ) {
     const htmlx = str.original;
-    const propsDecl = uses$$props ? ' let $$props: SvelteAllProps;' : '';
+    const propsDecl = uses$$props ? ' let $$props = __sveltets_allPropsType();' : '';
 
     if (scriptTag) {
         //I couldn't get magicstring to let me put the script before the <> we prepend during conversion of the template to jsx, so we just close it instead

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -112,7 +112,7 @@ function processSvelteTemplate(str: MagicString): TemplateProcessResult {
     const leaveArrowFunctionExpression = () => popScope();
 
     const handleIdentifier = (node: Node, parent: Node, prop: string) => {
-        if (node.name == '$$props') {
+        if (node.name === '$$props' || node.name === '$$restProps') {
             uses$$props = true;
             return;
         }
@@ -344,7 +344,7 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
     };
 
     const handleIdentifier = (ident: ts.Identifier, parent: ts.Node) => {
-        if (ident.text == '$$props') {
+        if (ident.text === '$$props' || ident.text === '$$restProps') {
             uses$$props = true;
             return;
         }
@@ -533,7 +533,6 @@ function processModuleScriptTag(str: MagicString, script: Node) {
     str.overwrite(scriptEndTagStart, script.end, ';<>');
 }
 
-// eslint-disable-next-line max-len
 function createRenderFunction(
     str: MagicString,
     scriptTag: Node,
@@ -543,7 +542,9 @@ function createRenderFunction(
     uses$$props: boolean,
 ) {
     const htmlx = str.original;
-    const propsDecl = uses$$props ? ' let $$props = __sveltets_allPropsType();' : '';
+    const propsDecl = uses$$props ?
+        ' let $$props = __sveltets_allPropsType(); let $$restProps = __sveltets_restPropsType();' :
+        '';
 
     if (scriptTag) {
         //I couldn't get magicstring to let me put the script before the <> we prepend during conversion of the template to jsx, so we just close it instead

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -32,6 +32,7 @@ type SvelteAnimation<U extends any[]> = (node: Element, move: { from: DOMRect, t
 }
 
 type SvelteAllProps = {	[index: string]: any }
+type SvelteRestProps = { [index: string]: any }
 type SvelteStore<T> =  { subscribe: (run: (value:T) => any, invalidate?: any) => any }
 
 declare var process: NodeJS.Process & { browser: boolean }
@@ -43,6 +44,7 @@ declare function __sveltets_ensureFunction(expression: (e: Event) => unknown ):a
 declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): any;
 declare function __sveltets_instanceOf<T>(type: AConstructorTypeOf<T>): T;
 declare function __sveltets_allPropsType(): SvelteAllProps
+declare function __sveltets_restPropsType(): SvelteRestProps
 declare function __sveltets_partial<T>(obj: T): Partial<T>;
 declare function __sveltets_partial_with_any<T>(obj: T): Partial<T> & SvelteAllProps
 declare function __sveltets_store_get<T=any>(store: SvelteStore<T>): T

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -42,6 +42,7 @@ declare function __sveltets_ensureTransition<U extends any[]>(transition: Svelte
 declare function __sveltets_ensureFunction(expression: (e: Event) => unknown ):any;
 declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): any;
 declare function __sveltets_instanceOf<T>(type: AConstructorTypeOf<T>): T;
+declare function __sveltets_allPropsType(): SvelteAllProps
 declare function __sveltets_partial<T>(obj: T): Partial<T>;
 declare function __sveltets_partial_with_any<T>(obj: T): Partial<T> & SvelteAllProps
 declare function __sveltets_store_get<T=any>(store: SvelteStore<T>): T

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
@@ -1,4 +1,4 @@
-<></>;function render() { let $$props = __sveltets_allPropsType();
+<></>;function render() { let $$props = __sveltets_allPropsType(); let $$restProps = __sveltets_restPropsType();
 
     let name = $$props['name'];
 ;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
@@ -1,4 +1,4 @@
-<></>;function render() { let $$props: SvelteAllProps;
+<></>;function render() { let $$props = __sveltets_allPropsType();
 
     let name = $$props['name'];
 ;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
@@ -1,4 +1,4 @@
-<></>;function render() { let $$props = __sveltets_allPropsType();
+<></>;function render() { let $$props = __sveltets_allPropsType(); let $$restProps = __sveltets_restPropsType();
 <><h1>{$$props['name']}</h1></>
 return { props: {}, slots: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
@@ -1,4 +1,4 @@
-<></>;function render() { let $$props: SvelteAllProps;
+<></>;function render() { let $$props = __sveltets_allPropsType();
 <><h1>{$$props['name']}</h1></>
 return { props: {}, slots: {} }}
 


### PR DESCRIPTION
fix #104 

Move the type annotation of `$$props` to a dummy declare function and refer type from function return type. So that there will not be any typescript annotation in emitted `tsx`.

Also, add support for `$$restProps`. I didn't create another flag for it because these two both provide access to undefined props, I think it can be simply checked at the same step.