### PR TITLE
fix destructuring in slot props (let:name={{val}})

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx.ts
@@ -16,6 +16,8 @@ const oneWayBindingAttributes: Map<string, ElementType> = new Map(
         ),
 );
 
+const beforeStart = (start: number) => start - 1;
+
 type Walker = (node: Node, parent: Node, prop: string, index: number) => void;
 
 // eslint-disable-next-line max-len
@@ -216,6 +218,7 @@ export function convertHtmlxToJsx(
     const handleSlot = (slotEl: Node, componentName: string, slotName: string) => {
         //collect "let" definitions
         let hasMoved = false;
+        let afterTag: number;
         for (const attr of slotEl.attributes) {
             if (attr.type != 'Let') continue;
 
@@ -225,9 +228,7 @@ export function convertHtmlxToJsx(
                 continue;
             }
 
-            // TODO: This code is confusing :D
-            // eslint-disable-next-line no-var
-            var afterTag = afterTag || htmlx.lastIndexOf('>', slotEl.children[0].start) + 1;
+            afterTag = afterTag || htmlx.lastIndexOf('>', slotEl.children[0].start) + 1;
 
             str.move(attr.start, attr.end, afterTag);
 
@@ -241,7 +242,7 @@ export function convertHtmlxToJsx(
             if (attr.expression) {
                 //overwrite the = as a :
                 const equalSign = htmlx.lastIndexOf('=', attr.expression.start);
-                const curly = htmlx.lastIndexOf('{', attr.expression.start);
+                const curly = htmlx.lastIndexOf('{', beforeStart(attr.expression.start));
                 str.overwrite(equalSign, curly + 1, ':');
                 str.remove(attr.expression.end, attr.end);
             }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/component-default-slot-let-destructure/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/component-default-slot-let-destructure/expected.jsx
@@ -1,0 +1,3 @@
+<><Component >{() => { let {thing:{ a }} = __sveltets_instanceOf(Component).$$slot_def.default;<>
+    <h1>Hello { a }</h1>
+</>}}</Component></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/component-default-slot-let-destructure/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/component-default-slot-let-destructure/input.svelte
@@ -1,0 +1,3 @@
+<Component let:thing={{ a }}>
+    <h1>Hello { a }</h1>
+</Component>


### PR DESCRIPTION
Fix destructuring in slot props by fixing the logical error in finding the start curly brackets of the slot props

before this fix
```svelte
<Component let:thing={{ a }}>
    <h1>Hello { a }</h1>
</Component>
```
got transform into
```tsx
<><Component >{() => { let {thing: a }} = __sveltets_instanceOf(Component).$$slot_def.default;<>
    <h1>Hello { a }</h1>
</>}}</Component></>
```
it miss an curly brackets after `thing:`
