### PR TITLE
(fix) refactor extractTag to use parse5 instead of RegEx

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -6,7 +6,6 @@
     "typings": "dist/src/index",
     "scripts": {
         "test": "cross-env TS_NODE_TRANSPILE_ONLY=true mocha --require ts-node/register \"test/**/*.ts\"",
-        "runonce": "ts-node runonce.ts",
         "build": "tsc",
         "watch": "tsc -w",
         "prepublishOnly": "yarn test && yarn build"

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -6,6 +6,7 @@
     "typings": "dist/src/index",
     "scripts": {
         "test": "cross-env TS_NODE_TRANSPILE_ONLY=true mocha --require ts-node/register \"test/**/*.ts\"",
+        "runonce": "ts-node runonce.ts",
         "build": "tsc",
         "watch": "tsc -w",
         "prepublishOnly": "yarn test && yarn build"

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -129,22 +129,50 @@ describe('document/utils', () => {
                     </script>
                 {/await}
                 <p>{@html <script> consolelog('not top level')</script>}</p>
+                {@html mycontent}
+                {@debug myvar}
                 <!-- p{ color: blue; }</script> -->
                 <!--<script lang="scss">
                 p{ color: blue; }
                 </script> -->
-                <scrit>blah</script>
+                <scrit>blah</scrit>
                 <script>top level script</script>
             `;
+            // Note: cannot test <scrit>blah</scriPt> as that breaks parse5 parsing for top level script!
+
             assert.deepStrictEqual(extractTag(text, 'script'), {
                 content: 'top level script',
                 attributes: {},
-                start: 1148,
-                end: 1164,
-                startPos: Position.create(32, 24),
-                endPos: Position.create(32, 40),
-                container: { start: 1140, end: 1173 },
+                start: 1212,
+                end: 1228,
+                startPos: Position.create(34, 24),
+                endPos: Position.create(34, 40),
+                container: { start: 1204, end: 1237 },
             });
         });
+
+        it('ignores script tag in svelte:head', () => {
+            // https://github.com/sveltejs/language-tools/issues/143#issuecomment-636422045
+            const text = `
+            <svelte:head>
+                <link rel="stylesheet" href="/lib/jodit.es2018.min.css" />
+                <script src="/lib/jodit.es2018.min.js"> 
+                </script>
+            </svelte:head>
+            <p>jo</p>
+            <script>top level script</script>
+            <h1>Hello, world!</h1>
+            <style>.bla {}</style>
+            `
+            assert.deepStrictEqual(extractTag(text, 'script'), {
+                content: 'top level script',
+                attributes: {},
+                start: 254,
+                end: 270,
+                startPos: Position.create(7, 20),
+                endPos: Position.create(7, 36),
+                container: { start: 246, end: 279 },
+            });
+        })
     });
 });

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -163,7 +163,7 @@ describe('document/utils', () => {
             <script>top level script</script>
             <h1>Hello, world!</h1>
             <style>.bla {}</style>
-            `
+            `;
             assert.deepStrictEqual(extractTag(text, 'script'), {
                 content: 'top level script',
                 attributes: {},
@@ -173,6 +173,6 @@ describe('document/utils', () => {
                 endPos: Position.create(7, 36),
                 container: { start: 246, end: 279 },
             });
-        })
+        });
     });
 });

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -44,6 +44,15 @@ describe('document/utils', () => {
             assert.deepStrictEqual(extractTag(text, 'style'), null);
         });
 
+        it('is canse sensitive to style/script', () => {
+            const text = `
+            <Style></Style>
+            <Script></Script>
+            `;
+            assert.deepStrictEqual(extractTag(text, 'style'), null);
+            assert.deepStrictEqual(extractTag(text, 'script'), null);
+        });
+
         it('only extract attribute until tag ends', () => {
             const text = `
             <script type="typescript">

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -21,7 +21,7 @@ describe('TypescriptPlugin', () => {
         const docManager = new DocumentManager(() => document);
         const testDir = path.join(__dirname, 'testfiles');
         const filePath = path.join(testDir, filename);
-        const document = new Document(pathToUrl(filePath), ts.sys.readFile(filePath)!);
+        const document = new Document(pathToUrl(filePath), ts.sys.readFile(filePath) || '');
         const pluginManager = new LSConfigManager();
         const plugin = new TypeScriptPlugin(docManager, pluginManager, testDir);
         docManager.openDocument(<any>'some doc');


### PR DESCRIPTION
closes https://github.com/sveltejs/language-tools/issues/143

Because parse5 parses tags in a very specific way, i had to tweak one of the tests, I will comment below.