### PR TITLE
Fix error when no content is in the script

### DIFF
--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -132,11 +132,17 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
             character: e.start?.column ?? 0,
         };
         const end: Position = e.end ? { line: e.end.line - 1, character: e.end.column } : start;
-        parserError = {
-            range: { start, end },
-            message: e.message,
-            code: -1,
-        };
+
+        // Suppress parse error on empty script.
+        parserError =
+            document.scriptInfo?.content === ''
+                ? null
+                : {
+                      range: { start, end },
+                      message: e.message,
+                      code: -1,
+                  };
+
         // fall back to extracted script, if any
         text = document.scriptInfo ? document.scriptInfo.content : '';
     }

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -133,15 +133,11 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
         };
         const end: Position = e.end ? { line: e.end.line - 1, character: e.end.column } : start;
 
-        // Suppress parse error on empty script.
-        parserError =
-            document.scriptInfo?.content === ''
-                ? null
-                : {
-                      range: { start, end },
-                      message: e.message,
-                      code: -1,
-                  };
+        parserError = {
+            range: { start, end },
+            message: e.message,
+            code: -1,
+        };
 
         // fall back to extracted script, if any
         text = document.scriptInfo ? document.scriptInfo.content : '';

--- a/packages/svelte2tsx/src/htmlxparser.ts
+++ b/packages/svelte2tsx/src/htmlxparser.ts
@@ -65,18 +65,23 @@ export function findVerbatimElements(htmlx: string) {
                 start: el.sourceCodeLocation.startOffset,
                 end: el.sourceCodeLocation.endOffset,
                 type: el.nodeName[0].toUpperCase() + el.nodeName.substr(1),
-                attributes: !el.attrs
-                    ? []
-                    : el.attrs.map((a) => parseValue(a)),
-                content: !content
-                    ? null
-                    : {
-                        type: 'Text',
-                        start: content.sourceCodeLocation.startOffset,
-                        end: content.sourceCodeLocation.endOffset,
-                        value: content.value,
-                        raw: content.value,
-                    },
+                attributes: !el.attrs ? [] : el.attrs.map((a) => parseValue(a)),
+                content:
+                    content === null
+                        ? {
+                              type: 'Text',
+                              start: el.sourceCodeLocation.startTag.endCol,
+                              end: el.sourceCodeLocation.endTag.startCol,
+                              value: '',
+                              raw: '',
+                          }
+                        : {
+                              type: 'Text',
+                              start: content.sourceCodeLocation.startOffset,
+                              end: content.sourceCodeLocation.endOffset,
+                              value: content.value,
+                              raw: content.value,
+                          },
             });
         }
     });

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/empty-source/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/empty-source/expected.jsx
@@ -1,0 +1,1 @@
+<><script></script></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/empty-source/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/empty-source/input.svelte
@@ -1,0 +1,1 @@
+<script></script>


### PR DESCRIPTION
Close #197 
When a parse error is caught, check if script is empty, and if so don't display the error.