### PR TITLE
(svelte-vscode) Add initial support for multiple preprocessors

### DIFF
--- a/packages/language-server/src/lib/documents/Document.ts
+++ b/packages/language-server/src/lib/documents/Document.ts
@@ -66,7 +66,17 @@ export class Document extends WritableDocument {
             return null;
         }
 
-        const defaultLang = this.config.preprocess?.defaultLanguages?.[tag];
+        let defaultLang: string | undefined;
+
+        if (Array.isArray(this.config.preprocess)) {
+            const groupWithConfig = this.config.preprocess.find(
+                (group) => group.defaultLanguages?.[tag],
+            );
+            defaultLang = groupWithConfig?.defaultLanguages?.[tag];
+        } else {
+            defaultLang = this.config.preprocess?.defaultLanguages?.[tag];
+        }
+
         if (!tagInfo.attributes.lang && !tagInfo.attributes.type && defaultLang) {
             tagInfo.attributes.lang = defaultLang;
         }

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -4,14 +4,16 @@ import { CompileOptions } from 'svelte/types/compiler/interfaces';
 import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 import { importSveltePreprocess } from '../../importPackage';
 
+export type InternalPreprocessorGroup = PreprocessorGroup & {
+    /**
+     * svelte-preprocess has this since 4.x
+     */
+    defaultLanguages?: { markup?: string; script?: string; style?: string };
+};
+
 export interface SvelteConfig {
     compilerOptions?: CompileOptions;
-    preprocess?: PreprocessorGroup & {
-        /**
-         * svelte-preprocess has this since 4.x
-         */
-        defaultLanguages?: { markup?: string; script?: string; style?: string };
-    };
+    preprocess?: InternalPreprocessorGroup | InternalPreprocessorGroup[];
     loadConfigError?: any;
 }
 


### PR DESCRIPTION
An initial stab at supporting multiple preprocessors in the `svelte.config.js` file.

Closes #279