### PR TITLE
(fix) vscode minimum version requirements

### DIFF
--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -11,6 +11,8 @@ If you have previously installed the old "Svelte" extension by James Birtles, un
 -   Through the UI: You can find it when searching for `@installed` in the extensions window (searching `Svelte` won't work).
 -   Command line: `code --uninstall-extension JamesBirtles.svelte-vscode`
 
+You need at least VSCode version `1.41.0`.
+
 Do you want to use TypeScript/SCSS/Less/..? [See the docs](/docs/README.md#language-specific-setup).
 
 More docs and troubleshooting: [See here](/docs/README.md).

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -35,7 +35,7 @@
         "Formatters"
     ],
     "engines": {
-        "vscode": "^1.30.0"
+        "vscode": "^1.41.0"
     },
     "activationEvents": [
         "onLanguage:svelte",


### PR DESCRIPTION
#504
It's 1.41.0 because of our dependency on vscode-language-server-node. Can be tracked here https://github.com/microsoft/vscode-languageserver-node/blob/master/client/package.json#L8 (note that the link is pointing to master which has an unreleased version, so you need to look through the tags/commit history to get the correct one)