### PR TITLE
Add note in documentation about preprocess array

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ Do you want to use TypeScript/SCSS/Less/..? See [Using with preprocessors](#usin
 
 If a svelte file contains some language other than `html`, `css` or `javascript`, `svelte-vscode` needs to know how to [preprocess](https://svelte.dev/docs#svelte_preprocess) it. This can be achieved by creating a `svelte.config.js` file at the root of your project which exports a svelte options object (similar to `svelte-loader` and `rollup-plugin-svelte`). It's recommended to use the official [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess) package which can handle many languages.
 
+**Note**: `svelte-preprocess` supports passing an array of preprocessors (e,g, `preprocess: [postcss(), typescript()]`), but this is **not** currently supported by the language server.
+
 ```js
 // svelte.config.js - NOTE: you cannot use the new "import x from y" and "export const" syntax in here.
 const sveltePreprocess = require('svelte-preprocess');


### PR DESCRIPTION
Adding an array causes the extension to work improperly (https://github.com/sveltejs/language-tools/issues/279), so this note should save some confusion