### PR TITLE
always include source map in ts-preprocess of internal svelte compile

### DIFF
--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -74,7 +74,7 @@ function useFallbackPreprocessor(path: string, foundConfig: boolean): SvelteConf
     );
     return {
         preprocess: importSveltePreprocess(path)({
-            typescript: { transpileOnly: true },
+            typescript: { transpileOnly: true, compilerOptions: { sourceMap: true } },
         }),
     };
 }


### PR DESCRIPTION
svelte-preprocess merge the `compilerOption` with the parsed config file
https://github.com/sveltejs/svelte-preprocess/blob/36d6421db847f8886ebad4c0e8c77671a9a4e3f9/src/transformers/typescript.ts#L69
So it won't override other user-defined configs. Although the problem mentioned here https://github.com/sveltejs/language-tools/issues/489#issuecomment-682281963 here still exists, this would at least make the set up a little bit easier.
