### PR TITLE
Fix svelte plugin diagnostic mapping for context="module"

### DIFF
--- a/packages/language-server/src/plugins/svelte/SvelteDocument.ts
+++ b/packages/language-server/src/plugins/svelte/SvelteDocument.ts
@@ -175,11 +175,16 @@ export class SvelteFragmentMapper {
     }
 
     static async createScript(originalDoc: Document, transpiled: string, processed: Processed[]) {
+        const scriptInfo = originalDoc.scriptInfo || originalDoc.moduleScriptInfo;
+        const maybeScriptTag = extractScriptTags(transpiled);
+        const maybeScriptTagInfo =
+            maybeScriptTag && (maybeScriptTag.script || maybeScriptTag.moduleScript);
+
         return SvelteFragmentMapper.create(
             originalDoc,
             transpiled,
-            originalDoc.scriptInfo,
-            extractScriptTags(transpiled)?.script || null,
+            scriptInfo,
+            maybeScriptTagInfo || null,
             processed,
         );
     }

--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -78,7 +78,10 @@ async function createParserErrorDiagnostic(error: any, document: Document) {
 
     if (diagnostic.message.includes('expected')) {
         const isInStyle = isInTag(diagnostic.range.start, document.styleInfo);
-        const isInScript = isInTag(diagnostic.range.start, document.scriptInfo);
+        const isInScript = isInTag(
+            diagnostic.range.start,
+            document.scriptInfo || document.moduleScriptInfo,
+        );
 
         if (isInStyle || isInScript) {
             diagnostic.message +=

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -151,7 +151,8 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
         if (tsxMap) {
             tsxMap.sources = [document.uri];
 
-            const tsCheck = getTsCheckComment(document.scriptInfo?.content);
+            const scriptInfo = document.scriptInfo || document.moduleScriptInfo;
+            const tsCheck = getTsCheckComment(scriptInfo?.content);
             if (tsCheck) {
                 text = tsCheck + text;
                 nrPrependedLines = 1;
@@ -172,7 +173,8 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
         };
 
         // fall back to extracted script, if any
-        text = document.scriptInfo ? document.scriptInfo.content : '';
+        const scriptInfo = document.scriptInfo || document.moduleScriptInfo;
+        text = scriptInfo ? scriptInfo.content : '';
     }
 
     return {
@@ -330,7 +332,7 @@ export class SvelteSnapshotFragment implements SnapshotFragment {
     ) {}
 
     get scriptInfo() {
-        return this.parent.scriptInfo;
+        return this.parent.scriptInfo || this.parent.moduleScriptInfo;
     }
 
     getOriginalPosition(pos: Position): Position {

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -55,7 +55,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
     }
 
     private async organizeImports(document: Document): Promise<CodeAction[]> {
-        if (!document.scriptInfo) {
+        if (!document.scriptInfo && !document.moduleScriptInfo) {
             return [];
         }
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -34,7 +34,7 @@ export interface CompletionEntryWithIdentifer extends ts.CompletionEntry, TextDo
 type validTriggerCharacter = '.' | '"' | "'" | '`' | '/' | '@' | '<' | '#';
 
 export class CompletionsProviderImpl implements CompletionsProvider<CompletionEntryWithIdentifer> {
-    constructor(private readonly lsAndTsDocResolver: LSAndTSDocResolver) { }
+    constructor(private readonly lsAndTsDocResolver: LSAndTSDocResolver) {}
 
     /**
      * The language service throws an error if the character is not a valid trigger character.

--- a/packages/language-server/test/plugins/svelte/testfiles/diagnostics-module.svelte
+++ b/packages/language-server/test/plugins/svelte/testfiles/diagnostics-module.svelte
@@ -1,0 +1,3 @@
+<script context="module" lang="typescript">
+    export let name: string;
+</script>

--- a/packages/language-server/test/plugins/svelte/testfiles/diagnostics.svelte
+++ b/packages/language-server/test/plugins/svelte/testfiles/diagnostics.svelte
@@ -1,0 +1,3 @@
+<script lang="typescript">
+    export let name: string;
+</script>


### PR DESCRIPTION
Hi again 👋 

After merging fix for the TS diagnostics misplacement within `context="module"` - #585 , I noticed this issue also occurs for svelte errors/warnings.

Before:
![image](https://user-images.githubusercontent.com/22738928/94921581-e0fb6f00-04b8-11eb-8615-f2a45dfdebfd.png)

After:
![image](https://user-images.githubusercontent.com/22738928/94921997-b0680500-04b9-11eb-9047-e60d17aec7ec.png)

**Changes**
Again, `moduleScriptInfo` was not taken into account when creating `SvelteFragmentMapper`. Now it is.

**Note**
In order to prevent similar errors similar to that one, I have scanned the `language-server` for references to `.scriptInfo` that are not accompanied by `|| doc.moduleScriptInfo`, and added the missing fallback.  While I tried to do my best, these changes were only based on my limited understanding of the codebase, and I would appreciate if someone more experienced could have a look into that.
To keep things clean, the first commit just solves the issue presented on the screen, and the second has the prevention measures (found via grep check, not by any observed issue). If we decide to discard the second commit, I am also fine with that.

**P.S.**
Going further with diagnostics for `context="module"`, I see that we are not handling correctly cases when component contains both `<script>...</script>` and `<script context="module">...</script>`. What are your thoughts on that? Should we wait with merging this, and try to get full handling of that as well at once, or is it fine if we go about it incrementally?