### PR TITLE
(fix) override react's JSX typings

### DIFF
--- a/packages/language-server/public/sink.d.ts
+++ b/packages/language-server/public/sink.d.ts
@@ -1,0 +1,1 @@
+declare module 'react' {}

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -181,6 +181,17 @@ export function createLanguageService(
             );
         }
 
+        configJson.compilerOptions = configJson.compilerOptions || {};
+        // Reroute react paths to a sink with no typings to prevent conflicts between the
+        // svelte2tsx JSX typings and react's JSX typings.
+        // This may happen if a node module has (in)directly installed/imported react's types.
+        if (!configJson.compilerOptions.paths?.react) {
+            configJson.paths = configJson.paths || {};
+            configJson.paths.react = [
+                ts.sys.resolvePath(resolve(__dirname, '../../../../public/sink.d.ts')),
+            ];
+        }
+
         const parsedConfig = ts.parseJsonConfigFileContent(
             configJson,
             ts.sys,
@@ -194,8 +205,9 @@ export function createLanguageService(
         const files = parsedConfig.fileNames;
 
         const sveltePkgInfo = getPackageInfo('svelte', workspacePath || process.cwd());
-        const types = (parsedConfig.options?.types ?? [])
-            .concat(resolve(sveltePkgInfo.path, 'types', 'runtime'));
+        const types = (parsedConfig.options?.types ?? []).concat(
+            resolve(sveltePkgInfo.path, 'types', 'runtime'),
+        );
         const compilerOptions: ts.CompilerOptions = {
             ...parsedConfig.options,
             types,


### PR DESCRIPTION
Reroute react paths to a sink with no typings to prevent conflicts between the svelte2tsx JSX typings and react's JSX typings. This may happen if a node module has (in)directly installed/imported react's types.

#228