### PR TITLE
(fix) filter out component import if already one present

### DIFF
--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -95,3 +95,15 @@ export function regexLastIndexOf(text: string, regex: RegExp, endPos?: number) {
     }
     return lastIndexOf;
 }
+
+/**
+ * Get all matches of a regexp.
+ */
+export function getRegExpMatches(regex: RegExp, str: string) {
+    let matches: RegExpExecArray[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(str))) {
+        matches.push(match);
+    }
+    return matches;
+}


### PR DESCRIPTION
#462
Drawback: Also will mark commented out imports as already imported - but this seems like a bigger edge case than having double imports when doing barrel exports. @jasonlyu123  what's your opinion on this?