### PR TITLE
(breaking) adjust svelte.config.js interface

### DIFF
--- a/packages/language-server/src/plugins/svelte/SvelteDocument.ts
+++ b/packages/language-server/src/plugins/svelte/SvelteDocument.ts
@@ -19,7 +19,8 @@ import { CompileOptions } from 'svelte/types/compiler/interfaces';
 
 export type SvelteCompileResult = ReturnType<typeof compile>;
 
-export interface SvelteConfig extends CompileOptions {
+export interface SvelteConfig {
+    compilerOptions?: CompileOptions;
     preprocess?: PreprocessorGroup;
     loadConfigError?: any;
 }
@@ -71,24 +72,15 @@ export class SvelteDocument {
 
     async getCompiled(): Promise<SvelteCompileResult> {
         if (!this.compileResult) {
-            this.compileResult = await this.getCompiledWith(this.getCompileOptions());
+            this.compileResult = await this.getCompiledWith(this.config.compilerOptions);
         }
 
         return this.compileResult;
     }
 
-    async getCompiledWith(options: CompileOptions): Promise<SvelteCompileResult> {
+    async getCompiledWith(options: CompileOptions = {}): Promise<SvelteCompileResult> {
         const svelte = importSvelte(this.getFilePath());
         return svelte.compile((await this.getTranspiled()).getText(), options);
-    }
-
-    private getCompileOptions() {
-        const config = { ...this.config };
-        // svelte compiler throws an error if we don't do this
-        delete config.preprocess;
-        delete config.loadConfigError;
-
-        return config;
     }
 
     /**

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -149,24 +149,30 @@ export class SveltePlugin
         Logger.log('Trying to load config for', document.getFilePath());
         try {
             const result = await this.cosmiConfigExplorer.search(document.getFilePath() || '');
-            const config = result?.config ?? this.useFallbackPreprocessor(document, false);
+            const config: SvelteConfig =
+                result?.config ?? this.useFallbackPreprocessor(document, false);
             if (result) {
                 Logger.log('Found config at ', result.filepath);
             }
-            return { ...DEFAULT_OPTIONS, ...config, ...NO_GENERATE };
+            return {
+                ...config,
+                compilerOptions: { ...DEFAULT_OPTIONS, ...config.compilerOptions, ...NO_GENERATE },
+            };
         } catch (err) {
             Logger.error('Error while loading config');
             Logger.error(err);
             return {
-                ...DEFAULT_OPTIONS,
                 ...this.useFallbackPreprocessor(document, true),
-                ...NO_GENERATE,
+                compilerOptions: {
+                    ...DEFAULT_OPTIONS,
+                    ...NO_GENERATE,
+                },
                 loadConfigError: err,
             };
         }
     }
 
-    private useFallbackPreprocessor(document: Document, foundConfig: boolean) {
+    private useFallbackPreprocessor(document: Document, foundConfig: boolean): SvelteConfig {
         const needsConfig =
             document.styleInfo?.attributes.lang ||
             document.styleInfo?.attributes.type ||


### PR DESCRIPTION
### BREAKING CHANGE

If you want to pass svelte compiler options to the svelte language server (which you probably never will/need to do), you now need to pass them inside `compilerOptions`. Note that `preprocess` stays where it was before.

Before:

`svelte.config.js`:
```
module.exports = {
   dev: true,
   preprocess: ...
};
```

After:

`svelte.config.js`:
```
module.exports = {
   compilerOptions: {
      dev: true
   },
   preprocess: ...
};
```

cc @dominikg 