### PR TITLE
(fix) svelte-preprocess name typo

### DIFF
--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -73,10 +73,10 @@ async function createParserErrorDiagnostic(error: any, document: Document) {
                 '\n\nIf you expect this syntax to work, here are some suggestions: ';
             if (isInScript) {
                 diagnostic.message +=
-                    '\nIf you use typescript with `svelte-preprocessor`, did you add `lang="typescript"` to your `script` tag? ';
+                    '\nIf you use typescript with `svelte-preprocess`, did you add `lang="typescript"` to your `script` tag? ';
             } else {
                 diagnostic.message +=
-                    '\nIf you use less/SCSS with `svelte-preprocessor`, did you add `lang="scss"`/`lang="less"` to you `style` tag? ' +
+                    '\nIf you use less/SCSS with `svelte-preprocess`, did you add `lang="scss"`/`lang="less"` to you `style` tag? ' +
                     scssNodeRuntimeHint;
             }
             diagnostic.message +=

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -197,7 +197,7 @@ describe('SveltePlugin#getDiagnostics', () => {
                 message:
                     'expected x to not be here' +
                     '\n\nIf you expect this syntax to work, here are some suggestions: ' +
-                    '\nIf you use typescript with `svelte-preprocessor`, did you add `lang="typescript"` to your `script` tag? ' +
+                    '\nIf you use typescript with `svelte-preprocess`, did you add `lang="typescript"` to your `script` tag? ' +
                     '\nDid you setup a `svelte.config.js`? ' +
                     '\nSee https://github.com/sveltejs/language-tools/tree/master/packages/svelte-vscode#using-with-preprocessors for more info.',
                 range: {


### PR DESCRIPTION
Just installed `v100` to give it a try and, first of all, congrats for the hark work put into this 🍾 🎉 ! 

However, I've noticed the diagnostic tip to add `lang="..."` to `style`/`script` tags is referring to a `svelte-preprocessor` which I believe is a typo. If not, feel free to close this pull request 😁 