### PR TITLE
(fix) make organize imports work with module script

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -74,7 +74,10 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                         // Handle svelte2tsx wrong import mapping:
                         // The character after the last import maps to the start of the script
                         // TODO find a way to fix this in svelte2tsx and then remove this
-                        if (range.end.line === 0 && range.end.character === 1) {
+                        if (
+                            (range.end.line === 0 && range.end.character === 1) ||
+                            range.end.line < range.start.line
+                        ) {
                             edit.span.length -= 1;
                             range = mapRangeToOriginal(fragment, convertRange(fragment, edit.span));
                             range.end.character += 1;

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -165,6 +165,81 @@ describe('CodeActionsProvider', () => {
         ]);
     });
 
+    it('organizes imports with module script', async () => {
+        const { provider, document } = setup('organize-imports-with-module.svelte');
+
+        const codeActions = await provider.getCodeActions(
+            document,
+            Range.create(Position.create(1, 4), Position.create(1, 5)), // irrelevant
+            {
+                diagnostics: [],
+                only: [CodeActionKind.SourceOrganizeImports],
+            },
+        );
+        (<TextDocumentEdit>codeActions[0]?.edit?.documentChanges?.[0])?.edits.forEach(
+            (edit) => (edit.newText = harmonizeNewLines(edit.newText)),
+        );
+
+        assert.deepStrictEqual(codeActions, [
+            {
+                edit: {
+                    documentChanges: [
+                        {
+                            edits: [
+                                {
+                                    // eslint-disable-next-line max-len
+                                    newText: "import A from './A';\nimport { c } from './c';\n",
+                                    range: {
+                                        start: {
+                                            line: 1,
+                                            character: 2,
+                                        },
+                                        end: {
+                                            line: 2,
+                                            character: 0,
+                                        },
+                                    },
+                                },
+                                {
+                                    newText: '',
+                                    range: {
+                                        start: {
+                                            line: 6,
+                                            character: 2,
+                                        },
+                                        end: {
+                                            line: 7,
+                                            character: 2,
+                                        },
+                                    },
+                                },
+                                {
+                                    newText: '',
+                                    range: {
+                                        start: {
+                                            line: 7,
+                                            character: 2,
+                                        },
+                                        end: {
+                                            line: 7,
+                                            character: 22,
+                                        },
+                                    },
+                                },
+                            ],
+                            textDocument: {
+                                uri: getUri('organize-imports-with-module.svelte'),
+                                version: null,
+                            },
+                        },
+                    ],
+                },
+                kind: CodeActionKind.SourceOrganizeImports,
+                title: 'Organize Imports',
+            },
+        ]);
+    });
+
     it('should do extract into const refactor', async () => {
         const { provider, document } = setup('codeactions.svelte');
 

--- a/packages/language-server/test/plugins/typescript/testfiles/organize-imports-with-module.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/organize-imports-with-module.svelte
@@ -1,0 +1,11 @@
+<script context="module">
+  import {c} from './c';
+  // do whatever
+</script>
+
+<script lang="ts">
+  import B from './B';
+  import A from './A';
+</script>
+
+<A>{c}</A>


### PR DESCRIPTION
#221
```
<script context="module">
  import {c} from './c';
</script>

<script lang="ts">
  import B from './B';
  import A from './A';
</script>

<A>{c}</A>
```

---->

```
<script context="module">
  import A from './A';
  import { c } from './c';
</script>

<script lang="ts">

</script>

<A>{c}</A>
```