### PR TITLE
fix default compileroption overrides user types config

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -190,9 +190,11 @@ export function createLanguageService(
         const files = parsedConfig.fileNames;
 
         const sveltePkgInfo = getPackageInfo('svelte', workspacePath || process.cwd());
+        const types = (parsedConfig.options?.types ?? [])
+            .concat(resolve(sveltePkgInfo.path, 'types', 'runtime'));
         const compilerOptions: ts.CompilerOptions = {
-            types: [resolve(sveltePkgInfo.path, 'types', 'runtime')],
             ...parsedConfig.options,
+            types,
             ...forcedCompilerOptions,
         };
 


### PR DESCRIPTION
fix #205 

1. fix default `compilerOption` overrides user `types` config
2. add fallback workspace path to resolve svelte package from.
3. improve readability related to applying default `compilerOption`. Make it more clear the one passed into `ts.parseJsonConfigFileContent` take priority over user's config. 