### PR TITLE
(Svelte2txs) custom:directive to custom_directive

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx.ts
@@ -350,6 +350,13 @@ export function convertHtmlxToJsx(
                 str.overwrite(attr.start, attr.start + attr.name.length, name);
             }
         }
+        
+        // support custom directives?
+        // hydrate:data={}
+        if (parent.type == 'InlineComponent' && attr.name.includes(':')) {
+            const colon = htmlx.indexOf(':', attr.start);
+            str.overwrite(colon, colon+1, "_");
+        }
 
         //we are a bare attribute
         if (attr.value === true) return;


### PR DESCRIPTION
So this is my first time playing with a language tool. 

The main problem is that the TS checker is choking on any sort of custom:directive as outlined in #339.

This PR simply replaces colons in attribute names with an underscore to get TS to validate them. 