### PR TITLE
(fix) Comma syntax in guard for If Block

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx.ts
@@ -445,11 +445,10 @@ export function convertHtmlxToJsx(
             return;
         }
         // {#if expr} ->
-        // {() => { if (expr) { <>
+        // {() => { if (expr){ <>
         str.overwrite(ifBlock.start, ifBlock.expression.start, '{() => {if (');
         const end = htmlx.indexOf('}', ifBlock.expression.end);
-        str.appendLeft(ifBlock.expression.end, ')');
-        str.overwrite(end, end + 1, '{<>');
+        str.overwrite(ifBlock.expression.end, end + 1, '){<>');
 
         // {/if} -> </>}}}</>
         const endif = htmlx.lastIndexOf('{', ifBlock.end);

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/if-comma-block/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/if-comma-block/expected.jsx
@@ -1,0 +1,3 @@
+<>{() => {if (true, false){<>
+<h1>Hello {name}</h1>
+</>}}}</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/if-comma-block/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/if-comma-block/input.svelte
@@ -1,0 +1,3 @@
+{#if (true, false)}
+<h1>Hello {name}</h1>
+{/if}


### PR DESCRIPTION
Adding comma syntax in the guard for If blocks. #231. 

Original svelte code:
```
{#if (true, false)}
  content
{/if}
```

Gets converted to:
```
<>{() => {if (true, false){<>
content
</>}}}</>
```

Caveat: any guard with multiple parentheses for example:
```
{#if (((true, false)))}
  content
{/if}
```

Would get converted to:
```
<>{() => {if (true, false){<>
<h1>Hello {name}</h1>
</>}}}</>
```
