### PR TITLE
(fix) allow empty initializationOptions

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -84,7 +84,7 @@ export function startServer(options?: LSOptions) {
             Logger.error('No workspace path set');
         }
 
-        pluginHost.initialize(!!evt.initializationOptions.dontFilterIncompleteCompletions);
+        pluginHost.initialize(!!evt.initializationOptions?.dontFilterIncompleteCompletions);
         pluginHost.updateConfig(evt.initializationOptions?.config);
         pluginHost.register(
             (sveltePlugin = new SveltePlugin(


### PR DESCRIPTION
Allow to start the language server with empty `initializationOptions`. Right now it throws an error 
`Cannot read property 'dontFilterIncompleteCompletions' of null (Internal Error)`