### PR TITLE
(fix) add include when there's no js/ts config

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -217,7 +217,7 @@ export function createLanguageService(
             },
             // Necessary to not flood the initial files
             // with potentially completely unrelated .ts/.js files:
-            include: ['**/*.svelte'],
+            include: [],
         };
     }
 


### PR DESCRIPTION
To not flood the initial files with potentially completely unrelated .js/.ts files

#207 , #151

@jasonlyu123 as discussed.