### PR TITLE
Add preview banner for daily deploy

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -29,6 +29,7 @@ jobs:
       # Setup the environment
       - run: 'json -I -f packages/svelte-vscode/package.json -e "this.dependencies[\`svelte-language-server\`]=\`file:../language-server\`"'
       - run: 'json -I -f packages/svelte-vscode/package.json -e "this.version=\`99.0.0\`"'
+      - run: 'json -I -f packages/svelte-vscode/package.json -e "this.preview=true"'
 
       # To deploy we need a node_modules folder which isn't in the yarn
       # So, remove the workspace


### PR DESCRIPTION
This adds the JSON field which adds a "preview" banner  during the nightly deploy

![Screen Shot 2020-06-03 at 10 54 45 AM](https://user-images.githubusercontent.com/49038/83652462-ac1df080-a588-11ea-8394-2655b4af1a5e.png)

Should make it easier for folks to see the diff when there's a prod build