### PR TITLE
(feat) show nearby locs for svelte-check output

### DIFF
--- a/packages/svelte-check/tsconfig.json
+++ b/packages/svelte-check/tsconfig.json
@@ -5,6 +5,7 @@
         "strict": true,
         "declaration": true,
         "outDir": "dist",
-        "composite": true
+        "composite": true,
+        "esModuleInterop": false
     }
 }


### PR DESCRIPTION
Instead of 10 prev/next chars, show the previous/next line of the diagnostic and the diagnostic line itself, highlighting the diagnostic range
#278