### PR TITLE
(fix) change svelte2tsx' default export

### DIFF
--- a/packages/svelte2tsx/rollup.config.js
+++ b/packages/svelte2tsx/rollup.config.js
@@ -4,24 +4,36 @@ import resolve from 'rollup-plugin-node-resolve';
 import json from 'rollup-plugin-json';
 import builtins from 'builtin-modules';
 
-export default [{
-	input: 'src/index.ts',
-	output: [{
-		sourcemap: true,
-		format: 'commonjs',
-		file: 'index.js'
-	},{
-		file: 'index.mjs',
-		format: 'esm'
-	}],
-	plugins: [
-		resolve({ browser: false, preferBuiltins: true }),
-		commonjs(),
-		json(),
-		typescript()
-	],
-	watch: {
-		clearScreen: false
-	},
-	external: [...builtins, 'typescript', 'svelte', 'svelte/compiler']
-}];
+export default [
+    {
+        input: 'src/index.ts',
+        output: [
+            {
+                sourcemap: true,
+                format: 'commonjs',
+                file: 'index.js',
+            },
+            {
+                file: 'index.mjs',
+                format: 'esm',
+            },
+        ],
+        plugins: [
+            resolve({ browser: false, preferBuiltins: true }),
+            commonjs(),
+            json(),
+            typescript(),
+        ],
+        watch: {
+            clearScreen: false,
+        },
+        external: [
+            ...builtins,
+            'typescript',
+            'svelte',
+            'svelte/compiler',
+            'dedent-js',
+            'pascal-case',
+        ],
+    },
+];

--- a/packages/svelte2tsx/test/svelte2tsx/samples/array-binding-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/array-binding-export/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {a: a , b: b , c: c}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
@@ -3,7 +3,7 @@ __sveltets_store_get(var);
 <></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
@@ -3,7 +3,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
@@ -13,7 +13,7 @@ function render() {
 </>})}}</>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
@@ -2,7 +2,7 @@
 <><input id="dom-input" type="radio" {...__sveltets_any(__sveltets_store_get(compile_options).generate)} value="dom"/></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expected.tsx
@@ -89,7 +89,7 @@
 </>}}}</>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
@@ -8,7 +8,7 @@
 </div></>
 return { props: {}, slots: {default: {a:b}} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
@@ -11,7 +11,7 @@
 </div></>
 return { props: {}, slots: {default: {a:b}, test: {c:d, e:e}} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
@@ -8,7 +8,7 @@
 </div></>
 return { props: {}, slots: {default: {a:b, b:b, c:"b", d:"__svelte_ts_string", e:b}} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expected.tsx
@@ -5,7 +5,7 @@
 return { props: {}, slots: {} }}
 
 /** This component does nothing at all */
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expected.tsx
@@ -17,7 +17,7 @@ return { props: {}, slots: {} }}
  *
  * The output should be indented properly!
  */
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expected.tsx
@@ -11,7 +11,7 @@ return { props: {}, slots: {} }}
  * type Type = 'type'
  * ```
  */
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-arrow-function/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-arrow-function/expected.tsx
@@ -8,7 +8,7 @@
 <></>
 return { props: {f: f}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-const/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-const/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {name: name} as {name?: string}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-has-type/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-has-type/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {a: a , b: b} as {a: A, b?: A}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-interface/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-interface/expected.tsx
@@ -4,7 +4,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-js-strictMode/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-js-strictMode/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {a: a , b: b , c: c} as {a: number, b: number | undefined, c?: number}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-list/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-list/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {name: name , name2: name2}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-references-local/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-references-local/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {name: name}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-ts-strictMode/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-ts-strictMode/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {a: a , b: b , c: c} as {a: number, b: number | undefined, c?: number}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = render().props
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-with-default-multi/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-with-default-multi/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {name: name , world: world}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expected.tsx
@@ -7,7 +7,7 @@ function render() {
 </>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/imports/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/imports/expected.tsx
@@ -11,7 +11,7 @@ function render() {
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line/expected.tsx
@@ -3,7 +3,7 @@
 <><h1>hello {world}</h1></>
 return { props: {world: world}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line2/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script-in-line2/expected.tsx
@@ -3,7 +3,7 @@
 <><h1>hello {world}</h1></>
 return { props: {world: world}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script/expected.tsx
@@ -10,7 +10,7 @@
 <h1>hello {world}</h1></>
 return { props: {world: world}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script2/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script2/expected.tsx
@@ -10,7 +10,7 @@
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/multiple-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/multiple-export/expected.tsx
@@ -7,7 +7,7 @@
 <h1>{number1} + {number2} = {number1 + number2}</h1></>
 return { props: {number1: number1 , number2: number2} as {number1: number, number2: number}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expected.tsx
@@ -24,7 +24,7 @@ const test4 = ({a,  b: { $top1: $top2 }}) => $top2 && __sveltets_store_get(top1)
 <></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expected.tsx
@@ -24,7 +24,7 @@
 }}>Hi</h1></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/object-binding-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/object-binding-export/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {rename: rename}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expected.tsx
@@ -8,7 +8,7 @@ let a: 1 | 2 = 1;
 <></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
@@ -6,7 +6,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
@@ -9,7 +9,7 @@ $: a = __sveltets_invalidate(() => 5);
 <></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/renamed-exports/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/renamed-exports/expected.tsx
@@ -7,7 +7,7 @@
 <></>
 return { props: {name3: name , name4: name2}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-and-module-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-and-module-script/expected.tsx
@@ -10,7 +10,7 @@
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
@@ -14,7 +14,7 @@
 </sveltehead></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-on-bottom/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-on-bottom/expected.tsx
@@ -6,7 +6,7 @@
 </>
 return { props: {world: world}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected.tsx
@@ -10,7 +10,7 @@
 <Style /></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
@@ -8,7 +8,7 @@ let a = 'b';
 </>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expected.tsx
@@ -2,7 +2,7 @@
 <><h1>hello</h1></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/single-export/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/single-export/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {name: name}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
@@ -2,7 +2,7 @@
 <><Me f={`${__sveltets_store_get(s)} `}/></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expected.tsx
@@ -5,7 +5,7 @@
 {true === true}</>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expected.tsx
@@ -2,7 +2,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style/expected.tsx
@@ -2,7 +2,7 @@
 <></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/typed-export-with-default/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/typed-export-with-default/expected.tsx
@@ -5,7 +5,7 @@
 <></>
 return { props: {name: name} as {name?: string | number}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
@@ -6,7 +6,7 @@
 </>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-ts-strictMode/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-ts-strictMode/expected.tsx
@@ -4,7 +4,7 @@
 <h1>{$$props['name']}</h1></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
@@ -2,7 +2,7 @@
 <><h1>{$$props['name']}</h1></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expected.tsx
@@ -6,7 +6,7 @@
 </>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expected.tsx
@@ -2,7 +2,7 @@
 <><h1>{$$restProps['name']}</h1></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial_with_any(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
@@ -3,7 +3,7 @@
 <button onclick={__sveltets_store_get(check) ? method1 : method2} >Bla</button></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
@@ -33,7 +33,7 @@ function render() {
 <button onclick={() => count.set( __sveltets_store_get(count) | myvar)}>OR</button></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-exclamation-mark/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-exclamation-mark/expected.tsx
@@ -10,7 +10,7 @@ function render() {
 <button onclick={() => !__sveltets_store_get(count)}>add</button></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
@@ -12,7 +12,7 @@ function render() {
 <button onclick={() => count.set( __sveltets_store_get(count) - 1)}>subtract</button></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
@@ -4,7 +4,7 @@ b.set(__sveltets_store_get(b).concat(5));
 <h1 onclick={() => b.set(__sveltets_store_get(b).concat(5))}>{__sveltets_store_get(b)}</h1></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected.tsx
@@ -13,7 +13,7 @@
 <svelteoptions /></>
 return { props: {}, slots: {} }}
 
-export default class Input {
+export default class Input__SvelteComponent_ {
     $$prop_def = __sveltets_partial(render().props)
     $$slot_def = render().slots
 }


### PR DESCRIPTION
Append `__SvelteComponent_` to make it unlikely that name clashes occur.
#294

Due to this most of the simplifications in #293 had to be reverted.