### PR TITLE
(feat) support default language of svelte-preprocess

### DIFF
--- a/packages/language-server/src/importPackage.ts
+++ b/packages/language-server/src/importPackage.ts
@@ -2,7 +2,7 @@ import { dirname, resolve } from 'path';
 import * as prettier from 'prettier';
 import * as svelte from 'svelte/compiler';
 import sveltePreprocess from 'svelte-preprocess';
-import { Logger } from '../logger';
+import { Logger } from './logger';
 
 export function getPackageInfo(packageName: string, fromPath: string) {
     const packageJSONPath = require.resolve(`${packageName}/package.json`, {

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -1,7 +1,7 @@
 import { Logger } from '../../logger';
 import { cosmiconfigSync } from 'cosmiconfig';
 import { CompileOptions } from 'svelte/types/compiler/interfaces';
-import { PreprocessorGroup } from 'svelte-preprocess/dist/types';
+import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 import { importSveltePreprocess } from '../../importPackage';
 
 export interface SvelteConfig {

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -1,0 +1,74 @@
+import { Logger } from '../../logger';
+import { cosmiconfigSync } from 'cosmiconfig';
+import { CompileOptions } from 'svelte/types/compiler/interfaces';
+import { PreprocessorGroup } from 'svelte-preprocess/dist/types';
+import { importSveltePreprocess } from '../../importPackage';
+
+export interface SvelteConfig {
+    compilerOptions?: CompileOptions;
+    preprocess?: PreprocessorGroup & {
+        /**
+         * svelte-preprocess has this since 4.x
+         */
+        defaultLanguages?: { markup?: string; script?: string; style?: string };
+    };
+    loadConfigError?: any;
+}
+
+const DEFAULT_OPTIONS: CompileOptions = {
+    dev: true,
+};
+
+const NO_GENERATE: CompileOptions = {
+    generate: false,
+};
+
+const svelteConfigExplorer = cosmiconfigSync('svelte', {
+    packageProp: 'svelte-ls',
+    cache: true,
+});
+
+/**
+ * Tries to load `svelte.config.js`
+ *
+ * @param path File path of the document to load the config for
+ */
+export function loadConfig(path: string): SvelteConfig {
+    Logger.log('Trying to load config for', path);
+    try {
+        const result = svelteConfigExplorer.search(path);
+        const config: SvelteConfig = result?.config ?? useFallbackPreprocessor(path, false);
+        if (result) {
+            Logger.log('Found config at ', result.filepath);
+        }
+        return {
+            ...config,
+            compilerOptions: { ...DEFAULT_OPTIONS, ...config.compilerOptions, ...NO_GENERATE },
+        };
+    } catch (err) {
+        Logger.error('Error while loading config');
+        Logger.error(err);
+        return {
+            ...useFallbackPreprocessor(path, true),
+            compilerOptions: {
+                ...DEFAULT_OPTIONS,
+                ...NO_GENERATE,
+            },
+            loadConfigError: err,
+        };
+    }
+}
+
+function useFallbackPreprocessor(path: string, foundConfig: boolean): SvelteConfig {
+    Logger.log(
+        (foundConfig
+            ? 'Found svelte.config.js but there was an error loading it. '
+            : 'No svelte.config.js found. ') +
+            'Using https://github.com/sveltejs/svelte-preprocess as fallback',
+    );
+    return {
+        preprocess: importSveltePreprocess(path)({
+            typescript: { transpileOnly: true },
+        }),
+    };
+}

--- a/packages/language-server/src/plugins/svelte/SvelteDocument.ts
+++ b/packages/language-server/src/plugins/svelte/SvelteDocument.ts
@@ -1,5 +1,5 @@
 import { SourceMapConsumer } from 'source-map';
-import { PreprocessorGroup } from 'svelte-preprocess/dist/types';
+import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 import type { compile } from 'svelte/compiler';
 import { CompileOptions } from 'svelte/types/compiler/interfaces';
 import { Processed } from 'svelte/types/compiler/preprocess';

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -11,7 +11,6 @@ import {
     positionAt,
     TagInformation,
     isInTag,
-    extractScriptTags,
 } from '../../lib/documents';
 import { pathToUrl } from '../../utils';
 import { ConsumerDocumentMapper } from './DocumentMapper';
@@ -112,13 +111,10 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
     let text = document.getText();
 
     try {
-        const tsx = svelte2tsx(
-            text,
-            {
-                strictMode: options.strictMode,
-                filename: document.getFilePath() ?? undefined,
-            }
-        );
+        const tsx = svelte2tsx(text, {
+            strictMode: options.strictMode,
+            filename: document.getFilePath() ?? undefined,
+        });
         text = tsx.code;
         tsxMap = tsx.map;
         if (tsxMap) {
@@ -175,10 +171,11 @@ export class SvelteDocumentSnapshot implements DocumentSnapshot {
 
     get scriptKind() {
         if (!this._scriptKind) {
-            const scriptTags = extractScriptTags(this.parent.getText());
-            const scriptKind = getScriptKindFromAttributes(scriptTags?.script?.attributes ?? {});
+            const scriptKind = getScriptKindFromAttributes(
+                this.parent.scriptInfo?.attributes ?? {},
+            );
             const moduleScriptKind = getScriptKindFromAttributes(
-                scriptTags?.moduleScript?.attributes ?? {},
+                this.parent.moduleScriptInfo?.attributes ?? {},
             );
             this._scriptKind = [scriptKind, moduleScriptKind].includes(ts.ScriptKind.TSX)
                 ? ts.ScriptKind.TSX

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -2,7 +2,7 @@ import { dirname, resolve } from 'path';
 import ts from 'typescript';
 import { Document } from '../../lib/documents';
 import { Logger } from '../../logger';
-import { getPackageInfo } from '../importPackage';
+import { getPackageInfo } from '../../importPackage';
 import { DocumentSnapshot } from './DocumentSnapshot';
 import { createSvelteModuleLoader } from './module-loader';
 import { SnapshotManager } from './SnapshotManager';

--- a/packages/language-server/test/plugins/svelte/SvelteDocument.test.ts
+++ b/packages/language-server/test/plugins/svelte/SvelteDocument.test.ts
@@ -2,8 +2,9 @@ import * as assert from 'assert';
 import sinon from 'sinon';
 import { Position } from 'vscode-languageserver';
 import { Document } from '../../../src/lib/documents';
-import * as importPackage from '../../../src/plugins/importPackage';
-import { SvelteDocument, SvelteConfig } from '../../../src/plugins/svelte/SvelteDocument';
+import * as importPackage from '../../../src/importPackage';
+import { SvelteDocument } from '../../../src/plugins/svelte/SvelteDocument';
+import * as configLoader from '../../../src/lib/documents/configLoader';
 
 describe('Svelte Document', () => {
     function getSourceCode(transpiled: boolean): string {
@@ -15,9 +16,11 @@ describe('Svelte Document', () => {
         `;
     }
 
-    function setup(config: SvelteConfig = {}) {
+    function setup(config: configLoader.SvelteConfig = {}) {
+        sinon.stub(configLoader, 'loadConfig').returns(config);
         const parent = new Document('file:///hello.svelte', getSourceCode(false));
-        const svelteDoc = new SvelteDocument(parent, config);
+        sinon.restore();
+        const svelteDoc = new SvelteDocument(parent);
         return { parent, svelteDoc };
     }
 

--- a/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
@@ -41,7 +41,7 @@ describe('SveltePlugin#getCodeAction', () => {
             pathToUrl(filePath),
             filename ? fs.readFileSync(filePath)?.toString() : '',
         );
-        const svelteDoc = new SvelteDocument(document, {});
+        const svelteDoc = new SvelteDocument(document);
         const codeAction = await getCodeActions(
             svelteDoc,
             Range.create(Position.create(0, 0), Position.create(0, 0)),
@@ -269,7 +269,7 @@ describe('SveltePlugin#getCodeAction', () => {
         <p>extract me</p>
         ${styleContent}`;
 
-        const doc = new SvelteDocument(new Document('someUrl', content), {});
+        const doc = new SvelteDocument(new Document('someUrl', content));
 
         async function extractComponent(filePath: string, range: Range) {
             return executeRefactoringCommand(doc, extractComponentCommand, [
@@ -345,7 +345,7 @@ describe('SveltePlugin#getCodeAction', () => {
             @import './style.css';
             </style>`;
             const existingFileUri = pathToUrl('C:/path/File.svelte');
-            const doc = new SvelteDocument(new Document(existingFileUri, content), {});
+            const doc = new SvelteDocument(new Document(existingFileUri, content));
             const range = Range.create(Position.create(4, 12), Position.create(4, 21));
             const result = await executeRefactoringCommand(doc, extractComponentCommand, [
                 '',

--- a/packages/language-server/test/plugins/svelte/features/getCompletions.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCompletions.test.ts
@@ -9,7 +9,7 @@ describe('SveltePlugin#getCompletions', () => {
         content: string,
         position: Position = Position.create(0, content.length),
     ) {
-        const svelteDoc = new SvelteDocument(new Document('url', content), {});
+        const svelteDoc = new SvelteDocument(new Document('url', content));
         const completions = getCompletions(svelteDoc, position);
         return {
             toEqual: (expectedLabels: string[] | null) =>

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -3,10 +3,10 @@ import { Diagnostic, DiagnosticSeverity, Position } from 'vscode-languageserver'
 import { Document } from '../../../../src/lib/documents';
 import { getDiagnostics } from '../../../../src/plugins/svelte/features/getDiagnostics';
 import {
-    SvelteConfig,
     SvelteDocument,
     TranspileErrorSource,
 } from '../../../../src/plugins/svelte/SvelteDocument';
+import { SvelteConfig } from '../../../../src/lib/documents/configLoader';
 
 describe('SveltePlugin#getDiagnostics', () => {
     async function expectDiagnosticsFor(

--- a/packages/language-server/test/plugins/svelte/features/getHoverInfo.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getHoverInfo.test.ts
@@ -7,7 +7,7 @@ import { Document } from '../../../../src/lib/documents';
 
 describe('SveltePlugin#getHoverInfo', () => {
     function expectHoverInfoFor(content: string, position: Position) {
-        const svelteDoc = new SvelteDocument(new Document('url', content), {});
+        const svelteDoc = new SvelteDocument(new Document('url', content));
         const hover = getHoverInfo(svelteDoc, position);
         return {
             toEqual: (tag: SvelteTag | null) =>


### PR DESCRIPTION
`svelte-preprocess` has a feature for setting default languages so you don't have to write `lang="x"` each time. This adds support for this in style/script tags.

To accomplish this, parsing of the `svelte.config.js` was moved up to `Document`. Inside it, the `lang` attribute is set to the default language if there exists no `lang`/`type` attribute.

I deliberately did not bump the `svelte-preprocess` version yet to wait until `4.x` has received some more feedback and bugfixes.