### PR TITLE
(fix) destructuring inside $

### DIFF
--- a/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
+++ b/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
@@ -4,7 +4,34 @@ import MagicString from 'magic-string';
 export class ImplicitTopLevelNames {
     private map = new Map<string, ts.LabeledStatement>();
 
-    add(identifier: ts.Identifier, node: ts.LabeledStatement, astOffset: number, str: MagicString) {
+    add(
+        binaryExpr: ts.BinaryExpression,
+        node: ts.LabeledStatement,
+        rootVariables: Set<string>,
+        astOffset: number,
+        str: MagicString,
+    ) {
+        if (ts.isIdentifier(binaryExpr.left)) {
+            this.addSingle(binaryExpr.left, node);
+        } else if (ts.isObjectLiteralExpression(binaryExpr.left)) {
+            this.getPropsOfObjectLiteral(binaryExpr.left).map((prop) =>
+                this.addSingle(prop.name, node),
+            );
+
+            if (
+                ts.isExpressionStatement(node.statement) &&
+                ts.isParenthesizedExpression(node.statement.expression) &&
+                this.objectLiteralContainsNoTopLevelNames(binaryExpr.left, rootVariables)
+            ) {
+                const start = node.statement.expression.getStart() + astOffset;
+                str.remove(start, start + 1);
+                const end = node.statement.expression.getEnd() + astOffset - 1;
+                str.remove(end, end + 1);
+            }
+        }
+    }
+
+    private addSingle(identifier: ts.Identifier, node: ts.LabeledStatement) {
         const name = identifier.text;
 
         // svelte won't let you create a variable with $ prefix anyway
@@ -12,17 +39,6 @@ export class ImplicitTopLevelNames {
 
         if (!this.map.has(name) && !isPotentialStore) {
             this.map.set(name, node);
-        }
-
-        // TODO don't do this if the variable inside the expression is defined explicetly
-        if (
-            ts.isExpressionStatement(node.statement) &&
-            ts.isParenthesizedExpression(node.statement.expression)
-        ) {
-            const start = node.statement.expression.getStart() + astOffset;
-            str.remove(start, start + 1);
-            const end = node.statement.expression.getEnd() + astOffset - 1;
-            str.remove(end, end + 1);
         }
     }
 
@@ -37,9 +53,21 @@ export class ImplicitTopLevelNames {
         }
     }
 
-    private propertyNamesOfObjectLiteral(node: ts.ObjectLiteralExpression) {
-        return node.properties
-            .filter(ts.isShorthandPropertyAssignment)
-            .map((prop) => prop.name.text);
+    private objectLiteralContainsNoTopLevelNames(
+        node: ts.ObjectLiteralExpression,
+        rootVariables: Set<string>,
+    ) {
+        return this.getPropsOfObjectLiteral(node).every(
+            (prop) => !rootVariables.has(prop.name.text),
+        );
+    }
+
+    private getPropsOfObjectLiteral(node: ts.ObjectLiteralExpression) {
+        return (
+            node.properties
+                // TODO could also be a property assignment,
+                // fix if it ever occurs in the wild.
+                .filter(ts.isShorthandPropertyAssignment)
+        );
     }
 }

--- a/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
+++ b/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import MagicString from 'magic-string';
-import { getBinaryAssignmentExpr } from '../utils/tsAst';
+import { getBinaryAssignmentExpr, extractIdentifiers } from '../utils/tsAst';
 
 export class ImplicitTopLevelNames {
     private map = new Set<ts.LabeledStatement>();
@@ -61,14 +61,12 @@ export class ImplicitTopLevelNames {
             return [];
         }
 
-        // svelte won't let you create a variable with $ prefix (reserved for stores)
-        if (ts.isIdentifier(leftHandSide) && !leftHandSide.text.startsWith('$')) {
-            return [leftHandSide.text];
-        }
-
-        if (ts.isObjectLiteralExpression(leftHandSide)) {
-            return this.getPropsOfObjectLiteral(leftHandSide).map((prop) => prop.name.text);
-        }
+        return (
+            extractIdentifiers(leftHandSide)
+                .map((id) => id.text)
+                // svelte won't let you create a variable with $ prefix (reserved for stores)
+                .filter((name) => !name.startsWith('$'))
+        );
     }
 
     private objectLiteralContainsNoTopLevelNames(

--- a/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
+++ b/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
@@ -1,0 +1,45 @@
+import ts from 'typescript';
+import MagicString from 'magic-string';
+
+export class ImplicitTopLevelNames {
+    private map = new Map<string, ts.LabeledStatement>();
+
+    add(identifier: ts.Identifier, node: ts.LabeledStatement, astOffset: number, str: MagicString) {
+        const name = identifier.text;
+
+        // svelte won't let you create a variable with $ prefix anyway
+        const isPotentialStore = name.startsWith('$');
+
+        if (!this.map.has(name) && !isPotentialStore) {
+            this.map.set(name, node);
+        }
+
+        // TODO don't do this if the variable inside the expression is defined explicetly
+        if (
+            ts.isExpressionStatement(node.statement) &&
+            ts.isParenthesizedExpression(node.statement.expression)
+        ) {
+            const start = node.statement.expression.getStart() + astOffset;
+            str.remove(start, start + 1);
+            const end = node.statement.expression.getEnd() + astOffset - 1;
+            str.remove(end, end + 1);
+        }
+    }
+
+    modifyCode(rootVariables: Set<string>, astOffset: number, str: MagicString) {
+        for (const [name, node] of this.map.entries()) {
+            if (!rootVariables.has(name)) {
+                const pos = node.label.getStart();
+                // remove '$:' label
+                str.remove(pos + astOffset, pos + astOffset + 2);
+                str.prependRight(pos + astOffset, `let `);
+            }
+        }
+    }
+
+    private propertyNamesOfObjectLiteral(node: ts.ObjectLiteralExpression) {
+        return node.properties
+            .filter(ts.isShorthandPropertyAssignment)
+            .map((prop) => prop.name.text);
+    }
+}

--- a/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
+++ b/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
@@ -23,6 +23,11 @@ export class ImplicitTopLevelNames {
                 ts.isParenthesizedExpression(node.statement.expression) &&
                 this.objectLiteralContainsNoTopLevelNames(binaryExpr.left, rootVariables)
             ) {
+                // Expression is of type `$: ({a} = b);`
+                // Remove the surrounding braces so that later the the transformation
+                // to `let {a} = b;` produces valid code.
+                // Do this now, not later, because we use `remove` which would
+                // remove everything that we appended/prepended previously.
                 const start = node.statement.expression.getStart() + astOffset;
                 str.remove(start, start + 1);
                 const end = node.statement.expression.getEnd() + astOffset - 1;

--- a/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
+++ b/packages/svelte2tsx/src/nodes/ImplicitTopLevelNames.ts
@@ -1,36 +1,16 @@
 import ts from 'typescript';
 import MagicString from 'magic-string';
-import { getBinaryAssignmentExpr, extractIdentifiers } from '../utils/tsAst';
+import {
+    getBinaryAssignmentExpr,
+    extractIdentifiers,
+    isParenthesizedObjectOrArrayLiteralExpression,
+} from '../utils/tsAst';
 
 export class ImplicitTopLevelNames {
     private map = new Set<ts.LabeledStatement>();
 
-    add(
-        binaryExpr: ts.BinaryExpression,
-        node: ts.LabeledStatement,
-        rootVariables: Set<string>,
-        astOffset: number,
-        str: MagicString,
-    ) {
+    add(node: ts.LabeledStatement) {
         this.map.add(node);
-
-        if (
-            ts.isExpressionStatement(node.statement) &&
-            ts.isParenthesizedExpression(node.statement.expression) &&
-            (ts.isObjectLiteralExpression(binaryExpr.left) ||
-                ts.isArrayLiteralExpression(binaryExpr.left)) &&
-            this.containsNoTopLevelNames(binaryExpr.left, rootVariables)
-        ) {
-            // Expression is of type `$: ({a} = b);`
-            // Remove the surrounding braces so that later the the transformation
-            // to `let {a} = b;` produces valid code.
-            // Do this now, not later, because we use `remove` which would
-            // remove everything that we appended/prepended previously.
-            const start = node.statement.expression.getStart() + astOffset;
-            str.remove(start, start + 1);
-            const end = node.statement.expression.getEnd() + astOffset - 1;
-            str.remove(end, end + 1);
-        }
     }
 
     modifyCode(rootVariables: Set<string>, astOffset: number, str: MagicString) {
@@ -40,14 +20,15 @@ export class ImplicitTopLevelNames {
                 continue;
             }
 
-            const implicitTopLevelNames = this.getNames(node).filter(
-                (name) => !rootVariables.has(name),
-            );
+            const implicitTopLevelNames = names.filter((name) => !rootVariables.has(name));
             const pos = node.label.getStart();
-            if (names.length === implicitTopLevelNames.length) {
+
+            if (this.hasOnlyImplicitTopLevelNames(names, implicitTopLevelNames)) {
                 // remove '$:' label
                 str.remove(pos + astOffset, pos + astOffset + 2);
                 str.prependRight(pos + astOffset, `let `);
+
+                this.removeBracesFromParenthizedExpression(node, astOffset, str);
             } else {
                 implicitTopLevelNames.forEach((name) => {
                     str.prependRight(pos + astOffset, `let ${name};\n`);
@@ -70,10 +51,26 @@ export class ImplicitTopLevelNames {
         );
     }
 
-    private containsNoTopLevelNames(
-        node: ts.ObjectLiteralExpression | ts.ArrayLiteralExpression,
-        rootVariables: Set<string>,
+    private hasOnlyImplicitTopLevelNames(names: string[], implicitTopLevelNames: string[]) {
+        return names.length === implicitTopLevelNames.length;
+    }
+
+    private removeBracesFromParenthizedExpression(
+        node: ts.LabeledStatement,
+        astOffset: number,
+        str: MagicString,
     ) {
-        return extractIdentifiers(node).every((prop) => !rootVariables.has(prop.text));
+        // If expression is of type `$: ({a} = b);`,
+        // remove the surrounding braces so that the transformation
+        // to `let {a} = b;` produces valid code.
+        if (
+            ts.isExpressionStatement(node.statement) &&
+            isParenthesizedObjectOrArrayLiteralExpression(node.statement.expression)
+        ) {
+            const start = node.statement.expression.getStart() + astOffset;
+            str.overwrite(start, start + 1, '', { contentOnly: true });
+            const end = node.statement.expression.getEnd() + astOffset - 1;
+            str.overwrite(end, end + 1, '', { contentOnly: true });
+        }
     }
 }

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -769,13 +769,13 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
         ) {
             const binaryExpression = getBinaryAssignmentExpr(node);
             if (binaryExpression) {
-                if (ts.isIdentifier(binaryExpression.left)) {
-                    implicitTopLevelNames.add(binaryExpression.left, node, astOffset, str);
-                } else if (ts.isObjectLiteralExpression(binaryExpression.left)) {
-                    binaryExpression.left.properties
-                        .filter(ts.isShorthandPropertyAssignment)
-                        .map((prop) => implicitTopLevelNames.add(prop.name, node, astOffset, str));
-                }
+                implicitTopLevelNames.add(
+                    binaryExpression,
+                    node,
+                    rootScope.declared,
+                    astOffset,
+                    str,
+                );
 
                 wrapExpressionWithInvalidate(binaryExpression.right);
             } else {

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -639,7 +639,6 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
         });
     };
 
-    const semiRegex = /^\s*;/;
     const wrapExpressionWithInvalidate = (expression: ts.Expression | undefined) => {
         if (!expression) {
             return;
@@ -656,10 +655,8 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
 
         str.prependLeft(start, '__sveltets_invalidate(() => ');
         str.appendRight(end, ')');
-
-        if (!semiRegex.test(htmlx.substring(end))) {
-            str.appendRight(end, ';');
-        }
+        // Not adding ';' at the end because right now this function is only invoked
+        // in situations where there is a line break of ; guaranteed to be present (else the code is invalid)
     };
 
     const walk = (node: ts.Node, parent: ts.Node) => {

--- a/packages/svelte2tsx/src/svelte2tsx.ts
+++ b/packages/svelte2tsx/src/svelte2tsx.ts
@@ -766,14 +766,7 @@ function processInstanceScriptContent(str: MagicString, script: Node): InstanceS
         ) {
             const binaryExpression = getBinaryAssignmentExpr(node);
             if (binaryExpression) {
-                implicitTopLevelNames.add(
-                    binaryExpression,
-                    node,
-                    rootScope.declared,
-                    astOffset,
-                    str,
-                );
-
+                implicitTopLevelNames.add(node);
                 wrapExpressionWithInvalidate(binaryExpression.right);
             } else {
                 const start = node.getStart() + astOffset;

--- a/packages/svelte2tsx/src/utils/tsAst.ts
+++ b/packages/svelte2tsx/src/utils/tsAst.ts
@@ -37,6 +37,20 @@ export function getBinaryAssignmentExpr(
 }
 
 /**
+ * Returns true if node is like `({bla} ..)` or `([bla] ...)`
+ */
+export function isParenthesizedObjectOrArrayLiteralExpression(
+    node: ts.Expression,
+): node is ts.ParenthesizedExpression {
+    return (
+        ts.isParenthesizedExpression(node) &&
+        ts.isBinaryExpression(node.expression) &&
+        (ts.isObjectLiteralExpression(node.expression.left) ||
+            ts.isArrayLiteralExpression(node.expression.left))
+    );
+}
+
+/**
  *
  * Adapted from https://github.com/Rich-Harris/periscopic/blob/d7a820b04e1f88b452313ab3e54771b352f0defb/src/index.ts#L150
  */

--- a/packages/svelte2tsx/src/utils/tsAst.ts
+++ b/packages/svelte2tsx/src/utils/tsAst.ts
@@ -3,3 +3,33 @@ import ts from 'typescript';
 export function findExortKeyword(node: ts.Node) {
     return node.modifiers?.find((x) => x.kind == ts.SyntaxKind.ExportKeyword);
 }
+
+/**
+ * Node is like `bla = ...` or `{bla} = ...`
+ */
+function isAssignmentBinaryExpr(node: ts.Expression): node is ts.BinaryExpression {
+    return (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind == ts.SyntaxKind.EqualsToken &&
+        (ts.isIdentifier(node.left) || ts.isObjectLiteralExpression(node.left))
+    );
+}
+
+/**
+ * Returns if node is like `$: bla = ...` or `$: ({bla} = ...)`
+ */
+export function getBinaryAssignmentExpr(
+    node: ts.LabeledStatement,
+): ts.BinaryExpression | undefined {
+    if (ts.isExpressionStatement(node.statement)) {
+        if (isAssignmentBinaryExpr(node.statement.expression)) {
+            return node.statement.expression;
+        }
+        if (
+            ts.isParenthesizedExpression(node.statement.expression) &&
+            isAssignmentBinaryExpr(node.statement.expression.expression)
+        ) {
+            return node.statement.expression.expression;
+        }
+    }
+}

--- a/packages/svelte2tsx/src/utils/tsAst.ts
+++ b/packages/svelte2tsx/src/utils/tsAst.ts
@@ -5,18 +5,20 @@ export function findExortKeyword(node: ts.Node) {
 }
 
 /**
- * Node is like `bla = ...` or `{bla} = ...`
+ * Node is like `bla = ...` or `{bla} = ...` or `[bla] = ...`
  */
 function isAssignmentBinaryExpr(node: ts.Expression): node is ts.BinaryExpression {
     return (
         ts.isBinaryExpression(node) &&
         node.operatorToken.kind == ts.SyntaxKind.EqualsToken &&
-        (ts.isIdentifier(node.left) || ts.isObjectLiteralExpression(node.left))
+        (ts.isIdentifier(node.left) ||
+            ts.isObjectLiteralExpression(node.left) ||
+            ts.isArrayLiteralExpression(node.left))
     );
 }
 
 /**
- * Returns if node is like `$: bla = ...` or `$: ({bla} = ...)`
+ * Returns if node is like `$: bla = ...` or `$: ({bla} = ...)` or `$: [bla] = ...=`
  */
 export function getBinaryAssignmentExpr(
     node: ts.LabeledStatement,

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
@@ -8,6 +8,14 @@
   let bla4;
   let bla5;
 $: ({ bla4, bla5 } = __sveltets_invalidate(() => __sveltets_store_get(data)))
+
+  let  [ count ] = __sveltets_invalidate(() => __sveltets_store_get(data));
+  let  [ count2 ] = __sveltets_invalidate(() => __sveltets_store_get(data))
+  let count3;
+  $: ([ count3 ] = __sveltets_invalidate(() => __sveltets_store_get(data)))
+  let bla4;
+  let bla5;
+$: ([ bla4, bla5 ] = __sveltets_invalidate(() => __sveltets_store_get(data)))
 ;
 () => (<></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
@@ -1,14 +1,14 @@
 <></>;function render() {
 
-  let  {bla} = __sveltets_invalidate(() => blubb);;
-  let  {bla2} = __sveltets_invalidate(() => blubb);
+  let  {bla} = __sveltets_invalidate(() => blubb);
+  let  {bla2} = __sveltets_invalidate(() => blubb)
   let bla3;
-  $: ({ bla3 } = __sveltets_invalidate(() => blubb));
-  
-  let  { count } = __sveltets_invalidate(() => __sveltets_store_get(data));;
-  let  { count2 } = __sveltets_invalidate(() => __sveltets_store_get(data));
+  $: ({ bla3 } = __sveltets_invalidate(() => blubb))
+
+  let  { count } = __sveltets_invalidate(() => __sveltets_store_get(data));
+  let  { count2 } = __sveltets_invalidate(() => __sveltets_store_get(data))
   let count3;
-  $: ({ count3 } = __sveltets_invalidate(() => __sveltets_store_get(data)));
+  $: ({ count3 } = __sveltets_invalidate(() => __sveltets_store_get(data)))
 ;
 () => (<></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
@@ -1,14 +1,13 @@
+///<reference types="svelte" />
 <></>;function render() {
-
-  let  {bla} = __sveltets_invalidate(() => blubb);
-  let  {bla2} = __sveltets_invalidate(() => blubb)
-  let bla3;
-  $: ({ bla3 } = __sveltets_invalidate(() => blubb))
 
   let  { count } = __sveltets_invalidate(() => __sveltets_store_get(data));
   let  { count2 } = __sveltets_invalidate(() => __sveltets_store_get(data))
   let count3;
   $: ({ count3 } = __sveltets_invalidate(() => __sveltets_store_get(data)))
+  let bla4;
+  let bla5;
+$: ({ bla4, bla5 } = __sveltets_invalidate(() => __sveltets_store_get(data)))
 ;
 () => (<></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
@@ -1,0 +1,17 @@
+<></>;function render() {
+
+  let  {bla} = __sveltets_invalidate(() => blubb);;
+  let  {bla2} = __sveltets_invalidate(() => blubb);
+  let bla3;
+  $: ({ bla3 } = __sveltets_invalidate(() => blubb));
+  
+  let  { count } = __sveltets_invalidate(() => __sveltets_store_get(data));;
+  let  { count2 } = __sveltets_invalidate(() => __sveltets_store_get(data));
+  let count3;
+  $: ({ count3 } = __sveltets_invalidate(() => __sveltets_store_get(data)));
+;
+() => (<></>);
+return { props: {}, slots: {}, getters: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(render)) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/input.svelte
@@ -1,0 +1,11 @@
+<script>
+  $: ({bla} = blubb);
+  $: ({bla2} = blubb)
+  let bla3;
+  $: ({ bla3 } = blubb)
+
+  $: ({ count } = $data);
+  $: ({ count2 } = $data)
+  let count3;
+  $: ({ count3 } = $data)
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/input.svelte
@@ -1,11 +1,15 @@
 <script>
-  $: ({bla} = blubb);
-  $: ({bla2} = blubb)
-  let bla3;
-  $: ({ bla3 } = blubb)
-
   $: ({ count } = $data);
   $: ({ count2 } = $data)
   let count3;
   $: ({ count3 } = $data)
+  let bla4;
+  $: ({ bla4, bla5 } = $data)
+
+  $: ([ count ] = $data);
+  $: ([ count2 ] = $data)
+  let count3;
+  $: ([ count3 ] = $data)
+  let bla4;
+  $: ([ bla4, bla5 ] = $data)
 </script>


### PR DESCRIPTION
#444

TODOs:
- [x] don't remove the `( )` around the expression if there is no transformation from `$: ...` to `let ...`
- [x] remove the `( )` in such a way that the inner transformations are preserved and not removed as well