### PR TITLE
syntax highlight for svelte block in markdown

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -233,6 +233,16 @@
                     "source.js": "javascript",
                     "source.ts": "typescript"
                 }
+            },
+            {
+              "scopeName": "markdown.svelte.codeblock",
+              "path": "./syntaxes/markdown-svelte.json",
+              "injectTo": [
+                "text.html.markdown"
+              ],
+              "embeddedLanguages": {
+                "meta.embedded.block.svelte": "svelte"
+              }
             }
         ],
         "commands": [

--- a/packages/svelte-vscode/syntaxes/markdown-svelte.json
+++ b/packages/svelte-vscode/syntaxes/markdown-svelte.json
@@ -1,0 +1,45 @@
+{
+    "scopeName": "markdown.svelte.codeblock",
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#svelte-code-block"
+        }
+    ],
+    "repository": {
+        "svelte-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(svelte|sv)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language"
+                },
+                "6": {
+                    "name": "fenced_code.block.language.attributes"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.svelte",
+                    "patterns": [
+                        {
+                            "include": "source.svelte"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Saw vetur has this feature and it's very easy to implement
![圖片](https://user-images.githubusercontent.com/36730922/87104367-4230ef00-c28a-11ea-89d0-2105ddea432e.png)
