### PR TITLE
Fix unused false positives

### DIFF
--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics-falsepositives.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics-falsepositives.svelte
@@ -1,8 +1,9 @@
 <script lang="typescript">
-export let noUsedBeforeDeclare: number;
+export let noUsedBeforeDeclare: number, anotherUsed: boolean;
 const blubb = 2;
 $: bla = blubb * 2;
 </script>
 <p on:click on:click></p>
 {bla}
 {noUsedBeforeDeclare}
+{anotherUsed}

--- a/packages/svelte2tsx/index.d.ts
+++ b/packages/svelte2tsx/index.d.ts
@@ -1,6 +1,11 @@
-type SvelteCompiledToTsx = {
-    code: string,
-    map: import("magic-string").SourceMap
+export interface SvelteCompiledToTsx {
+    code: string;
+    map: import("magic-string").SourceMap;
+    exportedNames: IExportedNames;
+}
+
+export interface IExportedNames {
+    has(name: string): boolean;
 }
 
 export default function svelte2tsx(

--- a/packages/svelte2tsx/src/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/nodes/ExportedNames.ts
@@ -1,11 +1,17 @@
-export class ExportedNames extends Map<
-    string,
-    {
-        type?: string;
-        identifierText?: string;
-        required?: boolean;
-    }
-> {
+export interface IExportedNames {
+    has(name: string): boolean;
+}
+
+export class ExportedNames
+    extends Map<
+        string,
+        {
+            type?: string;
+            identifierText?: string;
+            required?: boolean;
+        }
+    >
+    implements IExportedNames {
     /**
      * Creates a string from the collected props
      *

--- a/packages/svelte2tsx/src/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/nodes/ExportedNames.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
 export interface IExportedNames {
     has(name: string): boolean;
 }

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -1032,5 +1032,6 @@ export function svelte2tsx(
     return {
         code: str.toString(),
         map: str.generateMap({ hires: true, source: options?.filename }),
+        exportedNames
     };
 }


### PR DESCRIPTION
`svelte2tsx` now also returns `exportedNames` through which we can easily get the props.
#277 