### PR TITLE
Update svelte-jsx.d.ts

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -198,6 +198,8 @@
 
       // Transition Events
       ontransitionend?: TransitionEventHandler<T>;
+                      
+      // Vanilla Events     
       onoutrostart?: EventHandler<CustomEvent<null>, T>;
       onoutroend?: EventHandler<CustomEvent<null>, T>;
       onintrostart?: EventHandler<CustomEvent<null>, T>;

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -199,7 +199,7 @@
       // Transition Events
       ontransitionend?: TransitionEventHandler<T>;
                       
-      // Vanilla Events     
+      // Svelte Transition Events
       onoutrostart?: EventHandler<CustomEvent<null>, T>;
       onoutroend?: EventHandler<CustomEvent<null>, T>;
       onintrostart?: EventHandler<CustomEvent<null>, T>;

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -198,6 +198,10 @@
 
       // Transition Events
       ontransitionend?: TransitionEventHandler<T>;
+      onoutrostart?: TransitionEventHandler<T>;
+      onoutroend?: TransitionEventHandler<T>;
+      onintrostart?: TransitionEventHandler<T>;
+      onintroend?: TransitionEventHandler<T>;
 
       // Message Events
       onmessage?: MessageEventHandler<T>;

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -198,10 +198,10 @@
 
       // Transition Events
       ontransitionend?: TransitionEventHandler<T>;
-      onoutrostart?: TransitionEventHandler<T>;
-      onoutroend?: TransitionEventHandler<T>;
-      onintrostart?: TransitionEventHandler<T>;
-      onintroend?: TransitionEventHandler<T>;
+      onoutrostart?: EventHandler<CustomEvent<null>, T>;
+      onoutroend?: EventHandler<CustomEvent<null>, T>;
+      onintrostart?: EventHandler<CustomEvent<null>, T>;
+      onintroend?: EventHandler<CustomEvent<null>, T>;
 
       // Message Events
       onmessage?: MessageEventHandler<T>;

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -198,7 +198,7 @@
 
       // Transition Events
       ontransitionend?: TransitionEventHandler<T>;
-                      
+
       // Svelte Transition Events
       onoutrostart?: EventHandler<CustomEvent<null>, T>;
       onoutroend?: EventHandler<CustomEvent<null>, T>;


### PR DESCRIPTION
Adding missing type definitions for on:intro and on:outro start and end events. this project is using the frontendmasters course from https://github.com/Rich-Harris/cameoparison-starter

```
Type '{ onoutrostart: () => boolean; onoutroend: () => boolean; class: string; }' is not assignable to type 'HTMLProps<HTMLDivElement>'.
  Property 'onoutrostart' does not exist on type 'HTMLProps<HTMLDivElement>'.ts(2322)
```