### PR TITLE
Update README.md for setting up scss in vscode

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,9 @@ If a svelte file contains some language other than `html`, `css` or `javascript`
 const sveltePreprocess = require('svelte-preprocess');
 
 module.exports = {
-    preprocess: sveltePreprocess(),
+    preprocess: sveltePreprocess({
+        scss: true,
+    }),
     // ...other svelte options
 };
 ```


### PR DESCRIPTION
Without the `{scss:true}`, VS Code would keep complaining.

I spent an hour to searching for solution and finally found workable template from https://github.com/sveltejs/svelte-preprocess/issues/74#issuecomment-544322943.
