### PR TITLE
update all opened document diagnostics on save

### DIFF
--- a/packages/language-server/src/lib/DiagnosticsManager.ts
+++ b/packages/language-server/src/lib/DiagnosticsManager.ts
@@ -1,0 +1,27 @@
+import { IConnection, TextDocumentIdentifier, Diagnostic } from 'vscode-languageserver';
+import { DocumentManager, Document } from './documents';
+
+export type SendDiagnostics = IConnection['sendDiagnostics'];
+export type GetDiagnostics = (doc: TextDocumentIdentifier) => Thenable<Diagnostic[]>;
+
+export class DiagnosticsManager {
+    constructor(
+        private sendDiagnostics: SendDiagnostics,
+        private docManager: DocumentManager,
+        private getDiagnostics: GetDiagnostics
+    ) { }
+
+    updateAll() {
+        this.docManager.getAllOpenedByClient().forEach((doc) => {
+            this.update(doc[1]);
+        });
+    }
+
+    async update(document: Document) {
+        const diagnostics = await this.getDiagnostics({ uri: document.getURL() });
+        this.sendDiagnostics({
+            uri: document.getURL(),
+            diagnostics,
+        });
+    }
+}

--- a/packages/language-server/src/lib/documents/DocumentManager.ts
+++ b/packages/language-server/src/lib/documents/DocumentManager.ts
@@ -13,7 +13,7 @@ export type DocumentEvent = 'documentOpen' | 'documentChange' | 'documentClose';
  */
 export class DocumentManager {
     private emitter = new EventEmitter();
-    private openedByServer = new Set<string>();
+    private openedInClient = new Set<string>();
     public documents: Map<string, Document> = new Map();
     public locked = new Set<string>();
     public deleteCandidates = new Set<string>();
@@ -41,22 +41,18 @@ export class DocumentManager {
         this.locked.add(uri);
     }
 
-    markAsOpenedByServer(uri: string): void {
-        this.openedByServer.add(uri);
-    }
-
-    unmarkOpenedByServer(uri: string): void {
-        this.openedByServer.delete(uri);
+    markAsOpenedInClient(uri: string): void {
+        this.openedInClient.add(uri);
     }
 
     getAllOpenedByClient() {
         return Array.from(this.documents.entries())
-            .filter((doc) => !this.openedByServer.has(doc[0]));
+            .filter((doc) => this.openedInClient.has(doc[0]));
     }
 
     releaseDocument(uri: string): void {
         this.locked.delete(uri);
-        this.openedByServer.delete(uri);
+        this.openedInClient.delete(uri);
         if (this.deleteCandidates.has(uri)) {
             this.deleteCandidates.delete(uri);
             this.closeDocument(uri);
@@ -79,7 +75,7 @@ export class DocumentManager {
             this.deleteCandidates.add(uri);
         }
 
-        this.openedByServer.delete(uri);
+        this.openedInClient.delete(uri);
     }
 
     updateDocument(

--- a/packages/language-server/src/lib/documents/DocumentManager.ts
+++ b/packages/language-server/src/lib/documents/DocumentManager.ts
@@ -21,7 +21,6 @@ export class DocumentManager {
     constructor(private createDocument: (textDocument: TextDocumentItem) => Document) {}
 
     openDocument(textDocument: TextDocumentItem): Document {
-        console.log(textDocument.uri);
         let document: Document;
         if (this.documents.has(textDocument.uri)) {
             document = this.documents.get(textDocument.uri)!;

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -40,7 +40,6 @@ export class LSAndTSDocResolver {
             version: 0,
         });
         this.docManager.lockDocument(uri);
-        this.docManager.markAsOpenedByServer(uri);
         return document;
     };
 

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -40,6 +40,7 @@ export class LSAndTSDocResolver {
             version: 0,
         });
         this.docManager.lockDocument(uri);
+        this.docManager.markAsOpenedByServer(uri);
         return document;
     };
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -26,6 +26,7 @@ import _ from 'lodash';
 import { LSConfigManager } from './ls-config';
 import { urlToPath } from './utils';
 import { Logger } from './logger';
+import { DiagnosticsManager } from './lib/DiagnosticsManager';
 
 namespace TagCloseRequest {
     export const type: RequestType<
@@ -99,6 +100,9 @@ export function startServer(options?: LSOptions) {
                 textDocumentSync: {
                     openClose: true,
                     change: TextDocumentSyncKind.Incremental,
+                    save: {
+                        includeText: false
+                    },
                 },
                 hoverProvider: true,
                 completionProvider: {
@@ -162,6 +166,7 @@ export function startServer(options?: LSOptions) {
                 renameProvider: evt.capabilities.textDocument?.rename?.prepareSupport
                     ? { prepareProvider: true }
                     : true,
+
             },
         };
     });
@@ -175,7 +180,11 @@ export function startServer(options?: LSOptions) {
         pluginHost.updateConfig(settings.svelte?.plugin);
     });
 
-    connection.onDidOpenTextDocument((evt) => docManager.openDocument(evt.textDocument));
+    connection.onDidOpenTextDocument((evt) => {
+        docManager.openDocument(evt.textDocument);
+        docManager.unmarkOpenedByServer(evt.textDocument.uri);
+    });
+
     connection.onDidCloseTextDocument((evt) => docManager.closeDocument(evt.textDocument.uri));
     connection.onDidChangeTextDocument((evt) =>
         docManager.updateDocument(evt.textDocument, evt.contentChanges),
@@ -219,6 +228,13 @@ export function startServer(options?: LSOptions) {
 
         return pluginHost.resolveCompletion(data, completionItem);
     });
+
+    const diagnosticsManager = new DiagnosticsManager(
+        connection.sendDiagnostics,
+        docManager,
+        pluginHost.getDiagnostics.bind(pluginHost)
+    );
+
     connection.onDidChangeWatchedFiles((para) => {
         for (const change of para.changes) {
             const filename = urlToPath(change.uri);
@@ -226,17 +242,14 @@ export function startServer(options?: LSOptions) {
                 pluginHost.onWatchFileChanges(filename, change.type);
             }
         }
+
+        diagnosticsManager.updateAll();
     });
+    connection.onDidSaveTextDocument(() => diagnosticsManager.updateAll());
 
     docManager.on(
         'documentChange',
-        _.debounce(async (document: Document) => {
-            const diagnostics = await pluginHost.getDiagnostics({ uri: document.getURL() });
-            connection!.sendDiagnostics({
-                uri: document.getURL(),
-                diagnostics,
-            });
-        }, 500),
+        _.debounce(async (document: Document) => diagnosticsManager.update(document), 500),
     );
 
     // The language server protocol does not have a specific "did rename/move files" event,

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -182,7 +182,7 @@ export function startServer(options?: LSOptions) {
 
     connection.onDidOpenTextDocument((evt) => {
         docManager.openDocument(evt.textDocument);
-        docManager.unmarkOpenedByServer(evt.textDocument.uri);
+        docManager.markAsOpenedInClient(evt.textDocument.uri);
     });
 
     connection.onDidCloseTextDocument((evt) => docManager.closeDocument(evt.textDocument.uri));


### PR DESCRIPTION
related to #177 

update the diagnostics of all opened svelte files when a svelte file or js file is saved to disk. Mainly for typescript type errors.