### PR TITLE
(svelte2tsx) Add on:resize to DOMAttributes

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -1951,6 +1951,7 @@
       // UI Events
       onscroll?: UIEventHandler<T>;
       onscrollcapture?: UIEventHandler<T>;
+      onresize?: UIEventHandler<T>;
 
       // Wheel Events
       onwheel?: WheelEventHandler<T>;


### PR DESCRIPTION
Fixes #348 
The onresize event was missing in the svelte-jsx.d.ts file.
So I added it as a UI Event.