### PR TITLE
(svelte2tsx) Allow documenting components with a tagged HTML comment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,35 @@ It's also necessary to add a `type="text/language-name"` or `lang="language-name
 </style>
 ```
 
+## Documenting components
+
+To add documentation on a Svelte component that will show up as a docstring in
+LSP-compatible editors, you can use an HTML comment with the `@component` tag:
+
+```html
+<!--
+ @component
+ Here's some documentation for this component. It will show up on hover for
+ JavaScript/TypeScript projects using a LSP-compatible editor such as VSCode or
+ Vim/Neovim with coc.nvim.
+
+ - You can use markdown here.
+ - You can use code blocks here.
+ - JSDoc/TSDoc will be respected by LSP-compatible editors.
+ - Indentation will be respected as much as possible.
+-->
+
+<!-- @component You can use a single line, too -->
+
+<!-- @component But only the last documentation comment will be used -->
+
+<main>
+  <h1>
+    Hello world
+  </h1>
+</main>
+```
+
 ## Troubleshooting / FAQ
 
 ### Using TypeScript? See [this section](./preprocessors/typescript.md#troubleshooting--faq)

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -112,7 +112,13 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
     let text = document.getText();
 
     try {
-        const tsx = svelte2tsx(text, { strictMode: options.strictMode });
+        const tsx = svelte2tsx(
+            text,
+            {
+                strictMode: options.strictMode,
+                filename: document.getFilePath() ?? undefined,
+            }
+        );
         text = tsx.code;
         tsxMap = tsx.map;
         if (tsxMap) {

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -327,7 +327,7 @@ describe('CompletionProviderImpl', () => {
             item!,
         );
 
-        assert.strictEqual(detail, 'Auto import from ./imported-file.svelte\nclass default');
+        assert.strictEqual(detail, 'Auto import from ./imported-file.svelte\nclass ImportedFile');
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),
@@ -362,7 +362,7 @@ describe('CompletionProviderImpl', () => {
             item!,
         );
 
-        assert.strictEqual(detail, 'Auto import from ./imported-file.svelte\nclass default');
+        assert.strictEqual(detail, 'Auto import from ./imported-file.svelte\nclass ImportedFile');
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -57,5 +57,8 @@
         "LICENSE",
         "svelte-jsx.d.ts",
         "svelte-shims.d.ts"
-    ]
+    ],
+    "dependencies": {
+        "pascal-case": "^3.1.1"
+    }
 }

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -59,6 +59,7 @@
         "svelte-shims.d.ts"
     ],
     "dependencies": {
+        "dedent-js": "^1.0.1",
         "pascal-case": "^3.1.1"
     }
 }

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -1,3 +1,4 @@
+import { pascalCase } from 'pascal-case';
 import MagicString from 'magic-string';
 import path from 'path';
 import { parseHtmlx } from './htmlxparser';
@@ -787,8 +788,25 @@ function addComponentExport(
     str.append(statement);
 }
 
-function classNameFromFilename(filename: string): string {
-    return path.parse(filename).name;
+/**
+ * Returns a Svelte-compatible component name from a filename. Svelte
+ * components must use capitalized tags, so we try to transform the filename.
+ *
+ * Works with most filename styles except for filenames with multiple
+ * extensions, such as my-component.extension.svelte, which will result in
+ * MyComponentExtension.
+ *
+ * https://svelte.dev/docs#Tags
+ */
+export function classNameFromFilename(filename: string): string | undefined {
+    try {
+        const withoutExtension = path.parse(filename).name;
+        const inPascalCase = pascalCase(withoutExtension);
+        return inPascalCase;
+    } catch (error) {
+        console.warn(`Failed to create a name for the component class from filename ${filename}`);
+        return undefined;
+    }
 }
 
 function isTsFile(scriptTag: Node | undefined, moduleScriptTag: Node | undefined) {

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -769,7 +769,7 @@ function addComponentExport(
     strictMode: boolean,
     isTsFile: boolean,
     /** A named export allows for TSDoc-compatible docstrings */
-    name?: string,
+    className?: string,
 ) {
     const propDef =
         // Omit partial-wrapper only if both strict mode and ts file, because
@@ -782,9 +782,13 @@ function addComponentExport(
             : `__sveltets_partial${uses$$propsOr$$restProps ? '_with_any' : ''}(render().props)`;
 
     // eslint-disable-next-line max-len
-    const statement = `\n\nexport default class ${name ? `${name} ` : ''}{\n    $$prop_def = ${propDef}\n    $$slot_def = render().slots\n}`;
+    const statement = `\n\nexport default class ${className ? `${className} ` : ''}{\n    $$prop_def = ${propDef}\n    $$slot_def = render().slots\n}`;
 
     str.append(statement);
+}
+
+function classNameFromFilename(filename: string): string {
+    return path.parse(filename).name;
 }
 
 function isTsFile(scriptTag: Node | undefined, moduleScriptTag: Node | undefined) {
@@ -952,14 +956,14 @@ export function svelte2tsx(svelte: string, options?: { filename?: string; strict
         processModuleScriptTag(str, moduleScriptTag);
     }
 
-    const name = options?.filename && path.parse(options.filename).name;
+    const className = options?.filename && classNameFromFilename(options?.filename);
 
     addComponentExport(
         str,
         uses$$props || uses$$restProps,
         !!options?.strictMode,
         isTsFile(scriptTag, moduleScriptTag),
-        name,
+        className,
     );
 
     return {

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -836,16 +836,12 @@ function addComponentExport(
  * Returns a Svelte-compatible component name from a filename. Svelte
  * components must use capitalized tags, so we try to transform the filename.
  *
- * Works with most filename styles except for filenames with multiple
- * extensions, such as my-component.extension.svelte, which will result in
- * MyComponentExtension.
- *
  * https://svelte.dev/docs#Tags
  */
 export function classNameFromFilename(filename: string): string | undefined {
     try {
-        const withoutExtension = path.parse(filename).name;
-        const inPascalCase = pascalCase(withoutExtension);
+        const withoutExtensions = path.parse(filename).name?.split('.')[0];
+        const inPascalCase = pascalCase(withoutExtensions);
         return inPascalCase;
     } catch (error) {
         console.warn(`Failed to create a name for the component class from filename ${filename}`);

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent-js';
 import { pascalCase } from 'pascal-case';
 import MagicString from 'magic-string';
 import path from 'path';
@@ -792,12 +793,15 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
 
 function formatComponentDocumentation(contents?: string | null) {
     if (!contents) return '';
-
     if (!contents.includes('\n')) {
         return `/** ${contents} */\n`;
     }
 
-    const lines = contents.split('\n').map(line => ` *${line ? ` ${line}` : ''}`).join('\n');
+    const lines = dedent(contents)
+        .split('\n')
+        .map(line => ` *${line ? ` ${line}` : ''}`)
+        .join('\n');
+
     return `/**\n${lines}\n */\n`;
 }
 

--- a/packages/svelte2tsx/test/svelte2tsx/index.js
+++ b/packages/svelte2tsx/test/svelte2tsx/index.js
@@ -19,7 +19,7 @@ describe('svelte2tsx', () => {
             const input = fs.readFileSync(`${__dirname}/samples/${dir}/input.svelte`, 'utf-8').replace(/\s+$/, '').replace(/\r\n/g, "\n");
             const expectedOutput = fs.readFileSync(`${__dirname}/samples/${dir}/expected.tsx`, 'utf-8').replace(/\s+$/, '').replace(/\r\n/g, "\n");
 
-        const { map, code} = svelte2tsx(input, {strictMode: dir.endsWith('strictMode')});
+            const { map, code} = svelte2tsx(input, {strictMode: dir.endsWith('strictMode'), filename: 'input.svelte'});
             assert.equal(code, expectedOutput);
 		});
 	});

--- a/packages/svelte2tsx/test/svelte2tsx/samples/array-binding-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/array-binding-export/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {a: a , b: b , c: c}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/array-binding-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/array-binding-export/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {a: a , b: b , c: c}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
@@ -3,7 +3,7 @@ __sveltets_store_get(var);
 <></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
@@ -3,7 +3,7 @@ __sveltets_store_get(var);
 <></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
@@ -3,7 +3,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
@@ -3,7 +3,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
@@ -13,7 +13,7 @@ function render() {
 </>})}}</>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
@@ -13,7 +13,7 @@ function render() {
 </>})}}</>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
@@ -2,7 +2,7 @@
 <><input id="dom-input" type="radio" {...__sveltets_any(__sveltets_store_get(compile_options).generate)} value="dom"/></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
@@ -2,7 +2,7 @@
 <><input id="dom-input" type="radio" {...__sveltets_any(__sveltets_store_get(compile_options).generate)} value="dom"/></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expected.tsx
@@ -89,7 +89,7 @@
 </>}}}</>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expected.tsx
@@ -89,7 +89,7 @@
 </>}}}</>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
@@ -8,7 +8,7 @@
 </div></>
 return { props: {}, slots: {default: {a:b}} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
@@ -8,7 +8,7 @@
 </div></>
 return { props: {}, slots: {default: {a:b}} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
@@ -11,7 +11,7 @@
 </div></>
 return { props: {}, slots: {default: {a:b}, test: {c:d, e:e}} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
@@ -11,7 +11,7 @@
 </div></>
 return { props: {}, slots: {default: {a:b}, test: {c:d, e:e}} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
@@ -8,7 +8,7 @@
 </div></>
 return { props: {}, slots: {default: {a:b, b:b, c:"b", d:"__svelte_ts_string", e:b}} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
@@ -8,7 +8,7 @@
 </div></>
 return { props: {}, slots: {default: {a:b, b:b, c:"b", d:"__svelte_ts_string", e:b}} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expected.tsx
@@ -1,0 +1,11 @@
+<></>;function render() {
+<>
+
+<main>At least I am documented</main></>
+return { props: {}, slots: {} }}
+
+/** This component does nothing at all */
+export default class Input {
+    $$prop_def = __sveltets_partial(render().props)
+    $$slot_def = render().slots
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/input.svelte
@@ -1,0 +1,3 @@
+<!-- @component This component does nothing at all -->
+
+<main>At least I am documented</main>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expected.tsx
@@ -1,0 +1,23 @@
+<></>;function render() {
+<>
+
+<main>At least I am documented</main></>
+return { props: {}, slots: {} }}
+
+/**
+ * This component has indented multiline documentation:
+ *
+ * ```typescript
+ * type Type = 'type'
+ * ```
+ *
+ * An indented list:
+ *   - One item
+ *   - Two items
+ *
+ * The output should be indented properly!
+ */
+export default class Input {
+    $$prop_def = __sveltets_partial(render().props)
+    $$slot_def = render().slots
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/input.svelte
@@ -1,0 +1,16 @@
+<!--
+  @component
+  This component has indented multiline documentation:
+
+  ```typescript
+  type Type = 'type'
+  ```
+
+  An indented list:
+    - One item
+    - Two items
+
+  The output should be indented properly!
+-->
+
+<main>At least I am documented</main>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expected.tsx
@@ -1,0 +1,17 @@
+<></>;function render() {
+<>
+
+<main>At least I am documented</main></>
+return { props: {}, slots: {} }}
+
+/**
+ * This component has multiline documentation:
+ *
+ * ```typescript
+ * type Type = 'type'
+ * ```
+ */
+export default class Input {
+    $$prop_def = __sveltets_partial(render().props)
+    $$slot_def = render().slots
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/input.svelte
@@ -1,0 +1,10 @@
+<!--
+@component
+This component has multiline documentation:
+
+```typescript
+type Type = 'type'
+```
+-->
+
+<main>At least I am documented</main>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-arrow-function/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-arrow-function/expected.tsx
@@ -8,7 +8,7 @@
 <></>
 return { props: {f: f}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-arrow-function/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-arrow-function/expected.tsx
@@ -8,7 +8,7 @@
 <></>
 return { props: {f: f}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-const/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-const/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {name: name} as {name: string}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-const/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-const/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {name: name} as {name: string}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-has-type/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-has-type/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {a: a} as {a: A}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-has-type/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-has-type/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {a: a} as {a: A}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-interface/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-interface/expected.tsx
@@ -4,7 +4,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-interface/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-interface/expected.tsx
@@ -4,7 +4,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-js-strictMode/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-js-strictMode/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {a: a , b: b} as {a: number, b?: number | undefined}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-js-strictMode/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-js-strictMode/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {a: a , b: b} as {a: number, b?: number | undefined}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-list/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-list/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {name: name , name2: name2}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-list/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-list/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {name: name , name2: name2}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-references-local/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-references-local/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {name: name}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-references-local/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-references-local/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {name: name}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-ts-strictMode/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-ts-strictMode/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {a: a , b: b} as {a: number, b?: number | undefined}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = render().props
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-ts-strictMode/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-ts-strictMode/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {a: a , b: b} as {a: number, b?: number | undefined}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = render().props
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-with-default-multi/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-with-default-multi/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {name: name , world: world}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-with-default-multi/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-with-default-multi/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {name: name , world: world}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expected.tsx
@@ -7,7 +7,7 @@ function render() {
 </>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expected.tsx
@@ -7,7 +7,7 @@ function render() {
 </>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/imports/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/imports/expected.tsx
@@ -11,7 +11,7 @@ function render() {
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/imports/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/imports/expected.tsx
@@ -11,7 +11,7 @@ function render() {
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line/expected.tsx
@@ -3,7 +3,7 @@
 <><h1>hello {world}</h1></>
 return { props: {world: world}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line/expected.tsx
@@ -3,7 +3,7 @@
 <><h1>hello {world}</h1></>
 return { props: {world: world}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line2/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line2/expected.tsx
@@ -3,7 +3,7 @@
 <><h1>hello {world}</h1></>
 return { props: {world: world}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line2/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line2/expected.tsx
@@ -3,7 +3,7 @@
 <><h1>hello {world}</h1></>
 return { props: {world: world}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script/expected.tsx
@@ -10,7 +10,7 @@
 <h1>hello {world}</h1></>
 return { props: {world: world}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script/expected.tsx
@@ -10,7 +10,7 @@
 <h1>hello {world}</h1></>
 return { props: {world: world}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script2/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script2/expected.tsx
@@ -10,7 +10,7 @@
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script2/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script2/expected.tsx
@@ -10,7 +10,7 @@
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/multiple-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/multiple-export/expected.tsx
@@ -7,7 +7,7 @@
 <h1>{number1} + {number2} = {number1 + number2}</h1></>
 return { props: {number1: number1 , number2: number2} as {number1: number, number2: number}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/multiple-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/multiple-export/expected.tsx
@@ -7,7 +7,7 @@
 <h1>{number1} + {number2} = {number1 + number2}</h1></>
 return { props: {number1: number1 , number2: number2} as {number1: number, number2: number}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expected.tsx
@@ -24,7 +24,7 @@ const test4 = ({a,  b: { $top1: $top2 }}) => $top2 && __sveltets_store_get(top1)
 <></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expected.tsx
@@ -24,7 +24,7 @@ const test4 = ({a,  b: { $top1: $top2 }}) => $top2 && __sveltets_store_get(top1)
 <></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expected.tsx
@@ -24,7 +24,7 @@
 }}>Hi</h1></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expected.tsx
@@ -24,7 +24,7 @@
 }}>Hi</h1></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/object-binding-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/object-binding-export/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {rename: rename}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/object-binding-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/object-binding-export/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {rename: rename}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expected.tsx
@@ -8,7 +8,7 @@ let a: 1 | 2 = 1;
 <></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expected.tsx
@@ -8,7 +8,7 @@ let a: 1 | 2 = 1;
 <></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
@@ -9,7 +9,7 @@ $: a = __sveltets_invalidate(() => 5);
 <></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
@@ -9,7 +9,7 @@ $: a = __sveltets_invalidate(() => 5);
 <></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/renamed-exports/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/renamed-exports/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {name3: name , name4: name2}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/renamed-exports/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/renamed-exports/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {name3: name , name4: name2}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-and-module-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-and-module-script/expected.tsx
@@ -10,7 +10,7 @@
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-and-module-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-and-module-script/expected.tsx
@@ -10,7 +10,7 @@
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
@@ -14,7 +14,7 @@
 </sveltehead></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
@@ -14,7 +14,7 @@
 </sveltehead></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-on-bottom/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-on-bottom/expected.tsx
@@ -6,7 +6,7 @@
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-on-bottom/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-on-bottom/expected.tsx
@@ -6,7 +6,7 @@
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected.tsx
@@ -10,7 +10,7 @@
 <Style /></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected.tsx
@@ -10,7 +10,7 @@
 <Style /></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
@@ -8,7 +8,7 @@ let a = 'b';
 </>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
@@ -8,7 +8,7 @@ let a = 'b';
 </>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expected.tsx
@@ -2,7 +2,7 @@
 <><h1>hello</h1></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expected.tsx
@@ -2,7 +2,7 @@
 <><h1>hello</h1></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/single-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/single-export/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {name: name}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/single-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/single-export/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {name: name}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
@@ -2,7 +2,7 @@
 <><Me f={`${__sveltets_store_get(s)} `}/></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
@@ -2,7 +2,7 @@
 <><Me f={`${__sveltets_store_get(s)} `}/></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expected.tsx
@@ -5,7 +5,7 @@
 {true === true}</>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expected.tsx
@@ -5,7 +5,7 @@
 {true === true}</>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expected.tsx
@@ -2,7 +2,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expected.tsx
@@ -2,7 +2,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style/expected.tsx
@@ -2,7 +2,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style/expected.tsx
@@ -2,7 +2,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/typed-export-with-default/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/typed-export-with-default/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {name: name} as {name: string | number}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/typed-export-with-default/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/typed-export-with-default/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {name: name} as {name: string | number}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
@@ -6,7 +6,7 @@
 </>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
@@ -6,7 +6,7 @@
 </>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-ts-strictMode/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-ts-strictMode/expected.tsx
@@ -4,7 +4,7 @@
 <h1>{$$props['name']}</h1></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-ts-strictMode/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-ts-strictMode/expected.tsx
@@ -4,7 +4,7 @@
 <h1>{$$props['name']}</h1></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
@@ -2,7 +2,7 @@
 <><h1>{$$props['name']}</h1></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
@@ -2,7 +2,7 @@
 <><h1>{$$props['name']}</h1></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expected.tsx
@@ -6,7 +6,7 @@
 </>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expected.tsx
@@ -6,7 +6,7 @@
 </>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expected.tsx
@@ -2,7 +2,7 @@
 <><h1>{$$restProps['name']}</h1></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expected.tsx
@@ -2,7 +2,7 @@
 <><h1>{$$restProps['name']}</h1></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
@@ -3,7 +3,7 @@
 <button onclick={__sveltets_store_get(check) ? method1 : method2} >Bla</button></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
@@ -3,7 +3,7 @@
 <button onclick={__sveltets_store_get(check) ? method1 : method2} >Bla</button></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
@@ -33,7 +33,7 @@ function render() {
 <button onclick={() => count.set( __sveltets_store_get(count) | myvar)}>OR</button></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
@@ -33,7 +33,7 @@ function render() {
 <button onclick={() => count.set( __sveltets_store_get(count) | myvar)}>OR</button></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-exclamation-mark/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-exclamation-mark/expected.tsx
@@ -10,7 +10,7 @@ function render() {
 <button onclick={() => !__sveltets_store_get(count)}>add</button></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-exclamation-mark/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-exclamation-mark/expected.tsx
@@ -10,7 +10,7 @@ function render() {
 <button onclick={() => !__sveltets_store_get(count)}>add</button></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
@@ -12,7 +12,7 @@ function render() {
 <button onclick={() => count.set( __sveltets_store_get(count) - 1)}>subtract</button></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
@@ -12,7 +12,7 @@ function render() {
 <button onclick={() => count.set( __sveltets_store_get(count) - 1)}>subtract</button></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
@@ -4,7 +4,7 @@ b.set(__sveltets_store_get(b).concat(5));
 <h1 onclick={() => b.set(__sveltets_store_get(b).concat(5))}>{__sveltets_store_get(b)}</h1></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
@@ -4,7 +4,7 @@ b.set(__sveltets_store_get(b).concat(5));
 <h1 onclick={() => b.set(__sveltets_store_get(b).concat(5))}>{__sveltets_store_get(b)}</h1></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected.tsx
@@ -13,7 +13,7 @@
 <svelteoptions /></>
 return { props: {}, slots: {} }}
 
-export default class input {
+export default class Input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected.tsx
@@ -13,7 +13,7 @@
 <svelteoptions /></>
 return { props: {}, slots: {} }}
 
-export default class {
+export default class input {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,6 +1281,13 @@ log-symbols@3.0.0:
   dependencies:
     chalk "^2.4.2"
 
+lower-case@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.1.tgz#39eeb36e396115cc05e29422eaea9e692c9408c7"
+  integrity sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
+  dependencies:
+    tslib "^1.10.0"
+
 magic-string@^0.25.2, magic-string@^0.25.3, magic-string@^0.25.4:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -1441,6 +1448,14 @@ nise@^4.0.1:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
+no-case@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.3.tgz#c21b434c1ffe48b39087e86cfb4d2582e9df18f8"
+  integrity sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==
+  dependencies:
+    lower-case "^2.0.1"
+    tslib "^1.10.0"
+
 node-environment-flags@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.5.tgz#fa930275f5bf5dae188d6192b24b4c8bbac3d76a"
@@ -1571,6 +1586,14 @@ parse5@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+pascal-case@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.1.tgz#5ac1975133ed619281e88920973d2cd1f279de5f"
+  integrity sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==
+  dependencies:
+    no-case "^3.0.3"
+    tslib "^1.10.0"
 
 path-exists@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,6 +611,11 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+dedent-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dedent-js/-/dedent-js-1.0.1.tgz#bee5fb7c9e727d85dffa24590d10ec1ab1255305"
+  integrity sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU=
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"


### PR DESCRIPTION
### Goal

Solve https://github.com/sveltejs/language-tools/issues/280

For example:

```svelte
<!--
@component
Here's some documentation for this component. It will show up
on hover for TypeScript projects using a LSP-compatible editor
such as VSCode or Vim/Neovim with coc.nvim.

- You can use markdown here.
- You can use code blocks here.
-->

<main>
  <h1>
    Hello world
  </h1>
</main>
```

Single-line comments should work too. The contents of the HTML comment can then be picked up by the language service provider.

### Progress

- [x] Use named default exports instead of anonymous, using the name of the file for the exported class, in such a way that autocompletion doesn't end up broken.
  - [x] Maybe update the test suite to expect the more realistic case where `svelte2tsx` is called with a filename.
  - [x] Transform the filename into a `PascalCase` name for the default-exported class.
- [x] Implement the documentation feature with an HTML comment.
  - [x] Parse an HTML comment that looks like `<!-- @component Documentation string -->`.
  - [x] Take the string from the tag and add it to a JSDoc on the default (now named) export.
  - [x] Document this feature somewhere.

### About the test suite

With this, the test suite is now mostly unrealistic, since all the expected strings use anonymous exports. In most (if not all?) cases, `svelte2tsx` would be called with a filename. Maybe I should update all the tests.

### To be discussed

**Edit:** discussion solved, we go for `@component`.

Is this HTML comment approach the best? And if so, what should the tag look like? Here are some ideas:

- `@documentation`
- `@doc`
- `@component`: I like this one better because `@doc` or `@documentation` sounds a bit vague. `@component` specifies what the documentation is about, and it's obvious that it's documentation.

Maybe we could support multiple, too.