### PR TITLE
(feat) support for message events

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -668,9 +668,11 @@
       onbeforeprint?: EventHandler<Event, Window>;
       onafterprint?: EventHandler<Event, Window>;
       onlanguagechange?: EventHandler<Event, Window>;
+      onmessage?: EventHandler<MessageEvent, Window>;
+      onmessageerror?: EventHandler<MessageEvent, Window>;
       onoffline?: EventHandler<Event, Window>;
       ononline?: EventHandler<Event, Window>;
-      onbeforeunload?: EventHandler<Event, Window>;
+      onbeforeunload?: EventHandler<BeforeUnloadEvent, Window>;
       onunload?: EventHandler<Event, Window>;
       onstorage?: EventHandler<StorageEvent, Window>;
       onhashchange?: EventHandler<HashChangeEvent, Window>;


### PR DESCRIPTION
PR https://github.com/sveltejs/language-tools/pull/388 misses the [`onmessage` event](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onmessage) for window and lacks good types for the `onbeforeunload` event. This PR takes care of that.