### PR TITLE
(fix) await/each/if block close at wrong position

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/await.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/await.ts
@@ -78,6 +78,6 @@ export function handleAwait(htmlx: string, str: MagicString, awaitBlock: Node): 
     }
     // {/await} ->
     // <>})}
-    const awaitEndStart = htmlx.lastIndexOf('{', awaitBlock.end);
+    const awaitEndStart = htmlx.lastIndexOf('{', awaitBlock.end - 1);
     str.overwrite(awaitEndStart, awaitBlock.end, '</>})}}');
 }

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/each.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/each.ts
@@ -29,7 +29,7 @@ export function handleEach(htmlx: string, str: MagicString, eachBlock: Node): vo
         const endEachStart = htmlx.indexOf('}', contextEnd);
         str.overwrite(endEachStart, endEachStart + 1, ' <>');
     }
-    const endEach = htmlx.lastIndexOf('{', eachBlock.end);
+    const endEach = htmlx.lastIndexOf('{', eachBlock.end - 1);
     // {/each} -> </>)} or {:else} -> </>)}
     if (eachBlock.else) {
         const elseEnd = htmlx.lastIndexOf('}', eachBlock.else.start);

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/if-else.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/if-else.ts
@@ -18,7 +18,7 @@ export function handleIf(htmlx: string, str: MagicString, ifBlock: Node): void {
     str.overwrite(ifBlock.expression.end, end + 1, '){<>');
 
     // {/if} -> </>}}}</>
-    const endif = htmlx.lastIndexOf('{', ifBlock.end);
+    const endif = htmlx.lastIndexOf('{', ifBlock.end - 1);
     str.overwrite(endif, ifBlock.end, '</>}}}');
 }
 

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/blocks-without-whitespace-inbetween/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/blocks-without-whitespace-inbetween/expected.jsx
@@ -1,0 +1,1 @@
+<>{() => {if (name == "world"){<>!</>}}}{__sveltets_each(x, (y) => <>!</>)}{() => {let _$$p = (x); __sveltets_awaitThen(_$$p, (y) => {<>!</>})}}{() => {if (bla){<>*</>}}}</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/blocks-without-whitespace-inbetween/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/blocks-without-whitespace-inbetween/input.svelte
@@ -1,0 +1,1 @@
+{#if name == "world"}!{/if}{#each x as y}!{/each}{#await x then y}!{/await}{#if bla}*{/if}


### PR DESCRIPTION
When there's `{#if}..{/if}{#..}` (no space between closing and opening block), it did use the `{` of the next opening tag instead of the current closing tag