### PR TITLE
(fix) deal with multiple script tags

### DIFF
--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
@@ -1,0 +1,20 @@
+<></>;function render() {
+
+  let b = 'top level';
+;
+<><div>
+  
+</div>
+
+
+
+<sveltehead>
+  <link rel="stylesheet" href="/lib/jodit.es2018.min.css" />
+  
+</sveltehead></>
+return { props: {}, slots: {} }}
+
+export default class {
+    $$prop_def = __sveltets_partial(render().props)
+    $$slot_def = render().slots
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/input.svelte
@@ -1,0 +1,14 @@
+<div>
+  <script>let a = 'not top level';</script>
+</div>
+
+<script>
+  let b = 'top level';
+</script>
+
+<svelte:head>
+  <link rel="stylesheet" href="/lib/jodit.es2018.min.css" />
+  <script src="/lib/jodit.es2018.min.js">
+
+  </script>
+</svelte:head>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
@@ -1,7 +1,8 @@
 <></>;import Test from './Test.svelte';
 function render() {
 
- 
+
+let a = 'b';
 ;
 <><Test b="6" />
 </>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/input.svelte
@@ -1,4 +1,5 @@
 <Test b="6" />
 <script>
-import Test from './Test.svelte'; 
+import Test from './Test.svelte';
+let a = 'b';
 </script>


### PR DESCRIPTION
All script tags, no matter at what level, are listed within the root children.
To get the top level scripts, filter out all those that are part of children's children.
Those have another type ('Element' with name 'script').

Fixes #143