### PR TITLE
temporarily relax event type

### DIFF
--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -41,7 +41,7 @@ declare var process: NodeJS.Process & { browser: boolean }
 declare function __sveltets_ensureAnimation<U extends any[]>(animation: SvelteAnimation<U>, ...args: U): any;
 declare function __sveltets_ensureAction<U extends any[]>(action: SvelteAction<U>, ...args: U): any;
 declare function __sveltets_ensureTransition<U extends any[]>(transition: SvelteTransition<U>, ...args: U): any;
-declare function __sveltets_ensureFunction(expression: (e: Event) => unknown ):any;
+declare function __sveltets_ensureFunction(expression: (e: Event & { detail?: any }) => unknown ) : any;
 declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): any;
 declare function __sveltets_instanceOf<T>(type: AConstructorTypeOf<T>): T;
 declare function __sveltets_allPropsType(): SvelteAllProps


### PR DESCRIPTION
Temporarily relax component event type to have `detail` property. Once the forwarded DOM event type-check is possible this can be removed.
related #312 