### PR TITLE
fixes #5192: SvelteAction should allow void as return value - https:/…

### DIFF
--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -10,7 +10,7 @@ type AConstructorTypeOf<T> = new (...args:any[]) => T;
 type SvelteAction<U extends any[]> = (node: HTMLElement, ...args:U) => {
 	update?: (...args:U) => void,
 	destroy?: () => void
-}
+} | void
 
 
 type SvelteTransitionConfig = {


### PR DESCRIPTION
refers to https://github.com/sveltejs/svelte/issues/5192

This change allows to specify an action like this (just like you can do using js):

```typescript
const focusOnInit = (node) => node.focus()
```

instead of:

```typescript
const focusOnInit = (node) => { node.focus(); return {} }
```