### PR TITLE
fix style svg attribute

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -2147,7 +2147,7 @@
       method?: string;
       min?: number | string;
       name?: string;
-      style?: CSSProperties;
+      style?: CSSProperties | string;
       target?: string;
       type?: string;
       width?: number | string;


### PR DESCRIPTION
Fixes #345 
I changed the style attribute for svg element from CSSProperties to string | CSSProperties, as HTMLAttributes interface.