### PR TITLE
Svelte components bind this

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx.ts
@@ -167,6 +167,8 @@ export function convertHtmlxToJsx(
                     return getThisTypeForComponent(node);
                 case 'Element':
                     return 'HTMLElement';
+                case 'Body':
+                    return 'HTMLBodyElement';
                 default:
                     break;
             }
@@ -186,7 +188,7 @@ export function convertHtmlxToJsx(
             return;
         }
 
-        const supportsBindThis = ['InlineComponent', 'Element'];
+        const supportsBindThis = ['InlineComponent', 'Element', 'Body'];
 
         //bind this
         if (attr.name == 'this' && supportsBindThis.includes(el.type)) {

--- a/packages/svelte2tsx/src/htmlxtojsx.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx.ts
@@ -155,7 +155,7 @@ export function convertHtmlxToJsx(
 
     const handleBinding = (attr: Node, el: Node) => {
         const getThisTypeForComponent = (node: Node) => {
-            if (node.name === 'svelte:component') {
+            if (node.name === 'svelte:component' || node.name === 'svelte:self') {
                 return '__sveltets_componentType()';
             } else {
                 return node.name;

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -34,6 +34,7 @@ type SvelteAnimation<U extends any[]> = (node: Element, move: { from: DOMRect, t
 type SvelteAllProps = {	[index: string]: any }
 type SvelteRestProps = { [index: string]: any }
 type SvelteStore<T> =  { subscribe: (run: (value:T) => any, invalidate?: any) => any }
+type SvelteComponent = import('*.svelte').default
 
 declare var process: NodeJS.Process & { browser: boolean }
 
@@ -50,3 +51,4 @@ declare function __sveltets_partial_with_any<T>(obj: T): Partial<T> & SvelteAllP
 declare function __sveltets_with_any<T>(obj: T): T & SvelteAllProps
 declare function __sveltets_store_get<T=any>(store: SvelteStore<T>): T
 declare function __sveltets_any(dummy: any): any;
+declare function __sveltets_componentType(): SvelteComponent

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-body/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-body/expected.jsx
@@ -1,0 +1,1 @@
+<><sveltebody {...__sveltets_ensureType(HTMLBodyElement, element)} /></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-body/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-body/input.svelte
@@ -1,0 +1,1 @@
+<svelte:body bind:this={element} />

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-component/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-component/expected.jsx
@@ -1,0 +1,1 @@
+<><sveltecomponent this={A} {...__sveltets_ensureType(__sveltets_componentType(), element)} /></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-component/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-component/input.svelte
@@ -1,0 +1,1 @@
+<svelte:component this={A} bind:this={element} />

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-self/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-self/expected.jsx
@@ -1,0 +1,3 @@
+<>{() => {if (false){<>
+    <svelteself {...__sveltets_ensureType(__sveltets_componentType(), element)} />
+</>}}}</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-self/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-self/input.svelte
@@ -1,0 +1,3 @@
+{#if false}
+    <svelte:self bind:this={element} />
+{/if}


### PR DESCRIPTION
close #192 

I use this as the base type of svelte component:
```ts
type SvelteComponent = import('*.svelte').default
```
so that any `*.svelte` ambient type declaration can be merged with it

As for `svelte:self`. the current `__sveltets_ensureType` won't show any error to different component types anyway. so I just make it check with `SvelteComponent` as well.