### PR TITLE
(chore) bump ts to 4.0, fix build/tests

### DIFF
--- a/packages/language-server/src/plugins/css/CSSDocument.ts
+++ b/packages/language-server/src/plugins/css/CSSDocument.ts
@@ -5,7 +5,7 @@ import { Document, DocumentMapper, ReadableDocument, TagInformation } from '../.
 
 export class CSSDocument extends ReadableDocument implements DocumentMapper {
     private styleInfo: Pick<TagInformation, 'attributes' | 'start' | 'end'>;
-    private _version = this.parent.version;
+    readonly version = this.parent.version;
 
     public stylesheet: Stylesheet;
     public languageId: string;
@@ -81,14 +81,6 @@ export class CSSDocument extends ReadableDocument implements DocumentMapper {
 
     getAttributes() {
         return this.styleInfo.attributes;
-    }
-
-    get version(): number {
-        return this._version;
-    }
-
-    set version(version: number) {
-        // ignore
     }
 
     private get language() {

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -25,85 +25,6 @@ describe('TypescriptPlugin', () => {
         return { plugin, document };
     }
 
-    it('provides diagnostics', async () => {
-        const { plugin, document } = setup('diagnostics.svelte');
-        const diagnostics = await plugin.getDiagnostics(document);
-
-        assert.deepStrictEqual(diagnostics, [
-            {
-                code: 2322,
-                message: "Type 'true' is not assignable to type 'string'.",
-                range: {
-                    start: {
-                        character: 32,
-                        line: 0,
-                    },
-                    end: {
-                        character: 35,
-                        line: 0,
-                    },
-                },
-                severity: 1,
-                source: 'ts',
-            },
-        ]);
-    });
-
-    it('provides typecheck diagnostics for js file when //@ts-check at top of script', async () => {
-        const { plugin, document } = setup('diagnostics-js-typecheck.svelte');
-        const diagnostics = await plugin.getDiagnostics(document);
-
-        assert.deepStrictEqual(diagnostics, [
-            {
-                code: 2339,
-                message: "Property 'bla' does not exist on type '1'.",
-                range: {
-                    start: {
-                        character: 4,
-                        line: 3,
-                    },
-                    end: {
-                        character: 7,
-                        line: 3,
-                    },
-                },
-                severity: 1,
-                source: 'js',
-            },
-        ]);
-    });
-
-    it('provides no typecheck diagnostics for js file', async () => {
-        const { plugin, document } = setup('diagnostics-js-notypecheck.svelte');
-        const diagnostics = await plugin.getDiagnostics(document);
-
-        assert.deepStrictEqual(diagnostics, []);
-    });
-
-    it('provides diagnostics when there is a parser error', async () => {
-        const { plugin, document } = setup('diagnostics-parsererror.svelte');
-        const diagnostics = await plugin.getDiagnostics(document);
-
-        assert.deepStrictEqual(diagnostics, [
-            {
-                code: -1,
-                message: 'You can only have one top-level <style> tag per component',
-                range: {
-                    start: {
-                        character: 0,
-                        line: 1,
-                    },
-                    end: {
-                        character: 0,
-                        line: 1,
-                    },
-                },
-                severity: 1,
-                source: 'js',
-            },
-        ]);
-    });
-
     it('provides basic hover info when no docstring exists', async () => {
         const { plugin, document } = setup('hoverinfo.svelte');
 
@@ -299,9 +220,8 @@ describe('TypescriptPlugin', () => {
         const snapshotManager = plugin.getSnapshotManager(filePath);
 
         // make it the same style of path delimiter as vscode's request
-        const projectJsFile = urlToPath(
-            pathToUrl(path.join(path.dirname(filePath), 'documentation.ts'))
-        ) ?? '';
+        const projectJsFile =
+            urlToPath(pathToUrl(path.join(path.dirname(filePath), 'documentation.ts'))) ?? '';
 
         plugin.onWatchFileChanges(projectJsFile, FileChangeType.Changed);
 

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -248,7 +248,7 @@ describe('CodeActionsProvider', () => {
             Range.create(Position.create(7, 8), Position.create(7, 42)),
             { diagnostics: [], only: [CodeActionKind.Refactor] },
         );
-        const action = actions[0];
+        const action = actions[1];
 
         assert.deepStrictEqual(action, {
             command: {
@@ -338,7 +338,7 @@ describe('CodeActionsProvider', () => {
             Range.create(Position.create(7, 8), Position.create(7, 42)),
             { diagnostics: [], only: [CodeActionKind.Refactor] },
         );
-        const action = actions[1];
+        const action = actions[0];
 
         assert.deepStrictEqual(action, {
             command: {

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -152,6 +152,7 @@ describe('CompletionProviderImpl', () => {
         assert.deepStrictEqual(data, {
             hasAction: undefined,
             insertText: undefined,
+            isPackageJsonImport: undefined,
             isRecommended: undefined,
             kind: 'method',
             kindModifiers: '',

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -6,7 +6,7 @@ import { LSConfigManager } from '../../../../src/ls-config';
 import { TypeScriptPlugin } from '../../../../src/plugins';
 import { pathToUrl } from '../../../../src/utils';
 
-describe('TypescriptPlugin', () => {
+describe('DiagnosticsProvider', () => {
     function setup(filename: string) {
         const docManager = new DocumentManager(() => document);
         const testDir = path.join(__dirname, '..');
@@ -25,7 +25,7 @@ describe('TypescriptPlugin', () => {
         assert.deepStrictEqual(diagnostics, [
             {
                 code: 2322,
-                message: "Type 'true' is not assignable to type 'string'.",
+                message: "Type 'boolean' is not assignable to type 'string'.",
                 range: {
                     start: {
                         character: 32,

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -34,11 +34,11 @@
         "svelte": "3.24.0",
         "tiny-glob": "^0.2.6",
         "tslib": "^1.10.0",
-        "typescript": "^3.9.3"
+        "typescript": "^4.0.2"
     },
     "peerDependencies": {
         "svelte": "^3.24",
-        "typescript": "^3.9.3"
+        "typescript": "^4.0.2"
     },
     "scripts": {
         "build": "rollup -c",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,10 +2169,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@*, typescript@^3.9.3:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
-  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
+typescript@*, typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
- Change in CSSDocument necessary to avoid new "is defined as a property in class '..', but is overridden here in '..' as an accessor" error
- Changes in tests necessary because diagnostics + refactoring order changed slightly
- Also removed some duplicated tests