### PR TITLE
(fix) (feat) support destructuring inside await

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -52,7 +52,7 @@
         "prettier": "2.0.5",
         "prettier-plugin-svelte": "1.1.0",
         "source-map": "^0.7.3",
-        "svelte": "3.19.2",
+        "svelte": "3.23.0",
         "svelte-preprocess": "~3.7.4",
         "svelte2tsx": "~0.1.4",
         "typescript": "*",

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -1,61 +1,61 @@
 {
-  "name": "svelte2tsx",
-  "version": "0.1.4",
-  "description": "Convert Svelte components to TSX for type checking",
-  "author": "David Pershouse",
-  "license": "MIT",
-  "keywords": [
-    "svelte",
-    "typescript"
-  ],
-  "homepage": "https://github.com/halfnelson/svelte2tsx",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/halfnelson/svelte2tsx.git"
-  },
-  "type": "commonjs",
-  "main": "index.js",
-  "types": "index.d.ts",
-  "devDependencies": {
-    "@types/mocha": "^5.2.7",
-    "@types/node": "^8.10.53",
-    "@types/parse5": "^5.0.2",
-    "@types/unist": "^2.0.3",
-    "@types/vfile": "^3.0.2",
-    "magic-string": "^0.25.4",
-    "mocha": "^6.2.2",
-    "parse5": "^5.1.0",
-    "rollup": "^1.12.0",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-delete": "^1.1.0",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-typescript": "^1.0.1",
-    "source-map": "^0.6.1",
-    "source-map-support": "^0.5.16",
-    "svelte": "3.16.0",
-    "tiny-glob": "^0.2.6",
-    "tslib": "^1.10.0",
-    "typescript": "^3.6.4"
-  },
-  "peerDependencies": {
-    "svelte": "^3.16",
-    "typescript": "^3.6"
-  },
-  "scripts": {
-    "build": "rollup -c",
-    "dev": "rollup -c -w",
-    "test": "mocha --opts mocha.opts",
-    "pretest": "rollup -c rollup.config.test.js",
-    "prepublishOnly": "npm run build"
-  },
-  "files": [
-    "index.mjs",
-    "index.js",
-    "index.d.ts",
-    "README.md",
-    "LICENSE",
-    "svelte-jsx.d.ts",
-    "svelte-shims.d.ts"
-  ]
+    "name": "svelte2tsx",
+    "version": "0.1.4",
+    "description": "Convert Svelte components to TSX for type checking",
+    "author": "David Pershouse",
+    "license": "MIT",
+    "keywords": [
+        "svelte",
+        "typescript"
+    ],
+    "homepage": "https://github.com/halfnelson/svelte2tsx",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/halfnelson/svelte2tsx.git"
+    },
+    "type": "commonjs",
+    "main": "index.js",
+    "types": "index.d.ts",
+    "devDependencies": {
+        "@types/mocha": "^5.2.7",
+        "@types/node": "^8.10.53",
+        "@types/parse5": "^5.0.2",
+        "@types/unist": "^2.0.3",
+        "@types/vfile": "^3.0.2",
+        "magic-string": "^0.25.4",
+        "mocha": "^6.2.2",
+        "parse5": "^5.1.0",
+        "rollup": "^1.12.0",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-delete": "^1.1.0",
+        "rollup-plugin-json": "^4.0.0",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "rollup-plugin-typescript": "^1.0.1",
+        "source-map": "^0.6.1",
+        "source-map-support": "^0.5.16",
+        "svelte": "3.23.0",
+        "tiny-glob": "^0.2.6",
+        "tslib": "^1.10.0",
+        "typescript": "^3.9.3"
+    },
+    "peerDependencies": {
+        "svelte": "^3.23",
+        "typescript": "^3.9.3"
+    },
+    "scripts": {
+        "build": "rollup -c",
+        "dev": "rollup -c -w",
+        "test": "mocha --opts mocha.opts",
+        "pretest": "rollup -c rollup.config.test.js",
+        "prepublishOnly": "npm run build"
+    },
+    "files": [
+        "index.mjs",
+        "index.js",
+        "index.d.ts",
+        "README.md",
+        "LICENSE",
+        "svelte-jsx.d.ts",
+        "svelte-shims.d.ts"
+    ]
 }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-array/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-array/expected.jsx
@@ -1,0 +1,7 @@
+<>{() => {let _$$p = (thePromise); <>
+    loading
+</>; _$$p.then(([ a, b ]) => {<>
+    then
+</>}).catch(([c, [d, e]]) => {<>
+    catch
+</>})}}</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-array/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-array/input.svelte
@@ -1,0 +1,7 @@
+{#await thePromise}
+    loading
+{:then [ a, b ]}
+    then
+{:catch [c, [d, e]]}
+    catch
+{/await}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-default/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-default/expected.jsx
@@ -1,0 +1,19 @@
+<>{() => {let _$$p = (object); _$$p.then(({ a = 3, b = 4, c }) => {<>
+    then
+</>})}}
+
+{() => {let _$$p = (array); _$$p.then(([a, b, c = 3]) => {<>
+    then
+</>})}}
+
+{() => {let _$$p = (objectReject); _$$p.then((value) => {<>
+    then
+</>}).catch(({ a = 3, b = 4, c }) => {<>
+    catch
+</>})}}
+
+{() => {let _$$p = (arrayReject); _$$p.then((value) => {<>
+    then
+</>}).catch(([a, b, c = 3]) => {<>
+    catch
+</>})}}</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-default/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-default/input.svelte
@@ -1,0 +1,19 @@
+{#await object then { a = 3, b = 4, c }}
+    then
+{/await}
+
+{#await array then [a, b, c = 3]}
+    then
+{/await}
+
+{#await objectReject then value}
+    then
+{:catch { a = 3, b = 4, c }}
+    catch
+{/await}
+
+{#await arrayReject then value}
+    then
+{:catch [a, b, c = 3]}
+    catch
+{/await}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-object/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-object/expected.jsx
@@ -1,0 +1,7 @@
+<>{() => {let _$$p = (thePromise); <>
+    loading
+</>; _$$p.then(({ result, error }) => {<>
+    then
+</>}).catch(({ error: { message, code } }) => {<>
+    catch
+</>})}}</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-object/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-object/input.svelte
@@ -1,0 +1,7 @@
+{#await thePromise}
+    loading
+{:then { result, error }}
+    then
+{:catch { error: { message, code } }}
+    catch
+{/await}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-rest/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-rest/expected.jsx
@@ -1,0 +1,19 @@
+<>{() => {let _$$p = (object); _$$p.then(({ a, ...rest }) => {<>
+    then
+</>})}}
+
+{() => {let _$$p = (array); _$$p.then(([a, b, ...rest]) => {<>
+    then
+</>})}}
+
+{() => {let _$$p = (objectReject); _$$p.then((value) => {<>
+    then
+</>}).catch(({ a, ...rest }) => {<>
+    catch
+</>})}}
+
+{() => {let _$$p = (arrayReject); _$$p.then((value) => {<>
+    then
+</>}).catch(([a, b, ...rest]) => {<>
+    catch
+</>})}}</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-rest/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/await-block-destruct-rest/input.svelte
@@ -1,0 +1,19 @@
+{#await object then { a, ...rest }}
+    then
+{/await}
+
+{#await array then [a, b, ...rest]}
+    then
+{/await}
+
+{#await objectReject then value}
+    then
+{:catch { a, ...rest }}
+    catch
+{/await}
+
+{#await arrayReject then value}
+    then
+{:catch [a, b, ...rest]}
+    catch
+{/await}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,15 +2017,10 @@ svelte-preprocess@~3.7.4:
     detect-indent "^6.0.0"
     strip-indent "^3.0.0"
 
-svelte@3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.16.0.tgz#7ead284547240fcbcb985c73473dce811315fd15"
-  integrity sha512-k7nCQTd9/rGOi25iv/sBeJe2W89hK2lcaUsmUQqikH0Tye7Gh/tvvF9LuNTSF+dQY/isNX+g8K9fJf+5jMLfxw==
-
-svelte@3.19.2:
-  version "3.19.2"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.19.2.tgz#4b0169ee33b37399f08eb92163593a0a46c242c7"
-  integrity sha512-Jswg065u8R9QYcN0rdpTQSFIr0hFq7YUzcPpEY6ZpFSAWkJKZG9AJvHE1d8+NJDTfr7SzKrO6EYssYYkUmszpA==
+svelte@3.23.0:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.23.0.tgz#bbcd6887cf588c24a975b14467455abfff9acd3f"
+  integrity sha512-cnyd96bK/Nw5DnYuB1hzm5cl6+I1fpmdKOteA7KLzU9KGLsLmvWsSkSKbcntzODCLmSySN3HjcgTHRo6/rJNTw==
 
 table@^5.2.3:
   version "5.4.6"
@@ -2119,12 +2114,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@*:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
-  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
-
-typescript@^3.6.4:
+typescript@*, typescript@^3.9.3:
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
   integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==


### PR DESCRIPTION
svelte2tsx now requires minimum svelte version of 3.22

Closes #103