### PR TITLE
fix: TS diagnostic mapping for context="module"

### DIFF
--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -254,11 +254,13 @@ export class SvelteDocumentSnapshot implements DocumentSnapshot {
     }
 
     private async getMapper(uri: string) {
-        if (!this.parent.scriptInfo) {
+        const scriptInfo = this.parent.scriptInfo || this.parent.moduleScriptInfo;
+
+        if (!scriptInfo) {
             return new IdentityMapper(uri);
         }
         if (!this.tsxMap) {
-            return new FragmentMapper(this.parent.getText(), this.parent.scriptInfo, uri);
+            return new FragmentMapper(this.parent.getText(), scriptInfo, uri);
         }
         return new ConsumerDocumentMapper(
             await new SourceMapConsumer(this.tsxMap),
@@ -272,7 +274,8 @@ export class SvelteDocumentSnapshot implements DocumentSnapshot {
  * A js/ts document snapshot suitable for the ts language service and the plugin.
  * Since no mapping has to be done here, it also implements the mapper interface.
  */
-export class JSOrTSDocumentSnapshot extends IdentityMapper
+export class JSOrTSDocumentSnapshot
+    extends IdentityMapper
     implements DocumentSnapshot, SnapshotFragment {
     scriptKind = getScriptKindFromFileName(this.filePath);
     scriptInfo = null;

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -43,6 +43,31 @@ describe('DiagnosticsProvider', () => {
         ]);
     });
 
+    it('provides diagnostics for context="module"', async () => {
+        const { plugin, document } = setup('diagnostics-module.svelte');
+        const diagnostics = await plugin.getDiagnostics(document);
+
+        assert.deepStrictEqual(diagnostics, [
+            {
+                code: 2322,
+                message: "Type 'boolean' is not assignable to type 'string'.",
+                range: {
+                    start: {
+                        character: 49,
+                        line: 0,
+                    },
+                    end: {
+                        character: 52,
+                        line: 0,
+                    },
+                },
+                severity: 1,
+                source: 'ts',
+                tags: [],
+            },
+        ]);
+    });
+
     it('provides typecheck diagnostics for js file when //@ts-check at top of script', async () => {
         const { plugin, document } = setup('diagnostics-js-typecheck.svelte');
         const diagnostics = await plugin.getDiagnostics(document);

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics-module.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics-module.svelte
@@ -1,0 +1,1 @@
+<script context="module" lang="typescript">const asd: string = true;asd;</script>


### PR DESCRIPTION
Addresses #584 

Fixes typescript diagnostic info range for components with `context="module"`.

Before:
![image](https://user-images.githubusercontent.com/22738928/94860495-6d188280-0436-11eb-9f47-e718b3d90365.png)

After:
![image](https://user-images.githubusercontent.com/22738928/94860514-7570bd80-0436-11eb-9238-8fdfbbe2007e.png)

Changes:
Take `moduleScriptInfo` into account when creating `SvelteDocumentSnapshot` mapper.