### PR TITLE
(fix) moustache highlighting multiline

### DIFF
--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.json
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.json
@@ -790,7 +790,7 @@
             ]
         },
         "tag-moustaches": {
-            "begin": "\\b([a-zA-Z\\-_:]+)=(\"|')(?=.*{)",
+            "begin": "\\b([a-zA-Z\\-_:]+)=(\"|')",
             "beginCaptures": {
                 "1": {
                     "name": "entity.other.attribute-name.html"


### PR DESCRIPTION
Highlights moustache tags properly when the tag spans multiple lines
#478, #381

This fix looks suspicously simple, so it would be great if you could have a look at this @jasonlyu123  😄 