### PR TITLE
(svelte2tsx)Fix directive type check

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx.ts
@@ -185,7 +185,7 @@ export function convertHtmlxToJsx(
         //bind group on input
         if (attr.name == 'group' && el.name == 'input') {
             str.remove(attr.start, attr.expression.start);
-            str.appendLeft(attr.expression.start, '{...__sveltets_any(');
+            str.appendLeft(attr.expression.start, '{...__sveltets_empty(');
 
             const endBrackets = ')}';
             if (isShortHandAttribute(attr)) {
@@ -213,7 +213,7 @@ export function convertHtmlxToJsx(
         //one way binding
         if (oneWayBindingAttributes.has(attr.name) && el.type == 'Element') {
             str.remove(attr.start, attr.expression.start);
-            str.appendLeft(attr.expression.start, `{...__sveltets_any(`);
+            str.appendLeft(attr.expression.start, `{...__sveltets_empty(`);
             if (isShortHandAttribute(attr)) {
                 // eslint-disable-next-line max-len
                 str.appendLeft(

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -38,11 +38,11 @@ type SvelteComponent = import('*.svelte').default
 
 declare var process: NodeJS.Process & { browser: boolean }
 
-declare function __sveltets_ensureAnimation<U extends any[]>(animation: SvelteAnimation<U>, ...args: U): any;
-declare function __sveltets_ensureAction<U extends any[]>(action: SvelteAction<U>, ...args: U): any;
-declare function __sveltets_ensureTransition<U extends any[]>(transition: SvelteTransition<U>, ...args: U): any;
-declare function __sveltets_ensureFunction(expression: (e: Event) => unknown ):any;
-declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): any;
+declare function __sveltets_ensureAnimation<U extends any[]>(animation: SvelteAnimation<U>, ...args: U): {};
+declare function __sveltets_ensureAction<U extends any[]>(action: SvelteAction<U>, ...args: U): {};
+declare function __sveltets_ensureTransition<U extends any[]>(transition: SvelteTransition<U>, ...args: U): {};
+declare function __sveltets_ensureFunction(expression: (e: Event) => unknown ): {};
+declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): {};
 declare function __sveltets_instanceOf<T>(type: AConstructorTypeOf<T>): T;
 declare function __sveltets_allPropsType(): SvelteAllProps
 declare function __sveltets_restPropsType(): SvelteRestProps
@@ -51,5 +51,6 @@ declare function __sveltets_partial_with_any<T>(obj: T): Partial<T> & SvelteAllP
 declare function __sveltets_with_any<T>(obj: T): T & SvelteAllProps
 declare function __sveltets_store_get<T=any>(store: SvelteStore<T>): T
 declare function __sveltets_any(dummy: any): any;
+declare function __sveltets_empty(dummy: any): {};
 declare function __sveltets_componentType(): AConstructorTypeOf<SvelteComponent>
 declare function __sveltets_invalidate<T>(getValue: () => T): T

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-group-bare/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-group-bare/expected.jsx
@@ -1,2 +1,2 @@
-<><input type="radio" {...__sveltets_any(group)} value="Plain"/>
-<input type="radio" value="Plain" {...__sveltets_any(group)}/></>
+<><input type="radio" {...__sveltets_empty(group)} value="Plain"/>
+<input type="radio" value="Plain" {...__sveltets_empty(group)}/></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-group/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-group/expected.jsx
@@ -1,1 +1,1 @@
-<><input type="radio" {...__sveltets_any(tortilla)} value="Plain"/></>
+<><input type="radio" {...__sveltets_empty(tortilla)} value="Plain"/></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-oneway/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-oneway/expected.jsx
@@ -1,16 +1,16 @@
 <><div type="text" 
-    {...__sveltets_any(width=__sveltets_instanceOf(HTMLDivElement).clientWidth)} 
-    {...__sveltets_any(height=__sveltets_instanceOf(HTMLDivElement).clientHeight)} 
-    {...__sveltets_any(offsetWidth=__sveltets_instanceOf(HTMLDivElement).offsetWidth)} 
-    {...__sveltets_any(offsetHeight=__sveltets_instanceOf(HTMLDivElement).offsetHeight)}
+    {...__sveltets_empty(width=__sveltets_instanceOf(HTMLDivElement).clientWidth)} 
+    {...__sveltets_empty(height=__sveltets_instanceOf(HTMLDivElement).clientHeight)} 
+    {...__sveltets_empty(offsetWidth=__sveltets_instanceOf(HTMLDivElement).offsetWidth)} 
+    {...__sveltets_empty(offsetHeight=__sveltets_instanceOf(HTMLDivElement).offsetHeight)}
 />
 
 <video
     src={clip}
-    {...__sveltets_any(duration=__sveltets_instanceOf(HTMLMediaElement).duration)}
-    {...__sveltets_any(buffered=__sveltets_instanceOf(HTMLMediaElement).buffered)}
-    {...__sveltets_any(seekable=__sveltets_instanceOf(HTMLMediaElement).seekable)}
-    {...__sveltets_any(seeking=__sveltets_instanceOf(HTMLMediaElement).seeking)}
-    {...__sveltets_any(played=__sveltets_instanceOf(HTMLMediaElement).played)}
-    {...__sveltets_any(ended=__sveltets_instanceOf(HTMLMediaElement).ended)}
+    {...__sveltets_empty(duration=__sveltets_instanceOf(HTMLMediaElement).duration)}
+    {...__sveltets_empty(buffered=__sveltets_instanceOf(HTMLMediaElement).buffered)}
+    {...__sveltets_empty(seekable=__sveltets_instanceOf(HTMLMediaElement).seekable)}
+    {...__sveltets_empty(seeking=__sveltets_instanceOf(HTMLMediaElement).seeking)}
+    {...__sveltets_empty(played=__sveltets_instanceOf(HTMLMediaElement).played)}
+    {...__sveltets_empty(ended=__sveltets_instanceOf(HTMLMediaElement).ended)}
 ></video></>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
@@ -1,5 +1,5 @@
 <></>;function render() {
-<><input id="dom-input" type="radio" {...__sveltets_any(__sveltets_store_get(compile_options).generate)} value="dom"/></>
+<><input id="dom-input" type="radio" {...__sveltets_empty(__sveltets_store_get(compile_options).generate)} value="dom"/></>
 return { props: {}, slots: {} }}
 
 export default class Input__SvelteComponent_ {


### PR DESCRIPTION
As mentioned in https://github.com/sveltejs/language-tools/issues/347#issuecomment-663533996. Spread any on a template tag would suppress all other errors. Change `any` to empty object can fix it.

Before:
![圖片](https://user-images.githubusercontent.com/36730922/88453966-7ae1e280-ce9e-11ea-8c39-205470b65953.png)

After:
![圖片](https://user-images.githubusercontent.com/36730922/88453955-6271c800-ce9e-11ea-9ceb-e6e51358c2a5.png)

