### PR TITLE
feat: CLI argument --fail-on-hints

### DIFF
--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -101,13 +101,12 @@ to the workspace directory. The filename and the message are both wrapped in quo
 1590680326778 WARNING "imported-file.svelte" 0:37 "Component has unused export property 'prop'. If it is for external reference only, please consider using `export const prop`"
 ```
 
-The output concludes with a `COMPLETED` message that summarizes total numbers of files, errors,
-and warnings that were encountered during the check.
+The output concludes with a `COMPLETED` message that summarizes total numbers of files, errors, warnings and hints that were encountered during the check.
 
 ###### Example:
 
 ```
-1590680326807 COMPLETED 20 FILES 21 ERRORS 1 WARNINGS
+1590680326807 COMPLETED 20 FILES 21 ERRORS 1 WARNINGS 0 HINTS
 ```
 
 If the application experiences a runtime error, this error will appear as a `FAILURE` record.

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -60,6 +60,8 @@ Usage:
 
 `--fail-on-warnings` Will also exit with error code when there are warnings
 
+`--fail-on-hints` Will also exit with error code when there are hints
+
 `--compiler-warnings <code1:error|ignore,code2:error|ignore>` A list of Svelte compiler warning codes. Each entry defines whether that warning should be ignored or treated as an error. Warnings are comma-separated, between warning code and error level is a colon; all inside quotes. Example: --compiler-warnings "css-unused-selector:ignore,unused-export-let:error"
 
 `--diagnostic-sources <js,svelte,css>` A list of diagnostic sources which should run diagnostics on your code. Possible values are `js` (includes TS), `svelte`, `css`. Comma-separated, inside quotes. By default all are active. Example: --diagnostic-sources "js,svelte"

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -19,6 +19,7 @@ type Result = {
     fileCount: number;
     errorCount: number;
     warningCount: number;
+    hintCount: number;
 };
 
 function openAllDocuments(
@@ -56,6 +57,7 @@ async function getDiagnostics(
             fileCount: diagnostics.length,
             errorCount: 0,
             warningCount: 0,
+            hintCount: 0,
         };
 
         for (const diagnostic of diagnostics) {
@@ -71,6 +73,8 @@ async function getDiagnostics(
                     result.errorCount += 1;
                 } else if (d.severity === DiagnosticSeverity.Warning) {
                     result.warningCount += 1;
+                } else if (d.severity === DiagnosticSeverity.Hint) {
+                    result.hintCount += 1;
                 }
             });
         }
@@ -198,7 +202,8 @@ function getOptions(myArgs: argv.ParsedArgs): SvelteCheckOptions {
         if (
             result &&
             result.errorCount === 0 &&
-            (!myArgs['fail-on-warnings'] || result.warningCount === 0)
+            (!myArgs['fail-on-warnings'] || result.warningCount === 0) &&
+            (!myArgs['fail-on-hints'] || result.hintCount === 0)
         ) {
             process.exit(0);
         } else {

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -79,7 +79,12 @@ async function getDiagnostics(
             });
         }
 
-        writer.completion(result.fileCount, result.errorCount, result.warningCount);
+        writer.completion(
+            result.fileCount,
+            result.errorCount,
+            result.warningCount,
+            result.hintCount,
+        );
         return result;
     } catch (err) {
         writer.failure(err);

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -39,7 +39,8 @@
     //
     // Event Handler Types
     // ----------------------------------------------------------------------
-    type EventHandler<E = Event, T = HTMLElement> = (event: E & { currentTarget: EventTarget & T}) => any;
+    type EventHandler<E = Event, T = HTMLElement> =
+      (event: E & { currentTarget: EventTarget & T}) => any;
 
     type ClipboardEventHandler<T> = EventHandler<ClipboardEvent, T>;
     type CompositionEventHandler<T> = EventHandler<CompositionEvent, T>;


### PR DESCRIPTION
**Feature**
`svelte-check --fail-on-hints` will exit with error code when there are hints, similar to `--fail-on-warnings`

**Use case**
I want my CI and commit hooks to fail when there are hints, that way I can prevent committing code with hints such as: 

```
/path/to/Component.svelte:10:3
Hint: 'someVariable' is declared but its value is never read. (ts)
```
