### PR TITLE
(fix) fall back to FormattingOptions

### DIFF
--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -18,6 +18,7 @@ import {
     CompletionItem,
     CompletionContext,
     WorkspaceEdit,
+    FormattingOptions,
 } from 'vscode-languageserver';
 import { LSConfig, LSConfigManager } from '../ls-config';
 import { DocumentManager } from '../lib/documents';
@@ -136,14 +137,21 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
         return result ?? completionItem;
     }
 
-    async formatDocument(textDocument: TextDocumentIdentifier): Promise<TextEdit[]> {
+    async formatDocument(
+        textDocument: TextDocumentIdentifier,
+        options: FormattingOptions,
+    ): Promise<TextEdit[]> {
         const document = this.getDocument(textDocument.uri);
         if (!document) {
             throw new Error('Cannot call methods on an unopened document');
         }
 
         return flatten(
-            await this.execute<TextEdit[]>('formatDocument', [document], ExecuteMode.Collect),
+            await this.execute<TextEdit[]>(
+                'formatDocument',
+                [document, options],
+                ExecuteMode.Collect,
+            ),
         );
     }
 

--- a/packages/language-server/src/plugins/interfaces.ts
+++ b/packages/language-server/src/plugins/interfaces.ts
@@ -9,6 +9,7 @@ import {
     CompletionList,
     DefinitionLink,
     Diagnostic,
+    FormattingOptions,
     Hover,
     Position,
     Range,
@@ -51,7 +52,7 @@ export interface CompletionsProvider<T extends TextDocumentIdentifier = any> {
 }
 
 export interface FormattingProvider {
-    formatDocument(document: Document): Resolvable<TextEdit[]>;
+    formatDocument(document: Document, options: FormattingOptions): Resolvable<TextEdit[]>;
 }
 
 export interface TagCompleteProvider {

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -36,7 +36,7 @@ export class SveltePlugin
         CodeActionsProvider {
     private docManager = new Map<Document, SvelteDocument>();
 
-    constructor(private configManager: LSConfigManager, private prettierConfig: any) {}
+    constructor(private configManager: LSConfigManager, private prettierConfig?: any) {}
 
     async getDiagnostics(document: Document): Promise<Diagnostic[]> {
         if (!this.featureEnabled('diagnostics')) {

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -3,6 +3,7 @@ import {
     CodeActionContext,
     CompletionList,
     Diagnostic,
+    FormattingOptions,
     Hover,
     Position,
     Range,
@@ -35,11 +36,7 @@ export class SveltePlugin
         CodeActionsProvider {
     private docManager = new Map<Document, SvelteDocument>();
 
-    constructor(
-        private configManager: LSConfigManager,
-        private prettierConfig: any,
-        private editorConfig?: any,
-    ) {}
+    constructor(private configManager: LSConfigManager, private prettierConfig: any) {}
 
     async getDiagnostics(document: Document): Promise<Diagnostic[]> {
         if (!this.featureEnabled('diagnostics')) {
@@ -62,7 +59,7 @@ export class SveltePlugin
         }
     }
 
-    async formatDocument(document: Document): Promise<TextEdit[]> {
+    async formatDocument(document: Document, options: FormattingOptions): Promise<TextEdit[]> {
         if (!this.featureEnabled('format')) {
             return [];
         }
@@ -74,9 +71,9 @@ export class SveltePlugin
             (await prettier.resolveConfig(filePath, { editorconfig: true })) ||
             this.prettierConfig ||
             // Be defensive here because IDEs other than VSCode might not have these settings
-            (this.editorConfig && this.editorConfig.tabSize && {
-                tabWidth: this.editorConfig.tabSize,
-                useTabs: !this.editorConfig.insertSpaces,
+            (options && {
+                tabWidth: options.tabSize,
+                useTabs: !options.insertSpaces,
             });
         // Take .prettierignore into account
         const fileInfo = await prettier.getFileInfo(filePath, {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -99,7 +99,7 @@ export function startServer(options?: LSOptions) {
         pluginHost.register(
             (sveltePlugin = new SveltePlugin(
                 configManager,
-                evt.initializationOptions?.prettierConfig || {},
+                evt.initializationOptions?.prettierConfig,
             )),
         );
         pluginHost.register(new HTMLPlugin(docManager, configManager));

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -86,8 +86,9 @@ export function startServer(options?: LSOptions) {
     let sveltePlugin: SveltePlugin = undefined as any;
 
     connection.onInitialize((evt) => {
-        const workspaceUris = evt.workspaceFolders?.map(folder => folder.uri.toString())
-            ?? [evt.rootUri ?? ''];
+        const workspaceUris = evt.workspaceFolders?.map((folder) => folder.uri.toString()) ?? [
+            evt.rootUri ?? '',
+        ];
         Logger.log('Initialize language server at ', workspaceUris.join(', '));
         if (workspaceUris.length === 0) {
             Logger.error('No workspace path set');
@@ -99,7 +100,6 @@ export function startServer(options?: LSOptions) {
             (sveltePlugin = new SveltePlugin(
                 configManager,
                 evt.initializationOptions?.prettierConfig || {},
-                evt.initializationOptions?.editorConfig, // deliberatly don't fall back to empty object
             )),
         );
         pluginHost.register(new HTMLPlugin(docManager, configManager));
@@ -206,7 +206,9 @@ export function startServer(options?: LSOptions) {
     connection.onCompletion((evt) =>
         pluginHost.getCompletions(evt.textDocument, evt.position, evt.context),
     );
-    connection.onDocumentFormatting((evt) => pluginHost.formatDocument(evt.textDocument));
+    connection.onDocumentFormatting((evt) =>
+        pluginHost.formatDocument(evt.textDocument, evt.options),
+    );
     connection.onRequest(TagCloseRequest.type, (evt) =>
         pluginHost.doTagComplete(evt.textDocument, evt.position),
     );

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -94,7 +94,6 @@ export function activate(context: ExtensionContext) {
         initializationOptions: {
             config: workspace.getConfiguration('svelte.plugin'),
             prettierConfig: workspace.getConfiguration('prettier'),
-            editorConfig: workspace.getConfiguration('editor', { languageId: 'svelte' }),
             dontFilterIncompleteCompletions: true, // VSCode filters client side and is smarter at it than us
         },
     };


### PR DESCRIPTION
In case no prettier configs are found
#539

@jasonlyu123 what do you think? Is this change a change we want to make? It's a breaking change and _might_ be confusing. On the other hand it's also confusing right now that your user settings are not used if you don't know of prettier. So I'm in favor of it.

Situation: 
User does not have any prettier config (either through `.prettierrc` or through VSCode settings)

Before:
Prettier defaults of tabWidth and useTabs are used

After:
The FormattingOptions in the format request are used. These are usually the tabSize/insertSpaces editor settings.