### PR TITLE
Support for Yarn 2 (Adding language server path option)

### DIFF
--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -82,6 +82,11 @@ Path to the node executable you would like to use to run the language server.
 This is useful when you depend on native modules such as node-sass as without
 this they will run in the context of vscode, meaning v8 version mismatch is likely.
 
+##### `svelte.language-server.ls-path`
+
+Path to the langauge server file (either a relative path from the workspace root or an absolute path).
+Can be used to use a custom variant of the language server.
+
 ##### `svelte.language-server.port`
 
 At which port to spawn the language server.

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -51,6 +51,11 @@
                     "title": "Language Server Runtime",
                     "description": "Path to the node executable to use to spawn the language server"
                 },
+                "svelte.language-server.ls-path": {
+                    "type": "string",
+                    "title": "Language Server Path",
+                    "description": "Path to the langauge server file"
+                },
                 "svelte.language-server.port": {
                     "type": "number",
                     "title": "Language Server Port",

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -54,7 +54,7 @@
                 "svelte.language-server.ls-path": {
                     "type": "string",
                     "title": "Language Server Path",
-                    "description": "Path to the langauge server file"
+                    "description": "Path to the langauge server file (either a relative path from the workspace root or an absolute path). Can be used to use a custom variant of the language server."
                 },
                 "svelte.language-server.port": {
                     "type": "number",

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -34,9 +34,18 @@ namespace TagCloseRequest {
 export function activate(context: ExtensionContext) {
     const runtimeConfig = workspace.getConfiguration('svelte.language-server');
 
-    const lsPath = runtimeConfig.get<string>('ls-path');
-    const serverModule =
-        lsPath && lsPath != '' ? lsPath : require.resolve('svelte-language-server/bin/server.js');
+    const tempLsPath = runtimeConfig.get<string>('ls-path');
+    const lsPath = tempLsPath && tempLsPath.trim() != '' ? tempLsPath : undefined;
+
+    const { workspaceFolders } = workspace;
+    const workspaceRoots: string[] = workspaceFolders
+        ? workspaceFolders.map(({ uri }) => uri.fsPath)
+        : [];
+
+    const serverModule = require.resolve(lsPath || 'svelte-language-server/bin/server.js', {
+        paths: workspaceRoots,
+    });
+    console.log('Loading server from ', serverModule);
 
     const runExecArgv: string[] = [];
     let port = runtimeConfig.get<number>('port') ?? -1;

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -42,7 +42,7 @@ export function activate(context: ExtensionContext) {
     // Returns undefined if path is empty string
     // Return absolute path if not already
     const lsPath =
-        tempLsPath && tempLsPath.trim() != ''
+        tempLsPath && tempLsPath.trim() !== ''
             ? path.isAbsolute(tempLsPath)
                 ? tempLsPath
                 : path.join(rootPath as string, tempLsPath)

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -32,8 +32,11 @@ namespace TagCloseRequest {
 }
 
 export function activate(context: ExtensionContext) {
-    const serverModule = require.resolve('svelte-language-server/bin/server.js');
     const runtimeConfig = workspace.getConfiguration('svelte.language-server');
+
+    const lsPath = runtimeConfig.get<string>('ls-path');
+    const serverModule =
+        lsPath && lsPath != '' ? lsPath : require.resolve('svelte-language-server/bin/server.js');
 
     const runExecArgv: string[] = [];
     let port = runtimeConfig.get<number>('port') ?? -1;


### PR DESCRIPTION
For the extension to run in harmony with yarn 2, a `pnp`-fied version of the svelte language server needs to be used instead of the native one. In order to use this custom version of the language server, a config property had to be exposed through which we load the custom language server.

On a side note, I haven't really checked whether my changes work with the "normal" projects. If someone could test my changes that would be great!