### PR TITLE
(fix) try to be smarter about unclosed tags

### DIFF
--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -286,6 +286,21 @@ describe('document/utils', () => {
                 container: { start: 151, end: 181 },
             });
         });
+
+        it('extract script when unclosed tag preceeding', () => {
+            const text = `
+          <Unclosed-Tag
+          <script>let value = 2</script>`;
+            assert.deepStrictEqual(extractScriptTags(text)?.script, {
+                content: 'let value = 2',
+                attributes: {},
+                start: 43,
+                end: 56,
+                startPos: Position.create(2, 18),
+                endPos: Position.create(2, 31),
+                container: { start: 35, end: 65 },
+            });
+        });
     });
 
     describe('#getLineAtPosition', () => {


### PR DESCRIPTION
Tries to parse the HTML document and work around the limitations of the underlying parser which will trip up when there's a non-closed tag and treat everything afterwards as its child.
#547

Since this feels pretty hacky I'll leave this open a bit for others to have a look.