### PR TITLE
fixing memory issues

### DIFF
--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -67,7 +67,8 @@ export class LSAndTSDocResolver {
     getSnapshot(filePath: string, document: Document): SvelteDocumentSnapshot;
     getSnapshot(filePath: string, document?: Document): DocumentSnapshot;
     getSnapshot(filePath: string, document?: Document) {
-        const [tsService, snapshotManager] = this.getTSServiceWithManager(filePath);
+        const tsService = this.getTSService(filePath);
+        const { snapshotManager } = tsService;
 
         let tsDoc = snapshotManager.get(filePath);
         if (!tsDoc) {
@@ -92,13 +93,7 @@ export class LSAndTSDocResolver {
     }
 
     getSnapshotManager(filePath: string): SnapshotManager {
-        return this.getTSServiceWithManager(filePath)[1];
-    }
-
-    private getTSServiceWithManager(filePath: string): [LanguageServiceContainer, SnapshotManager] {
-        const tsService = this.getTSService(filePath);
-        const snapshotManager = SnapshotManager.getFromTsConfigPath(tsService.tsconfigPath);
-        return [tsService, snapshotManager];
+        return this.getTSService(filePath).snapshotManager;
     }
 
     private getTSService(filePath: string): LanguageServiceContainer {

--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -8,7 +8,7 @@ export class SnapshotManager {
     private documents: Map<string, DocumentSnapshot> = new Map();
 
     updateByFileName(fileName: string, options: SvelteSnapshotOptions) {
-        if (!this.projectFiles.includes(fileName)) {
+        if (!this.has(fileName)) {
             return;
         }
 
@@ -24,6 +24,10 @@ export class SnapshotManager {
         }
 
         this.set(fileName, newSnapshot);
+    }
+
+    has(fileName: string) {
+        return this.projectFiles.includes(fileName) || this.getFileNames().includes(fileName);
     }
 
     set(fileName: string, snapshot: DocumentSnapshot) {

--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -1,20 +1,30 @@
-import { DocumentSnapshot } from './DocumentSnapshot';
+import { DocumentSnapshot, SvelteSnapshotOptions } from './DocumentSnapshot';
 
 export class SnapshotManager {
-    private static managerContainer: Map<string, SnapshotManager> = new Map();
-
-    static getFromTsConfigPath(tsconfigPath: string): SnapshotManager {
-        let manager = this.managerContainer.get(tsconfigPath);
-
-        if (!manager) {
-            manager = new SnapshotManager();
-            this.managerContainer.set(tsconfigPath, manager);
-        }
-
-        return manager;
-    }
+    constructor(
+        private projectFiles: string[]
+    ) { }
 
     private documents: Map<string, DocumentSnapshot> = new Map();
+
+    updateByFileName(fileName: string, options: SvelteSnapshotOptions) {
+        if (!this.projectFiles.includes(fileName)) {
+            return;
+        }
+
+        const newSnapshot = DocumentSnapshot.fromFilePath(fileName, options);
+        const previousSnapshot = this.get(fileName);
+
+        if (previousSnapshot) {
+            newSnapshot.version = previousSnapshot.version + 1;
+        } else {
+            // ensure it's greater than initial version
+            // so that ts server picks up the change
+            newSnapshot.version += 1;
+        }
+
+        this.set(fileName, newSnapshot);
+    }
 
     set(fileName: string, snapshot: DocumentSnapshot) {
         const prev = this.get(fileName);
@@ -30,10 +40,16 @@ export class SnapshotManager {
     }
 
     delete(fileName: string) {
+        this.projectFiles = this.projectFiles
+            .filter(s => s !== fileName);
         return this.documents.delete(fileName);
     }
 
     getFileNames() {
         return Array.from(this.documents.keys());
+    }
+
+    getProjectFileNames() {
+        return [...this.projectFiles];
     }
 }

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -34,7 +34,7 @@ import {
     OnWatchFileChanges,
     UpdateImportsProvider,
 } from '../interfaces';
-import { DocumentSnapshot, SnapshotFragment } from './DocumentSnapshot';
+import { SnapshotFragment } from './DocumentSnapshot';
 import { CodeActionsProviderImpl } from './features/CodeActionsProvider';
 import {
     CompletionEntryWithIdentifer,
@@ -264,18 +264,7 @@ export class TypeScriptPlugin
 
         // Since the options parameter only applies to svelte snapshots, and this is not
         // a svelte file, we can just set it to false without having any effect.
-        const newSnapshot = DocumentSnapshot.fromFilePath(fileName, { strictMode: false });
-        const previousSnapshot = snapshotManager.get(fileName);
-
-        if (previousSnapshot) {
-            newSnapshot.version = previousSnapshot.version + 1;
-        } else {
-            // ensure it's greater than initial version
-            // so that ts server picks up the change
-            newSnapshot.version += 1;
-        }
-
-        snapshotManager.set(fileName, newSnapshot);
+        snapshotManager.updateByFileName(fileName, { strictMode: false });
     }
 
     private getLSAndTSDoc(document: Document) {
@@ -286,7 +275,11 @@ export class TypeScriptPlugin
         return this.lsAndTsDocResolver.getSnapshot(filePath, document);
     }
 
-    private getSnapshotManager(fileName: string) {
+    /**
+     *
+     * @internal
+     */
+    public getSnapshotManager(fileName: string) {
         return this.lsAndTsDocResolver.getSnapshotManager(fileName);
     }
 

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -160,21 +160,26 @@ export function createLanguageService(
         };
 
         const configJson = tsconfigPath && ts.readConfigFile(tsconfigPath, ts.sys.readFile).config;
-        let files: string[] = [];
-        if (configJson) {
-            const parsedConfig = ts.parseJsonConfigFileContent(
-                configJson,
-                ts.sys,
-                workspacePath,
-                compilerOptions,
-                tsconfigPath,
-                undefined,
-                [{ extension: 'svelte', isMixedContent: false, scriptKind: ts.ScriptKind.TSX }],
-            );
 
-            compilerOptions = { ...compilerOptions, ...parsedConfig.options };
-            files = parsedConfig.fileNames;
-        }
+        const defaultExclude = [
+            '__sapper__',
+            'node_modules'
+        ];
+
+        const config = Object.assign({ exclude: defaultExclude }, configJson);
+
+        const parsedConfig = ts.parseJsonConfigFileContent(
+            config,
+            ts.sys,
+            workspacePath,
+            compilerOptions,
+            tsconfigPath,
+            undefined,
+            [{ extension: 'svelte', isMixedContent: false, scriptKind: ts.ScriptKind.TSX }],
+        );
+
+        compilerOptions = { ...compilerOptions, ...parsedConfig.options };
+        const files = parsedConfig.fileNames;
 
         const forcedOptions: ts.CompilerOptions = {
             noEmit: true,

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -11,6 +11,7 @@ import { ensureRealSvelteFilePath, findTsConfigPath, isSvelteFilePath } from './
 export interface LanguageServiceContainer {
     readonly tsconfigPath: string;
     readonly compilerOptions: ts.CompilerOptions;
+    readonly snapshotManager: SnapshotManager;
     getService(): ts.LanguageService;
     updateDocument(document: Document): ts.LanguageService;
     deleteDocument(filePath: string): void;
@@ -58,10 +59,9 @@ export function createLanguageService(
     createDocument: CreateDocument,
 ): LanguageServiceContainer {
     const workspacePath = tsconfigPath ? dirname(tsconfigPath) : '';
-    const snapshotManager = SnapshotManager.getFromTsConfigPath(tsconfigPath);
-    const sveltePkgInfo = getPackageInfo('svelte', workspacePath);
 
-    const { compilerOptions, files } = getCompilerOptionsAndRootFiles();
+    const { compilerOptions, files } = getCompilerOptionsAndProjectFiles();
+    const snapshotManager = new SnapshotManager(files);
 
     const svelteModuleLoader = createSvelteModuleLoader(getSnapshot, compilerOptions);
 
@@ -72,8 +72,11 @@ export function createLanguageService(
 
     const host: ts.LanguageServiceHost = {
         getCompilationSettings: () => compilerOptions,
-        getScriptFileNames: () =>
-            Array.from(new Set([...files, ...snapshotManager.getFileNames(), ...svelteTsxFiles])),
+        getScriptFileNames: () => Array.from(new Set([
+            ...snapshotManager.getProjectFileNames(),
+            ...snapshotManager.getFileNames(),
+            ...svelteTsxFiles
+        ])),
         getScriptVersion: (fileName: string) => getSnapshot(fileName).version.toString(),
         getScriptSnapshot: getSnapshot,
         getCurrentDirectory: () => workspacePath,
@@ -95,6 +98,7 @@ export function createLanguageService(
         getService: () => languageService,
         updateDocument,
         deleteDocument,
+        snapshotManager
     };
 
     function deleteDocument(filePath: string): void {
@@ -144,7 +148,8 @@ export function createLanguageService(
         return doc;
     }
 
-    function getCompilerOptionsAndRootFiles() {
+    function getCompilerOptionsAndProjectFiles() {
+        const sveltePkgInfo = getPackageInfo('svelte', workspacePath);
         let compilerOptions: ts.CompilerOptions = {
             allowNonTsExtensions: true,
             target: ts.ScriptTarget.Latest,

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -165,7 +165,13 @@ export function createLanguageService(
         ) || {
             compilerOptions: getDeaultJsCompilerOption()
         };
-        configJson = Object.assign({ exclude: getDefaultExclude() }, configJson);
+
+        // Only default exclude when no extends for now
+        if (!configJson.extends) {
+            configJson = Object.assign({
+                exclude: getDefaultExclude()
+            }, configJson);
+        }
 
         const parsedConfig = ts.parseJsonConfigFileContent(
             configJson,


### PR DESCRIPTION
1. [x] fix onWatchFileChanges add ignored files.
2. [x] default to ignore `__sapper__`, `node_modules` and maybe `dist` .
3. [ ] reparse config when file got added.
4. [ ] fix memory leak when user add/remove/rename an jsconfig.json/ tsconfig.json