### PR TITLE
(fix) rework svelte-check to not use lsp

### DIFF
--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -1,2 +1,3 @@
 export * from './server';
 export { offsetAt } from './lib/documents';
+export { SvelteCheck } from './svelte-check';

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -210,11 +210,6 @@ export function startServer(options?: LSOptions) {
         pluginHost.updateImports(fileRename),
     );
 
-    // This event is triggered by Svelte-Check:
-    connection.onRequest('$/getDiagnostics', async (params) => {
-        return await pluginHost.getDiagnostics({ uri: params.uri });
-    });
-
     connection.onRequest('$/getCompiledCode', async (uri: DocumentUri) => {
         const doc = docManager.documents.get(uri);
         if (!doc) return null;

--- a/packages/language-server/src/svelte-check.ts
+++ b/packages/language-server/src/svelte-check.ts
@@ -1,0 +1,46 @@
+import { Document, DocumentManager } from './lib/documents';
+import { LSConfigManager } from './ls-config';
+import { CSSPlugin, HTMLPlugin, PluginHost, SveltePlugin, TypeScriptPlugin } from './plugins';
+import { Diagnostic } from 'vscode-languageserver';
+import { Logger } from './logger';
+
+/**
+ * Small wrapper around PluginHost's Diagnostic Capabilities
+ * for svelte-check, without the overhead of the lsp.
+ */
+export class SvelteCheck {
+    private docManager = new DocumentManager(
+        (textDocument) => new Document(textDocument.uri, textDocument.text),
+    );
+    private configManager = new LSConfigManager();
+    private pluginHost = new PluginHost(this.docManager, this.configManager);
+
+    constructor(workspacePath: string) {
+        Logger.setLogErrorsOnly(true);
+        this.initialize(workspacePath);
+    }
+
+    private initialize(workspacePath: string) {
+        this.pluginHost.register(new SveltePlugin(this.configManager, {}));
+        this.pluginHost.register(new HTMLPlugin(this.docManager, this.configManager));
+        this.pluginHost.register(new CSSPlugin(this.docManager, this.configManager));
+        this.pluginHost.register(
+            new TypeScriptPlugin(this.docManager, this.configManager, workspacePath),
+        );
+    }
+
+    /**
+     * Gets diagnostics for a svelte file.
+     *
+     * @param params Text and Uri of a svelte file
+     */
+    async getDiagnostics(params: { text: string; uri: string }): Promise<Diagnostic[]> {
+        this.docManager.openDocument({
+            languageId: 'svelte',
+            text: params.text,
+            uri: params.uri,
+            version: 1,
+        });
+        return await this.pluginHost.getDiagnostics({ uri: params.uri });
+    }
+}

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -6,20 +6,8 @@ import * as fs from 'fs';
 import * as glob from 'glob';
 import * as argv from 'minimist';
 import * as path from 'path';
-import { Duplex } from 'stream';
-import { startServer } from 'svelte-language-server';
-import { createConnection } from 'vscode-languageserver';
-import {
-    createProtocolConnection,
-    Diagnostic,
-    DiagnosticSeverity,
-    DidOpenTextDocumentNotification,
-    InitializeParams,
-    InitializeRequest,
-    Logger,
-    StreamMessageReader,
-    StreamMessageWriter,
-} from 'vscode-languageserver-protocol';
+import { SvelteCheck } from 'svelte-language-server';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { HumanFriendlyWriter, MachineFriendlyWriter, Writer } from './writers';
 
@@ -32,58 +20,10 @@ type Result = {
     warningCount: number;
 };
 
-/* eslint-disable @typescript-eslint/no-empty-function */
-class NullLogger implements Logger {
-    error(_message: string): void {}
-    warn(_message: string): void {}
-    info(_message: string): void {}
-    log(_message: string): void {}
-}
-
-class TestStream extends Duplex {
-    _write(chunk: string, _encoding: string, done: () => void) {
-        this.emit('data', chunk);
-        done();
-    }
-
-    _read(_size: number) {}
-}
-/* eslint-enable @typescript-eslint/no-empty-function */
-
-async function prepareClientConnection(workspaceUri: string) {
-    const up = new TestStream();
-    const down = new TestStream();
-    const logger = new NullLogger();
-
-    const clientConnection = createProtocolConnection(
-        new StreamMessageReader(down),
-        new StreamMessageWriter(up),
-        logger,
-    );
-
-    const serverConnection = createConnection(
-        new StreamMessageReader(up),
-        new StreamMessageWriter(down),
-    );
-    startServer({ connection: serverConnection, logErrorsOnly: true });
-
-    clientConnection.listen();
-
-    await clientConnection.sendRequest(InitializeRequest.type, <InitializeParams>{
-        capabilities: {},
-        processId: 1,
-        rootUri: workspaceUri,
-        workspaceFolders: null,
-        initializationOptions: { config: {} },
-    });
-
-    return clientConnection;
-}
-
 async function getDiagnostics(workspaceUri: URI, writer: Writer): Promise<Result | null> {
     writer.start(workspaceUri.fsPath);
 
-    const clientConnection = await prepareClientConnection(workspaceUri.toString());
+    const svelteCheck = new SvelteCheck(workspaceUri.fsPath);
 
     const files = glob.sync('**/*.svelte', {
         cwd: workspaceUri.fsPath,
@@ -101,21 +41,13 @@ async function getDiagnostics(workspaceUri: URI, writer: Writer): Promise<Result
     for (const absFilePath of absFilePaths) {
         const text = fs.readFileSync(absFilePath, 'utf-8');
 
-        clientConnection.sendNotification(DidOpenTextDocumentNotification.type, {
-            textDocument: {
-                languageId: 'svelte',
-                uri: URI.file(absFilePath).toString(),
-                version: 1,
-                text,
-            },
-        });
-
         let res: Diagnostic[] = [];
 
         try {
-            res = (await clientConnection.sendRequest('$/getDiagnostics', {
+            res = await svelteCheck.getDiagnostics({
                 uri: URI.file(absFilePath).toString(),
-            })) as Diagnostic[];
+                text,
+            });
         } catch (err) {
             writer.failure(err);
             return null;


### PR DESCRIPTION
Added a small diagnostics-only-wrapper instead to svelte-language-server, which svelte-check uses. This removes the overhead of the lsp protocol and also removes the possibility of the connection getting closed due to unknown reasons.

Fixes a bug where svelte-check would abort after about 5 seconds for unknown reasons.