### PR TITLE
(feat) bump to es2018

### DIFF
--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -3,6 +3,8 @@
 A language server (implementing the [language server protocol](https://microsoft.github.io/language-server-protocol/))
 for Svelte.
 
+Requires Node 12 or later.
+
 ## What is a language server?
 
 From https://microsoft.github.io/language-server-protocol/overview

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -31,6 +31,7 @@
     },
     "homepage": "https://github.com/sveltejs/language-tools#readme",
     "devDependencies": {
+        "@tsconfig/node12": "^1.0.0",
         "@types/cosmiconfig": "^6.0.0",
         "@types/estree": "^0.0.42",
         "@types/lodash": "^4.14.116",

--- a/packages/language-server/tsconfig.json
+++ b/packages/language-server/tsconfig.json
@@ -1,9 +1,7 @@
 {
+    "extends": "@tsconfig/node12/tsconfig.json",
     "compilerOptions": {
-        "target": "es5",
-        "module": "commonjs",
         "moduleResolution": "node",
-        "lib": ["es6", "es2016.array.include"],
         "strict": true,
         "declaration": true,
         "outDir": "dist",

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -6,6 +6,8 @@ Provides diagnostics for things such as
 -   Svelte A11y hints
 -   JavaScript/TypeScript diagnostics
 
+Requires Node 12 or later.
+
 ### Usage:
 
 #### Global

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -19,6 +19,7 @@
     },
     "homepage": "https://github.com/sveltejs/language-tools#readme",
     "dependencies": {
+        "@tsconfig/node12": "^1.0.0",
         "chalk": "^4.0.0",
         "glob": "^7.1.6",
         "minimist": "^1.2.5",

--- a/packages/svelte-check/tsconfig.json
+++ b/packages/svelte-check/tsconfig.json
@@ -1,9 +1,7 @@
 {
+    "extends": "@tsconfig/node12/tsconfig.json",
     "compilerOptions": {
-        "target": "es6",
-        "module": "commonjs",
         "moduleResolution": "node",
-        "lib": ["es6", "es2016.array.include"],
         "strict": true,
         "declaration": true,
         "outDir": "dist",

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -243,9 +243,10 @@
         ]
     },
     "devDependencies": {
+        "@tsconfig/node12": "^1.0.0",
         "@types/node": "^13.9.0",
-        "typescript": "*",
-        "@types/vscode": "*"
+        "@types/vscode": "*",
+        "typescript": "*"
     },
     "dependencies": {
         "svelte-language-server": "*",

--- a/packages/svelte-vscode/tsconfig.json
+++ b/packages/svelte-vscode/tsconfig.json
@@ -1,9 +1,7 @@
 {
+    "extends": "@tsconfig/node12/tsconfig.json",
     "compilerOptions": {
-        "target": "es6",
-        "module": "commonjs",
         "moduleResolution": "node",
-        "lib": ["es6", "es2016.array.include"],
         "strict": true,
         "declaration": true,
         "outDir": "dist",

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -17,7 +17,6 @@
     "main": "index.js",
     "types": "index.d.ts",
     "devDependencies": {
-        "@tsconfig/node12": "^1.0.0",
         "@types/mocha": "^5.2.7",
         "@types/node": "^8.10.53",
         "@types/parse5": "^5.0.2",

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -17,6 +17,7 @@
     "main": "index.js",
     "types": "index.d.ts",
     "devDependencies": {
+        "@tsconfig/node12": "^1.0.0",
         "@types/mocha": "^5.2.7",
         "@types/node": "^8.10.53",
         "@types/parse5": "^5.0.2",

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -599,9 +599,9 @@ function createRenderFunction(
 
     const slotsAsDef =
         '{' +
-        [...slots.entries()]
+        Array.from(slots.entries())
             .map(([name, attrs]) => {
-                const attrsAsString = [...attrs.entries()]
+                const attrsAsString = Array.from(attrs.entries())
                     .map(([exportName, expr]) => `${exportName}:${expr}`)
                     .join(', ');
                 return `${name}: {${attrsAsString}}`;
@@ -616,7 +616,7 @@ function createRenderFunction(
 }
 
 function createPropsStr(exportedNames: ExportedNames) {
-    const names = [...exportedNames.entries()];
+    const names = Array.from(exportedNames.entries());
 
     const returnElements = names.map(([key, value]) => {
         if (!value.identifierText) {

--- a/packages/svelte2tsx/tsconfig.json
+++ b/packages/svelte2tsx/tsconfig.json
@@ -1,6 +1,7 @@
 {
-    "extends": "@tsconfig/node12/tsconfig.json",
     "compilerOptions": {
+        "target": "es2018",
+        "lib": ["ES2018"],
         "rootDir": "src",
 
         "sourceMap": true,

--- a/packages/svelte2tsx/tsconfig.json
+++ b/packages/svelte2tsx/tsconfig.json
@@ -1,29 +1,26 @@
 {
+    "extends": "@tsconfig/node12/tsconfig.json",
     "compilerOptions": {
-      "rootDir": "src",
-      
-      "target":"es2017",
-      "lib": ["es2017"],
-      "sourceMap": true,
-      
-      "noEmitOnError": true,
-      "noErrorTruncation": true,
+        "rootDir": "src",
 
-      //let rollup handle these
-      "module": "esnext",
-      "moduleResolution": "node",
-      "resolveJsonModule": true,
-      "allowSyntheticDefaultImports": true,
+        "sourceMap": true,
 
-      "noImplicitThis": true,
-      "noUnusedLocals": true,
-      "noUnusedParameters": true,
+        "noEmitOnError": true,
+        "noErrorTruncation": true,
+
+        //let rollup handle these
+        "module": "esnext",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "allowSyntheticDefaultImports": true,
+
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true
     },
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+        "@/*": ["src/*"]
     },
-    "include": [ ],
-    "exclude": [ "node_modules"]
-  }
+    "include": [],
+    "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,6 +80,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@tsconfig/node12@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.0.tgz#da94e1a4d002a30ed05553784582894416ba3c7b"
+  integrity sha512-5yHnOI3nejtG2Ak55PRb4SduB14LNMZhihTI0zpKQBCVVuB4h7H1enwoDwhY/8/hC9aPIY8DeZTJzQpk2kZOGA==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"


### PR DESCRIPTION
Also add info that node 12 is required (although node 10 should also work)

Closes #155