### PR TITLE
(fix) ignore sass

### DIFF
--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -62,6 +62,11 @@ export class CSSPlugin
         }
 
         const cssDocument = this.getCSSDoc(document);
+
+        if (isSASS(cssDocument)) {
+            return [];
+        }
+
         const kind = extractLanguage(cssDocument);
 
         if (shouldExcludeValidation(kind)) {
@@ -80,7 +85,7 @@ export class CSSPlugin
         }
 
         const cssDocument = this.getCSSDoc(document);
-        if (!cssDocument.isInGenerated(position)) {
+        if (!cssDocument.isInGenerated(position) || isSASS(cssDocument)) {
             return null;
         }
 
@@ -114,7 +119,7 @@ export class CSSPlugin
         }
 
         const cssDocument = this.getCSSDoc(document);
-        if (!cssDocument.isInGenerated(position)) {
+        if (!cssDocument.isInGenerated(position) || isSASS(cssDocument)) {
             return null;
         }
 
@@ -153,6 +158,10 @@ export class CSSPlugin
 
         const cssDocument = this.getCSSDoc(document);
 
+        if (isSASS(cssDocument)) {
+            return [];
+        }
+
         return getLanguageService(extractLanguage(cssDocument))
             .findDocumentColors(cssDocument, cssDocument.stylesheet)
             .map((colorInfo) => mapColorInformationToOriginal(cssDocument, colorInfo));
@@ -164,7 +173,10 @@ export class CSSPlugin
         }
 
         const cssDocument = this.getCSSDoc(document);
-        if (!cssDocument.isInGenerated(range.start) && !cssDocument.isInGenerated(range.end)) {
+        if (
+            (!cssDocument.isInGenerated(range.start) && !cssDocument.isInGenerated(range.end)) ||
+            isSASS(cssDocument)
+        ) {
             return [];
         }
 
@@ -184,6 +196,10 @@ export class CSSPlugin
         }
 
         const cssDocument = this.getCSSDoc(document);
+
+        if (isSASS(cssDocument)) {
+            return [];
+        }
 
         return getLanguageService(extractLanguage(cssDocument))
             .findDocumentSymbols(cssDocument, cssDocument.stylesheet)
@@ -222,6 +238,16 @@ function shouldExcludeValidation(kind?: string) {
     switch (kind) {
         case 'postcss':
         case 'text/postcss':
+            return true;
+        default:
+            return false;
+    }
+}
+
+function isSASS(document: CSSDocument) {
+    switch (extractLanguage(document)) {
+        case 'sass':
+        case 'text/sass':
             return true;
         default:
             return false;


### PR DESCRIPTION
Some people use the old SASS syntax, and the language server does not support that. Instead of throwing errors and weird hover infos at them, just return nothing. No good highlighting/intellisense then but still better than showing syntax errors.