### PR TITLE
(feat) add documentation strings to hover response

### DIFF
--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -107,10 +107,19 @@ export class TypeScriptPlugin
         if (!info) {
             return null;
         }
-        const contents = ts.displayPartsToString(info.displayParts);
+        const declaration = ts.displayPartsToString(info.displayParts);
+        const documentation = typeof info.documentation === 'string'
+            ? info.documentation
+            : ts.displayPartsToString(info.documentation);
+
+        // https://microsoft.github.io/language-server-protocol/specification#textDocument_hover
+        const contents = ['```typescript', declaration, '```']
+            .concat(documentation ? ['---', documentation] : [])
+            .join('\n');
+
         return mapHoverToParent(fragment, {
             range: convertRange(fragment, info.textSpan),
-            contents: { language: 'ts', value: contents },
+            contents,
         });
     }
 

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -104,22 +104,37 @@ describe('TypescriptPlugin', () => {
         ]);
     });
 
-    it('provides hover info', async () => {
+    it('provides basic hover info when no docstring exists', async () => {
         const { plugin, document } = setup('hoverinfo.svelte');
 
-        assert.deepStrictEqual(await plugin.doHover(document, Position.create(0, 14)), <Hover>{
-            contents: {
-                language: 'ts',
-                value: 'const a: true',
-            },
+        assert.deepStrictEqual(await plugin.doHover(document, Position.create(4, 10)), <Hover>{
+            contents: '```typescript\nconst withoutDocs: true\n```',
             range: {
                 start: {
-                    character: 14,
-                    line: 0,
+                    character: 10,
+                    line: 4,
                 },
                 end: {
-                    character: 15,
-                    line: 0,
+                    character: 21,
+                    line: 4,
+                },
+            },
+        });
+    });
+
+    it('provides formatted hover info when a docstring exists', async () => {
+        const { plugin, document } = setup('hoverinfo.svelte');
+
+        assert.deepStrictEqual(await plugin.doHover(document, Position.create(2, 10)), <Hover>{
+            contents: '```typescript\nconst withDocs: true\n```\n---\nDocumentation string',
+            range: {
+                start: {
+                    character: 10,
+                    line: 2,
+                },
+                end: {
+                    character: 18,
+                    line: 2,
                 },
             },
         });

--- a/packages/language-server/test/plugins/typescript/testfiles/hoverinfo.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/hoverinfo.svelte
@@ -1,1 +1,6 @@
-<script>const a = true</script>
+<script>
+    /** Documentation string */
+    const withDocs = true
+
+    const withoutDocs = true
+</script>


### PR DESCRIPTION
Fixes https://github.com/sveltejs/language-tools/issues/281
Partially fixes https://github.com/sveltejs/svelte/issues/5102 and https://github.com/sveltejs/language-tools/issues/280 (still need to produce a docstring for default exports)

For a snippet:

```typescript
<script>
    /** Documentation string for a */
    const a = true
</script>
```

Improves the hover contents from:

```typescript
const a: true
```

To:

```
```typescript\nconst a: true\n```\n---\nDocumentation string for a
```

Which should print out more or less like this:

> ```typescript
> const a: true
> ```
> ---
> Documentation string for a

If there is no documentation, the result is the same as before (for example, just `const a: true` in a Markdown TypeScript snippet).

Following the documentation [here](https://microsoft.github.io/language-server-protocol/specification#textDocument_hover).