### PR TITLE
(fix) make bind:this understand specific element type again

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/RenameProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/RenameProvider.ts
@@ -311,13 +311,18 @@ export class RenameProviderImpl implements RenameProvider {
             }
 
             const content = snapshot.getText(0, snapshot.getLength());
-            const svelteInstanceOfFn = '__sveltets_instanceOf(';
             // When the user renames a Svelte component, ts will also want to rename
-            // `__sveltets_instanceOf(TheComponentToRename)`. Prevent that.
+            // `__sveltets_instanceOf(TheComponentToRename)` or
+            // `__sveltets_ensureType(TheComponentToRename,..`. Prevent that.
             return (
-                content.lastIndexOf(svelteInstanceOfFn, loc.textSpan.start) !==
-                loc.textSpan.start - svelteInstanceOfFn.length
+                notPrecededBy('__sveltets_instanceOf(') && notPrecededBy('__sveltets_ensureType(')
             );
+
+            function notPrecededBy(str: string) {
+                return (
+                    content.lastIndexOf(str, loc.textSpan.start) !== loc.textSpan.start - str.length
+                );
+            }
         });
     }
 

--- a/packages/svelte2tsx/src/htmlxtojsx.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx.ts
@@ -214,12 +214,8 @@ export function convertHtmlxToJsx(
 
             if (thisType) {
                 str.remove(attr.start, attr.expression.start);
-                str.appendLeft(attr.expression.start, '{...__sveltets_empty(');
-                str.overwrite(
-                    attr.expression.end,
-                    attr.end,
-                    `=__sveltets_instanceOf(${thisType}))}`
-                );
+                str.appendLeft(attr.expression.start, `{...__sveltets_ensureType(${thisType}, `);
+                str.overwrite(attr.expression.end, attr.end, ')}');
                 return;
             }
         }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-component/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-component/expected.jsx
@@ -1,1 +1,1 @@
-<><Component type="radio" {...__sveltets_empty(element=__sveltets_instanceOf(Component))} value="Plain"/></>
+<><Component type="radio" {...__sveltets_ensureType(Component, element)} value="Plain"/></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-body/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-body/expected.jsx
@@ -1,1 +1,1 @@
-<><sveltebody {...__sveltets_empty(element=__sveltets_instanceOf(HTMLBodyElement))} /></>
+<><sveltebody {...__sveltets_ensureType(HTMLBodyElement, element)} /></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-component/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-component/expected.jsx
@@ -1,1 +1,1 @@
-<><sveltecomponent this={A} {...__sveltets_empty(element=__sveltets_instanceOf(__sveltets_componentType()))} /></>
+<><sveltecomponent this={A} {...__sveltets_ensureType(__sveltets_componentType(), element)} /></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-self/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-self/expected.jsx
@@ -1,3 +1,3 @@
 <>{() => {if (false){<>
-    <svelteself {...__sveltets_empty(element=__sveltets_instanceOf(__sveltets_componentType()))} />
+    <svelteself {...__sveltets_ensureType(__sveltets_componentType(), element)} />
 </>}}}</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this/expected.jsx
@@ -1,1 +1,1 @@
-<><input type="radio" {...__sveltets_empty(element=__sveltets_instanceOf(HTMLElement))} value="Plain"/></>
+<><input type="radio" {...__sveltets_ensureType(HTMLElement, element)} value="Plain"/></>

--- a/packages/svelte2tsx/test/sourcemaps/repl.html
+++ b/packages/svelte2tsx/test/sourcemaps/repl.html
@@ -135,7 +135,7 @@ function render() {
 				<TableOfContents sections={sections} slug={slug} selected={selected}/>
 			</div>
 
-			<div class="chapter-markup" {...__sveltets_empty(scrollable=__sveltets_instanceOf(HTMLElement))}>
+			<div class="chapter-markup" {...__sveltets_ensureType(HTMLElement, scrollable)}>
 				{ chapter.html}
 
 				<div class="controls">
@@ -159,7 +159,7 @@ function render() {
 
 		<div class="tutorial-repl">
 			<Repl
-				{...__sveltets_empty(repl=__sveltets_instanceOf(Repl))}
+				{...__sveltets_ensureType(Repl, repl)}
 				workersUrl="workers"
 				svelteUrl={svelteUrl}
 				rollupUrl={rollupUrl}


### PR DESCRIPTION
The changes done in #363 can be reverted because the bug which the PR was fixing (#338) is also fixed through #314
#400
