### PR TITLE
(fix) fine-grained control over incomplete completions

### DIFF
--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -29,6 +29,7 @@ import {
     FileRename,
 } from './interfaces';
 import { Logger } from '../logger';
+import { regexLastIndexOf } from '../utils';
 
 enum ExecuteMode {
     None,
@@ -37,9 +38,14 @@ enum ExecuteMode {
 }
 
 export class PluginHost implements LSProvider, OnWatchFileChanges {
+    private filterIncompleteCompletions = false;
     private plugins: Plugin[] = [];
 
     constructor(private documentsManager: DocumentManager, private config: LSConfigManager) {}
+
+    initialize(dontFilterIncompleteCompletions: boolean) {
+        this.filterIncompleteCompletions = !dontFilterIncompleteCompletions;
+    }
 
     register(plugin: Plugin) {
         this.plugins.push(plugin);
@@ -87,14 +93,28 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
             )
         ).filter((completion) => completion != null);
 
-        const flattenedCompletions = flatten(completions.map((completion) => completion.items));
-        return CompletionList.create(
-            flattenedCompletions,
-            completions.reduce(
-                (incomplete, completion) => incomplete || completion.isIncomplete,
-                false as boolean,
-            ),
+        let flattenedCompletions = flatten(completions.map((completion) => completion.items));
+        const isIncomplete = completions.reduce(
+            (incomplete, completion) => incomplete || completion.isIncomplete,
+            false as boolean,
         );
+
+        // If the result is incomplete, we need to filter the results ourselves
+        // to throw out non-matching results. VSCode does filter client-side,
+        // but other IDEs might not.
+        if (isIncomplete && this.filterIncompleteCompletions) {
+            const offset = document.offsetAt(position);
+            // Assumption for performance reasons:
+            // Noone types import names longer than 20 characters and still expects perfect autocompletion.
+            const text = document.getText().substring(Math.max(0, offset - 20), offset);
+            const start = regexLastIndexOf(text, /[\W\s]/g) + 1;
+            const filterValue = text.substring(start).toLowerCase();
+            flattenedCompletions = flattenedCompletions.filter((comp) =>
+                comp.label.toLowerCase().includes(filterValue),
+            );
+        }
+
+        return CompletionList.create(flattenedCompletions, isIncomplete);
     }
 
     async resolveCompletion(

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -147,7 +147,8 @@ export class CSSPlugin
             [...(results ? results.items : []), ...emmetResults.items].map((completionItem) =>
                 mapCompletionItemToOriginal(cssDocument, completionItem),
             ),
-            true,
+            // Emmet completions change on every keystroke, so they are never complete
+            emmetResults.items.length > 0,
         );
     }
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -8,8 +8,13 @@ import {
     TextDocumentIdentifier,
     TextEdit,
 } from 'vscode-languageserver';
-import { Document, mapCompletionItemToOriginal, mapRangeToOriginal } from '../../../lib/documents';
-import { isNotNullOrUndefined, pathToUrl, regexLastIndexOf } from '../../../utils';
+import {
+    Document,
+    isInTag,
+    mapCompletionItemToOriginal,
+    mapRangeToOriginal,
+} from '../../../lib/documents';
+import { isNotNullOrUndefined, pathToUrl } from '../../../utils';
 import { AppCompletionItem, AppCompletionList, CompletionsProvider } from '../../interfaces';
 import { SvelteSnapshotFragment } from '../DocumentSnapshot';
 import { LSAndTSDocResolver } from '../LSAndTSDocResolver';
@@ -46,6 +51,10 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         position: Position,
         completionContext?: CompletionContext,
     ): Promise<AppCompletionList<CompletionEntryWithIdentifer> | null> {
+        if (isInTag(position, document.styleInfo)) {
+            return null;
+        }
+
         const { lang, tsDoc } = this.lsAndTsDocResovler.getLSAndTSDoc(document);
 
         const filePath = tsDoc.filePath;
@@ -79,7 +88,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         });
 
         if (!completions) {
-            return null;
+            return tsDoc.parserError ? CompletionList.create([], true) : null;
         }
 
         const completionItems = completions.entries
@@ -87,14 +96,6 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
                 this.toCompletionItem(fragment, comp, pathToUrl(tsDoc.filePath), position),
             )
             .filter(isNotNullOrUndefined)
-            .filter(
-                filterOurselvesIfError(
-                    !!tsDoc.parserError,
-                    document,
-                    position,
-                    completionContext?.triggerCharacter,
-                ),
-            )
             .map((comp) => mapCompletionItemToOriginal(fragment, comp));
 
         return CompletionList.create(completionItems, !!tsDoc.parserError);
@@ -314,29 +315,3 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
 }
 
 const beginOfDocumentRange = Range.create(Position.create(0, 0), Position.create(0, 0));
-
-/**
- * In case of a svelte2tsx parser error, we set the completion list to incomplete
- * so that recomputations are triggered.
- * In this case we need to handle filtering ourselves according to the lsp spec.
- */
-function filterOurselvesIfError(
-    hasError: boolean,
-    document: Document,
-    position: Position,
-    triggerCharacter: string | undefined,
-) {
-    if (!hasError || triggerCharacter) {
-        return () => true;
-    }
-
-    // Since we have no svelte2tsx output, we need to find the typed import name ourselves.
-    const offset = document.offsetAt(position);
-    // Assumption for performance reasons:
-    // Noone types import names longer than 20 characters and still expects perfect autocompletion.
-    const text = document.getText().substring(Math.max(0, offset - 20), offset);
-    const start = regexLastIndexOf(text, /[\W\s]/g) + 1;
-    const filterValue = text.substring(start).toLowerCase();
-    return (comp: AppCompletionItem<CompletionEntryWithIdentifer>) =>
-        comp.label.toLowerCase().includes(filterValue);
-}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -78,6 +78,7 @@ export function startServer(options?: LSOptions) {
             Logger.error('No workspace path set');
         }
 
+        pluginHost.initialize(!!evt.initializationOptions.dontFilterIncompleteCompletions);
         pluginHost.updateConfig(evt.initializationOptions?.config);
         pluginHost.register(
             (sveltePlugin = new SveltePlugin(
@@ -107,18 +108,20 @@ export function startServer(options?: LSOptions) {
                         '@',
                         '<',
 
-                        // For Emmet
+                        // Emmet
                         '>',
                         '*',
                         '#',
                         '$',
-                        ' ',
                         '+',
                         '^',
                         '(',
                         '[',
                         '@',
                         '-',
+                        // No whitespace because
+                        // it makes for weird/too many completions
+                        // of other completion providers
 
                         // Svelte
                         ':',

--- a/packages/language-server/test/utils.test.ts
+++ b/packages/language-server/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { isBeforeOrEqualToPosition } from '../src/utils';
+import { isBeforeOrEqualToPosition, regexLastIndexOf } from '../src/utils';
 import { Position } from 'vscode-languageserver';
 import * as assert from 'assert';
 
@@ -27,6 +27,20 @@ describe('utils', () => {
         it('is after position (line lower, character higher)', () => {
             const result = isBeforeOrEqualToPosition(Position.create(1, 1), Position.create(2, 0));
             assert.equal(result, false);
+        });
+    });
+
+    describe('#regexLastIndexOf', () => {
+        it('should work #1', () => {
+            assert.equal(regexLastIndexOf('1 2 3', /\s/g), 3);
+        });
+
+        it('should work #2', () => {
+            assert.equal(regexLastIndexOf('1_2:- 3', /\W/g), 5);
+        });
+
+        it('should work #3', () => {
+            assert.equal(regexLastIndexOf('<bla blubb={() => hello', /[\W\s]/g), 17);
         });
     });
 });

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -87,6 +87,7 @@ export function activate(context: ExtensionContext) {
         initializationOptions: {
             config: workspace.getConfiguration('svelte.plugin'),
             prettierConfig: workspace.getConfiguration('prettier'),
+            dontFilterIncompleteCompletions: true, // VSCode filters client side and is smarter at it than us
         },
     };
 


### PR DESCRIPTION
- html/css: only set to incomplete if there are emmet results
- no more white space trigger, causes too many problems/unnecessary completion triggers
- filter all completions in the language server if not set otherwise. VSCode will filter client side so it's turned off for it.

Fixes #217