### PR TITLE
add support for svelte component import completion

### DIFF
--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -71,6 +71,7 @@ export function createSvelteModuleLoader(
     return {
         fileExists: svelteSys.fileExists,
         readFile: svelteSys.readFile,
+        readDirectory: svelteSys.readDirectory,
         deleteFromModuleCache: (path: string) => moduleCache.delete(path),
         resolveModuleNames,
     };

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -84,7 +84,7 @@ export function createLanguageService(
         fileExists: svelteModuleLoader.fileExists,
         readFile: svelteModuleLoader.readFile,
         resolveModuleNames: svelteModuleLoader.resolveModuleNames,
-        readDirectory: ts.sys.readDirectory,
+        readDirectory: svelteModuleLoader.readDirectory,
         getDirectories: ts.sys.getDirectories,
         // vscode's uri is all lowercase
         useCaseSensitiveFileNames: () => false,

--- a/packages/language-server/src/plugins/typescript/svelte-sys.ts
+++ b/packages/language-server/src/plugins/typescript/svelte-sys.ts
@@ -15,6 +15,17 @@ export function createSvelteSys(getSnapshot: (fileName: string) => DocumentSnaps
             const snapshot = getSnapshot(path);
             return snapshot.getText(0, snapshot.getLength());
         },
+        readDirectory(path, extensions, exclude, include, depth) {
+            const extensionsWithSvelte = (extensions ?? []).concat('.svelte');
+
+            return ts.sys.readDirectory(
+                path,
+                extensionsWithSvelte,
+                exclude,
+                include,
+                depth
+            );
+        }
     };
 
     if (ts.sys.realpath) {


### PR DESCRIPTION
![圖片](https://user-images.githubusercontent.com/36730922/84857373-81a95880-b09b-11ea-803b-7723b2162e7d.png)
close #195 
Basically it is just telling ts language service to also looks for `.svelte` file