### PR TITLE
TS template control flow inside {#if} blocks

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -178,4 +178,11 @@ describe('DiagnosticsProvider', () => {
             },
         ]);
     });
+
+    it('treats svelte {#if ...} as typescript flow control', async () => {
+        const { plugin, document } = setup('ts-template-flow-control.svelte');
+        const diagnostics = await plugin.getDiagnostics(document);
+
+        assert.deepStrictEqual(diagnostics, []);
+    });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/ts-template-flow-control.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/ts-template-flow-control.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    import {writable} from 'svelte/store'
+    const store = writable<{ val: number } | null>(null);
+</script>
+
+{#if $store}<p>{$store.val}</p>{/if}
+{#if $store !== null}<p>{$store.val}</p>{/if}

--- a/packages/svelte2tsx/src/utils/uniq.ts
+++ b/packages/svelte2tsx/src/utils/uniq.ts
@@ -1,0 +1,1 @@
+export const uniq = <T>(arr: T[]): T[] => [...new Set(arr)];

--- a/packages/svelte2tsx/test/sourcemaps/event-binding.html
+++ b/packages/svelte2tsx/test/sourcemaps/event-binding.html
@@ -1,9 +1,10 @@
 ///<reference types="svelte" />
 <></>;function render() {
-<><Component  />{__sveltets_instanceOf(Component).$on('click', __sveltets_store_get(check) ? method1 : method2)}
-                                                                                    1====  2================== 
-<button onclick={__sveltets_store_get(check) ? method1 : method2} >Bla</button></>
-                                      3====  4==================
+const __svelte_store_get_values__ = {check:__sveltets_store_get(check),};
+<><Component  />{__sveltets_instanceOf(Component).$on('click', __svelte_store_get_values__['check'] ? method1 : method2)}
+                                                                                            1====   2================== 
+<button onclick={__svelte_store_get_values__['check'] ? method1 : method2} >Bla</button></>
+                                              3====   4==================
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {

--- a/packages/svelte2tsx/test/svelte2tsx/index.js
+++ b/packages/svelte2tsx/test/svelte2tsx/index.js
@@ -26,6 +26,7 @@ describe('svelte2tsx', () => {
 				isTsFile: dir.startsWith('ts-'),
 				filename: 'input.svelte'
 			});
+
 			assert.equal(output.code, expectedOutput);
 			if (expecterOtherOutput) {
 				expecterOtherOutput(output);

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-index/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-index/expected.tsx
@@ -1,6 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
-<>{someRecordOrArr[__sveltets_store_get(store)]}
+const __svelte_store_get_values__ = {store:__sveltets_store_get(store),};
+<>{someRecordOrArr[__svelte_store_get_values__['store']]}
 {someObject['$store']}
 {someObject.$store}</>
 return { props: {}, slots: {}, getters: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
@@ -5,10 +5,11 @@ function render() {
 
 	
 	const store = readable(Promise.resolve('test'), () => {});
-;
+;const __svelte_store_get_values__ = {store:__sveltets_store_get(store),};
+
 () => (<>
 
-{() => {let _$$p = (__sveltets_store_get(store)); <>
+{() => {let _$$p = (__svelte_store_get_values__['store']); <>
 	<p>loading</p>
 </>; __sveltets_awaitThen(_$$p, (data) => {<>
 	{data}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
@@ -1,6 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
-<><input id="dom-input" type="radio" {...__sveltets_empty(__sveltets_store_get(compile_options).generate)} value="dom"/></>
+const __svelte_store_get_values__ = {compile_options:__sveltets_store_get(compile_options),};
+<><input id="dom-input" type="radio" {...__sveltets_empty(__svelte_store_get_values__['compile_options'].generate)} value="dom"/></>
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
@@ -1,6 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
-<><Me f={`${__sveltets_store_get(s)} `}/></>
+const __svelte_store_get_values__ = {s:__sveltets_store_get(s),};
+<><Me f={`${__svelte_store_get_values__['s']} `}/></>
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
@@ -1,7 +1,8 @@
 ///<reference types="svelte" />
 <></>;function render() {
-<><Component  />{__sveltets_instanceOf(Component).$on('click', __sveltets_store_get(check) ? method1 : method2)}
-<button onclick={__sveltets_store_get(check) ? method1 : method2} >Bla</button></>
+const __svelte_store_get_values__ = {check:__sveltets_store_get(check),};
+<><Component  />{__sveltets_instanceOf(Component).$on('click', __svelte_store_get_values__['check'] ? method1 : method2)}
+<button onclick={__svelte_store_get_values__['check'] ? method1 : method2} >Bla</button></>
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
@@ -18,21 +18,22 @@ function render() {
   const handler10 = () => count.set( __sveltets_store_get(count) & myvar)
   const handler11 = () => count.set( __sveltets_store_get(count) ^ myvar)
   const handler12 = () => count.set( __sveltets_store_get(count) | myvar)
-;
+;const __svelte_store_get_values__ = {count:__sveltets_store_get(count),};
+
 () => (<>
 
-<button onclick={() => count.set( __sveltets_store_get(count) + myvar)}>add</button>
-<button onclick={() => count.set( __sveltets_store_get(count) - myvar)}>subtract</button>
-<button onclick={() => count.set( __sveltets_store_get(count) * myvar)}>multiply</button>
-<button onclick={() => count.set( __sveltets_store_get(count) / myvar)}>divide</button>
-<button onclick={() => count.set( __sveltets_store_get(count) ** myvar)}>exponent</button>
-<button onclick={() => count.set( __sveltets_store_get(count) % myvar)}>mod</button>
-<button onclick={() => count.set( __sveltets_store_get(count) << myvar)}>leftshift</button>
-<button onclick={() => count.set( __sveltets_store_get(count) >> myvar)}>rightshift</button>
-<button onclick={() => count.set( __sveltets_store_get(count) >>> myvar)}>unsigned rightshift</button>
-<button onclick={() => count.set( __sveltets_store_get(count) & myvar)}>AND</button>
-<button onclick={() => count.set( __sveltets_store_get(count) ^ myvar)}>XOR</button>
-<button onclick={() => count.set( __sveltets_store_get(count) | myvar)}>OR</button></>);
+<button onclick={() => count.set( __svelte_store_get_values__['count'] + myvar)}>add</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] - myvar)}>subtract</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] * myvar)}>multiply</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] / myvar)}>divide</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] ** myvar)}>exponent</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] % myvar)}>mod</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] << myvar)}>leftshift</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] >> myvar)}>rightshift</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] >>> myvar)}>unsigned rightshift</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] & myvar)}>AND</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] ^ myvar)}>XOR</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] | myvar)}>OR</button></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-exclamation-mark/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-exclamation-mark/expected.tsx
@@ -6,10 +6,11 @@ function render() {
   
   const count = writable(0);
   const handler1 = () => !__sveltets_store_get(count)
-;
+;const __svelte_store_get_values__ = {count:__sveltets_store_get(count),};
+
 () => (<>
 
-<button onclick={() => !__sveltets_store_get(count)}>add</button></>);
+<button onclick={() => !__svelte_store_get_values__['count']}>add</button></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
@@ -7,11 +7,12 @@ function render() {
   const count = writable(0);
   const handler1 = () => count.set( __sveltets_store_get(count) + 1)
   const handler2 = () => count.set( __sveltets_store_get(count) - 1)
-;
+;const __svelte_store_get_values__ = {count:__sveltets_store_get(count),};
+
 () => (<>
 
-<button onclick={() => count.set( __sveltets_store_get(count) + 1)}>add</button>
-<button onclick={() => count.set( __sveltets_store_get(count) - 1)}>subtract</button></>);
+<button onclick={() => count.set( __svelte_store_get_values__['count'] + 1)}>add</button>
+<button onclick={() => count.set( __svelte_store_get_values__['count'] - 1)}>subtract</button></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
@@ -1,8 +1,9 @@
 ///<reference types="svelte" />
 <></>;function render() {
-b.set(__sveltets_store_get(b).concat(5));
+b.set(__sveltets_store_get(b).concat(5));const __svelte_store_get_values__ = {b:__sveltets_store_get(b),};
+
 () => (<>
-<h1 onclick={() => b.set(__sveltets_store_get(b).concat(5))}>{__sveltets_store_get(b)}</h1></>);
+<h1 onclick={() => b.set(__svelte_store_get_values__['b'].concat(5))}>{__svelte_store_get_values__['b']}</h1></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {


### PR DESCRIPTION
Addresses #493 

**Before**, `{#if $store}` was not working as a flow control statement, which meant that if store value was nullable, `{#if` was not narrowing down the type.

```svelte
<script lang="ts">
  import { writable } from 'svelte/store';
  const store = writable<{ val: number } | null>(null);
</script>

{#if $store}
  <p>{$store.val}</p>
<!--  ^^^^^^^ 'Object is possibly 'null'' -->
{/if}
```

**After**, `{#if` acts as flow control statement.

```svelte
<script lang="ts">
  import { writable } from 'svelte/store';
  const store = writable<{ val: number } | null>(null);
</script>

{#if $store}
  <p>{$store.val}</p>
<!--  ^^^^^^^ No errors here -->
{/if}
```

This also works with custom type guards:
```svelte
<script lang="ts">
  import {writable} from 'svelte/store'
  const store = writable<number | string | { val: number }>('');
  const isString = (x: unknown): x is string => typeof x === 'string';
  const isNumber = (x: unknown): x is number => typeof x === 'number';
</script>

{#if isString($store)}
  <p>{$store.split('')}</p>
{:else if isNumber($store)}
  <p>{$store.toPrecision()}</p>
{:else}
  <p>{$store.val}</p>
{/if}
```

**Approach**
Previously, `svelte2tsx` was transforming 
```svelte
{#if $store}
  <p>{$store.val}</p>
{/if}
```
into roughly: 
```tsx
if (__sveltets_store_get(store)){<>
    <h1>{__sveltets_store_get(store).val}</h1>
</>}
```
Since `ts` can not safely assume that `__sveltets_store_get` is pure, `if` will not narrow down the type. In order to achieve the desired result, `__sveltets_store_get(store)` must be first assigned to a variable.
```tsx
const storeVal = __sveltets_store_get(store);
if (storeVal){<>
    <h1>{storeVal.val}</h1>
</>}
```

**Implementation**
References to store values are now hoisted to a variable `__svelte_store_get_values__` which is a record containing actual store values.
*E.g.*
```ts
const __svelte_store_get_values__ = {storeA:__sveltets_store_get(storeA),storeB:__sveltets_store_get(storeB),}
```
This declaration is injected between _script_ and _template_ section of `tsx` component.
*E.g.*
```tsx
<></>;
import {writable} from 'svelte/store'
function render() {
const store = writable<{ val: number } | null>(null);
;
() => (<>
{() => {if (__sveltets_store_get(store)){<>
    <p>{__sveltets_store_get(store).val}</p>
</>}}}</>);
```
became:
```tsx
<></>;
import {writable} from 'svelte/store'
function render() {
const store = writable<{ val: number } | null>(null);
;const __svelte_store_get_values__ = {store:__sveltets_store_get(store),};
() => (<>
{() => {if (__svelte_store_get_values__['store']){<>
    <p>{__svelte_store_get_values__['store'].val}</p>
</>}}}</>);
```

**Edge case**
A special case of accessing stores is when they are accessed inside `BlockStatements` inside event handlers. In current svelte, declaring stores outside script tag is forbidden, however based on the error message this may change in future versions.
```svelte
<button on:click={() => {
  const store = writable();
  if ($store) { /* forbidden for now, but who knows */ }
}}/>
```
The problem with such case is that we cannot hoist `__sveltets_store_get(store)` in `__svelte_store_get_values__`, because `store` is not defined in script tag scope. I had two ways of handling this:
1. Disregard the future possibility of declaring store in handler being valid, and do not worry about it (this however would potentially cause ts errors if that feature was allowed, and require to remove/update this test case `packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template`)
2. Do not hoist store accesses inside block statements inside component template. (Downside is that user will have to assign the store value him/herself to a contant to achieve type narrowing. This is however safer in case declaring stores would be allowed inside nested scopes, because it would not begin throwing errors).

I took the latter option, but option 1. has an advantage of being simpler (no checks if hoisting is allowed). I can _degrade_ to option 1. if you consider this additional complexity yucky 😅 