### PR TITLE
(fix) blank if tag content

### DIFF
--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -257,6 +257,35 @@ describe('document/utils', () => {
                 },
             });
         });
+
+        it('extract tag correctly with #if and < operator', () => {
+            const text = `
+            {#if value < 3}
+              <div>
+                bla
+              </div>
+            {:else if value < 4}
+            {/if}
+          <script>let value = 2</script>
+
+          <div>
+            {#if value < 3}
+              <div>
+                bla
+              </div>
+            {:else if value < 4}
+            {/if}
+          </div>`;
+            assert.deepStrictEqual(extractScriptTags(text)?.script, {
+                content: 'let value = 2',
+                attributes: {},
+                start: 159,
+                end: 172,
+                startPos: Position.create(7, 18),
+                endPos: Position.create(7, 31),
+                container: { start: 151, end: 181 },
+            });
+        });
     });
 
     describe('#getLineAtPosition', () => {


### PR DESCRIPTION
if-blocks can contain the `<` operator, which mistakingly is
parsed as a "open tag" character by the html parser.
To prevent this, just replace the whole content inside the if with whitespace.
#326

Also remove the `i` modifier from regex because {#If or {#IF are not valid.