### PR TITLE
Fix paths on Windows

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -29,7 +29,7 @@ import {
     SveltePlugin,
     TypeScriptPlugin,
 } from './plugins';
-import { urlToPath } from './utils';
+import { urlToPath, normalizeUrl } from './utils';
 
 namespace TagCloseRequest {
     export const type: RequestType<
@@ -77,7 +77,7 @@ export function startServer(options?: LSOptions) {
     }
 
     const docManager = new DocumentManager(
-        (textDocument) => new Document(textDocument.uri, textDocument.text),
+        (textDocument) => new Document(normalizeUrl(textDocument.uri), textDocument.text),
     );
     const configManager = new LSConfigManager();
     const pluginHost = new PluginHost(docManager, configManager);
@@ -191,10 +191,10 @@ export function startServer(options?: LSOptions) {
 
     connection.onDidOpenTextDocument((evt) => {
         docManager.openDocument(evt.textDocument);
-        docManager.markAsOpenedInClient(evt.textDocument.uri);
+        docManager.markAsOpenedInClient(normalizeUrl(evt.textDocument.uri));
     });
 
-    connection.onDidCloseTextDocument((evt) => docManager.closeDocument(evt.textDocument.uri));
+    connection.onDidCloseTextDocument((evt) => docManager.closeDocument(normalizeUrl(evt.textDocument.uri)));
     connection.onDidChangeTextDocument((evt) =>
         docManager.updateDocument(evt.textDocument, evt.contentChanges),
     );

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -1,6 +1,8 @@
 import { URI } from 'vscode-uri';
 import { Position, Range } from 'vscode-languageserver';
 
+const isWindows = process.platform === 'win32';
+
 export function clamp(num: number, min: number, max: number): number {
     return Math.max(min, Math.min(max, num));
 }
@@ -14,7 +16,15 @@ export function urlToPath(stringUrl: string): string | null {
 }
 
 export function pathToUrl(path: string) {
-    return URI.file(path).toString();
+    const url = URI.file(path).toString();
+    // On Windows, first %3A should be part of drive name.
+    return isWindows ? url.replace(/%3A/, ':') : url;
+}
+
+export function normalizeUrl(stringUrl: string) {
+    // vscode-uri use lower-case drive letter
+    // https://github.com/microsoft/vscode-uri/blob/95e03c06f87d38f25eda1ae3c343fe5b7eec3f52/src/index.ts#L1017
+    return isWindows ? stringUrl.replace(/file:\/\/\/[A-Z]:/, (s) => s.toLowerCase()) : stringUrl;
 }
 
 export function flatten<T>(arr: T[][]): T[] {

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -1,8 +1,6 @@
 import { URI } from 'vscode-uri';
 import { Position, Range } from 'vscode-languageserver';
 
-const isWindows = process.platform === 'win32';
-
 export function clamp(num: number, min: number, max: number): number {
     return Math.max(min, Math.min(max, num));
 }
@@ -16,15 +14,13 @@ export function urlToPath(stringUrl: string): string | null {
 }
 
 export function pathToUrl(path: string) {
-    const url = URI.file(path).toString();
-    // On Windows, first %3A should be part of drive name.
-    return isWindows ? url.replace(/%3A/, ':') : url;
+    return URI.file(path).toString();
 }
 
 export function normalizeUrl(stringUrl: string) {
     // vscode-uri use lower-case drive letter
     // https://github.com/microsoft/vscode-uri/blob/95e03c06f87d38f25eda1ae3c343fe5b7eec3f52/src/index.ts#L1017
-    return isWindows ? stringUrl.replace(/file:\/\/\/[A-Z]:/, (s) => s.toLowerCase()) : stringUrl;
+    return URI.parse(stringUrl).toString();
 }
 
 export function flatten<T>(arr: T[][]): T[] {


### PR DESCRIPTION
On Windows, definition does not work when svelte-language-server is started with `--stdio`. This is because that vscode-uri always use lower-case drive letter. vscode is also use vscode-uri. So it always works correctly. But Language Server Client may send request  with upper-case drive letter.

This change add normalizeUrl to fix URLs.