### PR TITLE
added TSX style color to svelte component tags.

### DIFF
--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.json
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.json
@@ -3,6 +3,7 @@
     "scopeName": "source.svelte",
     "fileTypes": ["svelte"],
     "uuid": "7582b62f-51d9-4a84-8c8d-fc189530faf6",
+
     "patterns": [
         {
             "begin": "(<)(style)\\b(?=[^>]*(?:type=('text/sass'|\"text/sass\")|lang=(sass|'sass'|\"sass\")))(?![^/>]*/>\\s*$)",
@@ -540,7 +541,7 @@
             ]
         },
         {
-            "begin": "(</?)([a-zA-Z][a-zA-Z0-9:-]*)",
+            "begin": "(</?)([a-z][a-zA-Z0-9:-]*)",
             "beginCaptures": {
                 "1": {
                     "name": "punctuation.definition.tag.begin.html"
@@ -556,6 +557,32 @@
                 }
             },
             "name": "meta.tag.other.html",
+            "patterns": [
+                {
+                    "include": "#tag-stuff"
+                }
+            ]
+        },
+        {
+            "begin": "(</?)([A-Z][a-zA-Z0-9:-]*)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.begin.html"
+                },
+                "2": {
+                    "name": "support.class.component.tsx"
+                }
+            },
+            "end": "(/?>)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.end.html"
+                },
+                "2": {
+                    "name": "support.class.component.tsx"
+                }
+            },
+            "name": "meta.tag.svelte",
             "patterns": [
                 {
                     "include": "#tag-stuff"


### PR DESCRIPTION
i modified the grammar file using support.class.component.tsx to append any tag starting with a capital letter with TSX style colors to separate svelte components from html tags. the yarn test script passes without issues.

granted, i might want to double-check the intellisense in case i added tsx commands by accident. if i can narrow the scope to just affect the color alone this will be perfect.

![image](https://user-images.githubusercontent.com/15244006/87814612-0f5e9c00-c832-11ea-845b-fac70cdea32a.png)

