### PR TITLE
type check for reactive declaration

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -790,13 +790,7 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
         if (!rootScope.declared.has(name)) {
             // remove '$:' label
             str.remove(pos + astOffset, pos + astOffset+2);
-            const followingChar = str.slice(pos + astOffset+2, pos + astOffset+3);
-            // if there exists whitespace after '$:', we do not insert more space.
-            if (followingChar === ' ' || followingChar === '\t' || followingChar === '\n') {
-                str.prependRight(pos + astOffset, `let`);
-            } else {
-                str.prependRight(pos + astOffset, `let `);
-            }
+            str.prependRight(pos + astOffset, `let `);
         }
     }
 

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -788,7 +788,15 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
     // declare implicit reactive variables we found in the script
     for (const [name, pos] of implicitTopLevelNames.entries()) {
         if (!rootScope.declared.has(name)) {
-            str.prependRight(pos + astOffset, `;let ${name}; `);
+            // remove '$:' label
+            str.remove(pos + astOffset, pos + astOffset+2);
+            const followingChar = str.slice(pos + astOffset+2, pos + astOffset+3);
+            // if there exists whitespace after '$:', we do not insert more space.
+            if (followingChar === ' ' || followingChar === '\t' || followingChar === '\n') {
+                str.prependRight(pos + astOffset, `let`);
+            } else {
+                str.prependRight(pos + astOffset, `let `);
+            }
         }
     }
 

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -392,7 +392,7 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
     const astOffset = script.content.start;
     const exportedNames: ExportedNames = new Map();
 
-    const implicitTopLevelNames: Map<string, {pos: number; expr: ts.Expression}> = new Map();
+    const implicitTopLevelNames: Map<string, number> = new Map();
     let uses$$props = false;
     let uses$$restProps = false;
 
@@ -760,10 +760,7 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
             ) {
                 const name = node.statement.expression.left.text;
                 if (!implicitTopLevelNames.has(name)) {
-                    implicitTopLevelNames.set(name, {
-                        pos: node.label.getStart(),
-                        expr: node.statement.expression.right
-                    });
+                    implicitTopLevelNames.set(name, node.label.getStart());
                 }
 
                 wrapExpressionWithInvalidate(node.statement.expression.right);
@@ -789,10 +786,9 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
     pendingStoreResolutions.map(resolveStore);
 
     // declare implicit reactive variables we found in the script
-    for (const [name, {pos, expr}] of implicitTopLevelNames.entries()) {
+    for (const [name, pos] of implicitTopLevelNames.entries()) {
         if (!rootScope.declared.has(name)) {
-            const exprStr = str.slice(astOffset + expr.getStart(), astOffset + expr.getEnd());
-            str.prependRight(pos + astOffset, `;let ${name} = ${exprStr}; `);
+            str.prependRight(pos + astOffset, `;let ${name}; `);
         }
     }
 

--- a/packages/svelte2tsx/test/sourcemaps/let.html
+++ b/packages/svelte2tsx/test/sourcemaps/let.html
@@ -1,6 +1,6 @@
 <></>;function render() {
 
-    ;let selected; $: selected = __sveltets_invalidate(() => lookup.get(slug));
+    ;let selected = lookup.get(slug); $: selected = __sveltets_invalidate(() => lookup.get(slug));
 ;
 <>
 </>

--- a/packages/svelte2tsx/test/sourcemaps/let.html
+++ b/packages/svelte2tsx/test/sourcemaps/let.html
@@ -1,6 +1,6 @@
 <></>;function render() {
 
-    ;let selected; $: selected = __sveltets_invalidate(() => lookup.get(slug));
+    let selected = __sveltets_invalidate(() => lookup.get(slug));
 ;
 <>
 </>

--- a/packages/svelte2tsx/test/sourcemaps/let.html
+++ b/packages/svelte2tsx/test/sourcemaps/let.html
@@ -1,6 +1,6 @@
 <></>;function render() {
 
-    ;let selected = lookup.get(slug); $: selected = __sveltets_invalidate(() => lookup.get(slug));
+    ;let selected; $: selected = __sveltets_invalidate(() => lookup.get(slug));
 ;
 <>
 </>

--- a/packages/svelte2tsx/test/sourcemaps/let.html
+++ b/packages/svelte2tsx/test/sourcemaps/let.html
@@ -1,6 +1,6 @@
 <></>;function render() {
 
-    let selected = __sveltets_invalidate(() => lookup.get(slug));
+    let  selected = __sveltets_invalidate(() => lookup.get(slug));
 ;
 <>
 </>

--- a/packages/svelte2tsx/test/sourcemaps/repl.html
+++ b/packages/svelte2tsx/test/sourcemaps/repl.html
@@ -69,8 +69,8 @@ function render() {
 	//   here statically
 	const tutorial_repo_link = 'https://github.com/sveltejs/svelte/tree/master/site/content/tutorial';
 
-	;let selected; $: selected = __sveltets_invalidate(() => lookup.get(slug));
-	;let improve_link; $: improve_link = __sveltets_invalidate(() => `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`);
+	;let selected = lookup.get(slug); $: selected = __sveltets_invalidate(() => lookup.get(slug));
+	;let improve_link = `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`; $: improve_link = __sveltets_invalidate(() => `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`);
 
 	const clone = file => ({
 		name: file.name,
@@ -85,7 +85,7 @@ function render() {
 		});
     }}
 
-	;let mobile; $: mobile = __sveltets_invalidate(() => width < 768);
+	;let mobile = width < 768; $: mobile = __sveltets_invalidate(() => width < 768);
 
 	function reset() {
 		repl.update({

--- a/packages/svelte2tsx/test/sourcemaps/repl.html
+++ b/packages/svelte2tsx/test/sourcemaps/repl.html
@@ -69,8 +69,8 @@ function render() {
 	//   here statically
 	const tutorial_repo_link = 'https://github.com/sveltejs/svelte/tree/master/site/content/tutorial';
 
-	;let selected; $: selected = __sveltets_invalidate(() => lookup.get(slug));
-	;let improve_link; $: improve_link = __sveltets_invalidate(() => `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`);
+	let selected = __sveltets_invalidate(() => lookup.get(slug));
+	let improve_link = __sveltets_invalidate(() => `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`);
 
 	const clone = file => ({
 		name: file.name,
@@ -85,7 +85,7 @@ function render() {
 		});
     }}
 
-	;let mobile; $: mobile = __sveltets_invalidate(() => width < 768);
+	let mobile = __sveltets_invalidate(() => width < 768);
 
 	function reset() {
 		repl.update({

--- a/packages/svelte2tsx/test/sourcemaps/repl.html
+++ b/packages/svelte2tsx/test/sourcemaps/repl.html
@@ -69,8 +69,8 @@ function render() {
 	//   here statically
 	const tutorial_repo_link = 'https://github.com/sveltejs/svelte/tree/master/site/content/tutorial';
 
-	let selected = __sveltets_invalidate(() => lookup.get(slug));
-	let improve_link = __sveltets_invalidate(() => `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`);
+	let  selected = __sveltets_invalidate(() => lookup.get(slug));
+	let  improve_link = __sveltets_invalidate(() => `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`);
 
 	const clone = file => ({
 		name: file.name,
@@ -85,7 +85,7 @@ function render() {
 		});
     }}
 
-	let mobile = __sveltets_invalidate(() => width < 768);
+	let  mobile = __sveltets_invalidate(() => width < 768);
 
 	function reset() {
 		repl.update({

--- a/packages/svelte2tsx/test/sourcemaps/repl.html
+++ b/packages/svelte2tsx/test/sourcemaps/repl.html
@@ -69,8 +69,8 @@ function render() {
 	//   here statically
 	const tutorial_repo_link = 'https://github.com/sveltejs/svelte/tree/master/site/content/tutorial';
 
-	;let selected = lookup.get(slug); $: selected = __sveltets_invalidate(() => lookup.get(slug));
-	;let improve_link = `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`; $: improve_link = __sveltets_invalidate(() => `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`);
+	;let selected; $: selected = __sveltets_invalidate(() => lookup.get(slug));
+	;let improve_link; $: improve_link = __sveltets_invalidate(() => `${tutorial_repo_link}/${selected.chapter.section_dir}/${selected.chapter.chapter_dir}`);
 
 	const clone = file => ({
 		name: file.name,
@@ -85,7 +85,7 @@ function render() {
 		});
     }}
 
-	;let mobile = width < 768; $: mobile = __sveltets_invalidate(() => width < 768);
+	;let mobile; $: mobile = __sveltets_invalidate(() => width < 768);
 
 	function reset() {
 		repl.update({

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
@@ -1,7 +1,7 @@
 <></>;function render() {
 
 
-;let b; $: b = __sveltets_invalidate(() => ({ a: 1 }));
+let b = __sveltets_invalidate(() => ({ a: 1 }));
 ;
 <></>
 return { props: {}, slots: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
@@ -1,7 +1,7 @@
 <></>;function render() {
 
 
-;let b; $: b = __sveltets_invalidate(() => ({ a: 1 }));
+;let b = { a: 1 }; $: b = __sveltets_invalidate(() => ({ a: 1 }));
 ;
 <></>
 return { props: {}, slots: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
@@ -1,7 +1,7 @@
 <></>;function render() {
 
 
-let b = __sveltets_invalidate(() => ({ a: 1 }));
+let  b = __sveltets_invalidate(() => ({ a: 1 }));
 ;
 <></>
 return { props: {}, slots: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
@@ -1,7 +1,7 @@
 <></>;function render() {
 
 
-;let b = { a: 1 }; $: b = __sveltets_invalidate(() => ({ a: 1 }));
+;let b; $: b = __sveltets_invalidate(() => ({ a: 1 }));
 ;
 <></>
 return { props: {}, slots: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
@@ -1,7 +1,7 @@
 <></>;function render() {
 
 
-let b = __sveltets_invalidate(() => 7);
+let  b = __sveltets_invalidate(() => 7);
 
 let a;
 $: a = __sveltets_invalidate(() => 5);

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
@@ -1,7 +1,7 @@
 <></>;function render() {
 
 
-;let b; $: b = __sveltets_invalidate(() => 7);
+let b = __sveltets_invalidate(() => 7);
 
 let a;
 $: a = __sveltets_invalidate(() => 5);

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
@@ -1,7 +1,7 @@
 <></>;function render() {
 
 
-;let b; $: b = __sveltets_invalidate(() => 7);
+;let b = 7; $: b = __sveltets_invalidate(() => 7);
 
 let a;
 $: a = __sveltets_invalidate(() => 5);

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
@@ -1,7 +1,7 @@
 <></>;function render() {
 
 
-;let b = 7; $: b = __sveltets_invalidate(() => 7);
+;let b; $: b = __sveltets_invalidate(() => 7);
 
 let a;
 $: a = __sveltets_invalidate(() => 5);


### PR DESCRIPTION
```js
let a = 1;
$: b = a
```

generates

```javascript
let a = 1;

;let b = a; $: b = __sveltets_invalidate(() => a);

```

so typescript can infer the type of `b` to be `number` instead of `any`.