### PR TITLE
Broken link to "Using with preprocessors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To run the developer version of both the language server and the VSCode extensio
 -   Go to the debugging panel
 -   Make sure "Run VSCode Extension" is selected, and hit run
 
-This launches a new VSCode window and a watcher for your changes. In this dev window you can choose an existing Svelte project to work against. If you don't use pure Javascript and CSS, but languages like Typescript or SCSS, your project will need a [Svelte preprocessor setup](packages/svelte-vscode#using-with-preprocessors). When you make changes to the extension or language server you can use the command "Reload Window" in the VSCode command palette to see your changes. When you make changes to `svelte2tsx`, you first need to run `yarn build` within its folder.
+This launches a new VSCode window and a watcher for your changes. In this dev window you can choose an existing Svelte project to work against. If you don't use pure Javascript and CSS, but languages like Typescript or SCSS, your project will need a [Svelte preprocessor setup](docs#using-with-preprocessors). When you make changes to the extension or language server you can use the command "Reload Window" in the VSCode command palette to see your changes. When you make changes to `svelte2tsx`, you first need to run `yarn build` within its folder.
 
 ### Running Tests
 

--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -96,7 +96,7 @@ async function createParserErrorDiagnostic(error: any, document: Document) {
             }
             diagnostic.message +=
                 '\nDid you setup a `svelte.config.js`? ' +
-                '\nSee https://github.com/sveltejs/language-tools/tree/master/packages/svelte-vscode#using-with-preprocessors for more info.';
+                '\nSee https://github.com/sveltejs/language-tools/tree/master/docs#using-with-preprocessors for more info.';
         }
     }
 
@@ -241,7 +241,7 @@ function getErrorMessage(error: any, source: string, hint = '') {
         " requires a preprocessor that doesn't seem to be setup or failed during setup. " +
         'Did you setup a `svelte.config.js`? ' +
         hint +
-        '\n\nSee https://github.com/sveltejs/language-tools/tree/master/packages/svelte-vscode#using-with-preprocessors for more info.'
+        '\n\nSee https://github.com/sveltejs/language-tools/tree/master/docs#using-with-preprocessors for more info.'
     );
 }
 

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -221,7 +221,7 @@ describe('SveltePlugin#getDiagnostics', () => {
                     '\n\nIf you expect this syntax to work, here are some suggestions: ' +
                     '\nIf you use typescript with `svelte-preprocess`, did you add `lang="typescript"` to your `script` tag? ' +
                     '\nDid you setup a `svelte.config.js`? ' +
-                    '\nSee https://github.com/sveltejs/language-tools/tree/master/packages/svelte-vscode#using-with-preprocessors for more info.',
+                    '\nSee https://github.com/sveltejs/language-tools/tree/master/docs#using-with-preprocessors for more info.',
                 range: {
                     start: {
                         character: 8,


### PR DESCRIPTION
The documentation for "Using with preprocessors" seems to have moved to `docs/README.md`