### PR TITLE
(fix) add compilerOptions.baseUrl if compilerOptions.paths is set

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -186,6 +186,7 @@ export function createLanguageService(
         // svelte2tsx JSX typings and react's JSX typings.
         // This may happen if a node module has (in)directly installed/imported react's types.
         if (!configJson.compilerOptions.paths?.react) {
+            configJson.compilerOptions.baseUrl = configJson.compilerOptions.baseUrl || '.';
             configJson.compilerOptions.paths = configJson.compilerOptions.paths || {};
             configJson.compilerOptions.paths.react = [
                 ts.sys.resolvePath(resolve(__dirname, '../../../../public/sink.d.ts')),

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -216,7 +216,7 @@ describe('CompletionProviderImpl', () => {
             item!,
         );
 
-        assert.strictEqual(detail, 'Auto import from ./definitions\nfunction blubb(): boolean');
+        assert.strictEqual(detail, 'Auto import from definitions\nfunction blubb(): boolean');
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),
@@ -249,7 +249,7 @@ describe('CompletionProviderImpl', () => {
             item!,
         );
 
-        assert.strictEqual(detail, 'Auto import from ./definitions\nfunction blubb(): boolean');
+        assert.strictEqual(detail, 'Auto import from definitions\nfunction blubb(): boolean');
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),
@@ -281,7 +281,7 @@ describe('CompletionProviderImpl', () => {
             item!,
         );
 
-        assert.strictEqual(detail, 'Auto import from ./definitions\nfunction blubb(): boolean');
+        assert.strictEqual(detail, 'Auto import from definitions\nfunction blubb(): boolean');
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),
@@ -327,7 +327,7 @@ describe('CompletionProviderImpl', () => {
             item!,
         );
 
-        assert.strictEqual(detail, 'Auto import from ./imported-file.svelte\nclass default');
+        assert.strictEqual(detail, 'Auto import from imported-file.svelte\nclass default');
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),
@@ -362,7 +362,7 @@ describe('CompletionProviderImpl', () => {
             item!,
         );
 
-        assert.strictEqual(detail, 'Auto import from ./imported-file.svelte\nclass default');
+        assert.strictEqual(detail, 'Auto import from imported-file.svelte\nclass default');
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),


### PR DESCRIPTION
This ensures that the `compilerOptions.paths` setting is "accepted" by the typescript compiler. Even though the path to the `react` override is an absolute path, it seems that if no `compilerOptions.baseUrl` is set, the compiler just ignores `compilerOptions.paths` altogether. 
 
Follow up to #260 and #234. Fixes #228.