### PR TITLE
(fix) better autocomplete in error state

### DIFF
--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -280,10 +280,6 @@ export class TypeScriptPlugin
         return this.lsAndTsDocResolver.getLSAndTSDoc(document);
     }
 
-    private getLSForPath(path: string) {
-        return this.lsAndTsDocResolver.getLSForPath(path);
-    }
-
     private getSnapshot(filePath: string, document?: Document) {
         return this.lsAndTsDocResolver.getSnapshot(filePath, document);
     }

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -92,7 +92,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             .filter(isNotNullOrUndefined)
             .map((comp) => mapCompletionItemToOriginal(fragment, comp));
 
-        return CompletionList.create(completionItems);
+        return CompletionList.create(completionItems, !!tsDoc.parserError);
     }
 
     private toCompletionItem(


### PR DESCRIPTION
Mark completion list as incomplete when there are parser errors. This way, the server is asked about completions until he can give valid suggestions.

Fixes #144