### PR TITLE
(fix) empty diagnostics on close

### DIFF
--- a/packages/language-server/src/lib/DiagnosticsManager.ts
+++ b/packages/language-server/src/lib/DiagnosticsManager.ts
@@ -8,8 +8,8 @@ export class DiagnosticsManager {
     constructor(
         private sendDiagnostics: SendDiagnostics,
         private docManager: DocumentManager,
-        private getDiagnostics: GetDiagnostics
-    ) { }
+        private getDiagnostics: GetDiagnostics,
+    ) {}
 
     updateAll() {
         this.docManager.getAllOpenedByClient().forEach((doc) => {
@@ -22,6 +22,13 @@ export class DiagnosticsManager {
         this.sendDiagnostics({
             uri: document.getURL(),
             diagnostics,
+        });
+    }
+
+    removeDiagnostics(document: Document) {
+        this.sendDiagnostics({
+            uri: document.getURL(),
+            diagnostics: [],
         });
     }
 }

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -259,6 +259,9 @@ export function startServer(options?: LSOptions) {
         'documentChange',
         _.debounce(async (document: Document) => diagnosticsManager.update(document), 500),
     );
+    docManager.on('documentClose', (document: Document) =>
+        diagnosticsManager.removeDiagnostics(document),
+    );
 
     // The language server protocol does not have a specific "did rename/move files" event,
     // so we create our own in the extension client and handle it here


### PR DESCRIPTION
When a document is closed by the user, make its diagnostics disappear from the Problems tab
#316