### PR TITLE
(fix) force boolean typing

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -83,7 +83,15 @@ export function processInstanceScriptContent(
             const jsDocType = ts.getJSDocType(declaration);
             const type = tsType || jsDocType;
 
-            if (!ts.isIdentifier(identifier) || !type) {
+            if (
+                !ts.isIdentifier(identifier) ||
+                (!type &&
+                    // Edge case: TS infers `export let bla = false` to type `false`.
+                    // prevent that by adding the any-wrap in this case, too.
+                    ![ts.SyntaxKind.FalseKeyword, ts.SyntaxKind.TrueKeyword].includes(
+                        declaration.initializer?.kind,
+                    ))
+            ) {
                 return;
             }
             const name = identifier.getText();

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-boolean/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-boolean/expected.tsx
@@ -1,0 +1,14 @@
+///<reference types="svelte" />
+<></>;function render() {
+
+     let bla = false;bla = __sveltets_any(bla);;
+     let blubb = true;blubb = __sveltets_any(blubb);;
+     let bla1: boolean = false;bla1 = __sveltets_any(bla1);;
+     let blubb1: boolean = true;blubb1 = __sveltets_any(blubb1);;
+     let a1 = true;a1 = __sveltets_any(a1);;let  a2 = false;a2 = __sveltets_any(a2);;let  b1: boolean = true;b1 = __sveltets_any(b1);;let  b2: boolean = false;b2 = __sveltets_any(b2);;
+;
+() => (<></>);
+return { props: {bla: bla , blubb: blubb , bla1: bla1 , blubb1: blubb1 , a1: a1 , a2: a2 , b1: b1 , b2: b2} as {bla?: typeof bla, blubb?: typeof blubb, bla1?: boolean, blubb1?: boolean, a1?: typeof a1, a2?: typeof a2, b1?: boolean, b2?: boolean}, slots: {}, getters: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-boolean/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-boolean/input.svelte
@@ -1,0 +1,7 @@
+<script>
+    export let bla = false;
+    export let blubb = true;
+    export let bla1: boolean = false;
+    export let blubb1: boolean = true;
+    export let a1 = true, a2 = false, b1: boolean = true, b2: boolean = false;
+</script>


### PR DESCRIPTION
In case of `export let bla = true/false` where the boolean typing is not given by user, prevent TS from thinking the type is `false`/`true` instead of `boolean`.
#588