### PR TITLE
(docs) add troubleshooting about conflicting react types

### DIFF
--- a/packages/language-server/public/sink.d.ts
+++ b/packages/language-server/public/sink.d.ts
@@ -1,1 +1,0 @@
-declare module 'react' {}

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -181,17 +181,6 @@ export function createLanguageService(
             );
         }
 
-        configJson.compilerOptions = configJson.compilerOptions || {};
-        // Reroute react paths to a sink with no typings to prevent conflicts between the
-        // svelte2tsx JSX typings and react's JSX typings.
-        // This may happen if a node module has (in)directly installed/imported react's types.
-        if (!configJson.compilerOptions.paths?.react) {
-            configJson.compilerOptions.paths = configJson.compilerOptions.paths || {};
-            configJson.compilerOptions.paths.react = [
-                ts.sys.resolvePath(resolve(__dirname, '../../../../public/sink.d.ts')),
-            ];
-        }
-
         const parsedConfig = ts.parseJsonConfigFileContent(
             configJson,
             ts.sys,

--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -80,7 +80,7 @@ It's also necessary to add a `type="text/language-name"` or `lang="language-name
 
 This may be due to some library you are using having installed typings for `react`. These are picked up by the TypeScript compiler. Because we internally transform svelte to jsx, there is a clash and said error occurs.
 
-To fix this, do the following:
+The underlying [issue in TypeScript](https://github.com/microsoft/TypeScript/issues/18588) is yet to be fixed but in the meantime, one way to work around it as follows:
 
 1. Add a `sink.d.ts` with content `declare module 'react' {}`
 2. Go to your `tsconfig.json`

--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -80,6 +80,8 @@ It's also necessary to add a `type="text/language-name"` or `lang="language-name
 
 This may be due to some library you are using having installed typings for `react`. These are picked up by the TypeScript compiler. Because we internally transform svelte to jsx, there is a clash and said error occurs.
 
+![image](https://user-images.githubusercontent.com/374638/85633868-72697280-b67a-11ea-8f8c-7fe2b4702339.png)
+
 The underlying [issue in TypeScript](https://github.com/microsoft/TypeScript/issues/18588) is yet to be fixed but in the meantime, one way to work around it as follows:
 
 1. Add a `sink.d.ts` with content `declare module 'react' {}`

--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -74,6 +74,40 @@ It's also necessary to add a `type="text/language-name"` or `lang="language-name
 </style>
 ```
 
+### Troubleshooting
+
+#### I get weird type errors on my html tags
+
+This may be due to some library you are using having installed typings for `react`. These are picked up by the TypeScript compiler. Because we internally transform svelte to jsx, there is a clash and said error occurs.
+
+To fix this, do the following:
+
+1. Add a `sink.d.ts` with content `declare module 'react' {}`
+2. Go to your `tsconfig.json`
+3. If you do not have such a setting already, enhance `compilerOptions` with `"baseUrl": "."`
+4. Enhance `compilerOptions` with `"paths": { "react": ["<path to your sink.d.ts, relative to the baseUrl>"] }`
+
+`tsconfig.json`
+
+```json
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "react": ["sink.d.ts"]
+        }
+    }
+}
+```
+
+`sink.d.ts:`
+
+```ts
+declare module 'react';
+```
+
+For more info see [this issue](https://github.com/sveltejs/language-tools/issues/228)
+
 ### Settings
 
 ##### `svelte.language-server.runtime`

--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -82,7 +82,7 @@ This may be due to some library you are using having installed typings for `reac
 
 ![image](https://user-images.githubusercontent.com/374638/85633868-72697280-b67a-11ea-8f8c-7fe2b4702339.png)
 
-The underlying [issue in TypeScript](https://github.com/microsoft/TypeScript/issues/18588) is yet to be fixed but in the meantime, one way to work around it as follows:
+The underlying [issue in TypeScript](https://github.com/microsoft/TypeScript/issues/18588) is yet to be fixed but in the meantime, one way to work around it is as follows:
 
 1. Add a `sink.d.ts` with content `declare module 'react' {}`
 2. Go to your `tsconfig.json`


### PR DESCRIPTION
#228

Cannot be fixed in the language-server because it would require us to add a baseUrl to the tsconfig.json, which would break every bundler setup which does not know about this.

@joelmukuthu I'm really sorry this cannot be fixed 😞 Could you read the docs change and tell me if it is understandable?