### PR TITLE
fix failure to start with emacs/lsp-mode

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -94,7 +94,7 @@ export function startServer(options?: LSOptions) {
         }
 
         pluginHost.initialize(!!evt.initializationOptions?.dontFilterIncompleteCompletions);
-        pluginHost.updateConfig(evt.initializationOptions?.config);
+        pluginHost.updateConfig(evt.initializationOptions?.config || {});
         pluginHost.register(
             (sveltePlugin = new SveltePlugin(
                 configManager,


### PR DESCRIPTION
initializationOptions was null (it's optional but the vscode client
always sets it), which resulted in this traceback:

TypeError: Cannot read property 'svelte' of undefined
+    at LSConfigManager.update (.../dist/src/ls-config.js:61:46)
+    at PluginHost.updateConfig (.../PluginHost.js:29:21)
...snip...

Fixes regression from #411