### PR TITLE
(feat) transform number attrs

### DIFF
--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-number/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-number/expected.jsx
@@ -1,0 +1,2 @@
+<><SomeComponent tabindex="1" />
+<div tabindex={1} maxlength={1} minlength={1} span={1} role="none"></div></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-number/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-number/input.svelte
@@ -1,0 +1,2 @@
+<SomeComponent tabindex="1" />
+<div tabindex="1" maxlength=1 minlength={1} span="{1}" role="none"></div>


### PR DESCRIPTION
#366

When
1. an attribute expects input of number only
2. its value is of type number
3. attribute is written as string

then transform it
Example: `<div tabindex="1"></div>` --> `<div tabindex={1}></div>`