### PR TITLE
(fix) improve on:event autocompletion

### DIFF
--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -315,6 +315,30 @@ export function getNodeIfIsInComponentStartTag(
 }
 
 /**
+ * Gets word range at position.
+ * Delimiter is by default a whitespace, but can be adjusted.
+ */
+export function getWordRangeAt(
+    str: string,
+    pos: number,
+    delimiterRegex = { left: /\S+$/, right: /\s/ }
+): { start: number; end: number } {
+    let start = str.slice(0, pos).search(delimiterRegex.left);
+    if (start < 0) {
+        start = pos;
+    }
+
+    let end = str.slice(pos).search(delimiterRegex.right);
+    if (end < 0) {
+        end = str.length;
+    } else {
+        end = end + pos;
+    }
+
+    return { start, end };
+}
+
+/**
  * Gets word at position.
  * Delimiter is by default a whitespace, but can be adjusted.
  */
@@ -323,12 +347,31 @@ export function getWordAt(
     pos: number,
     delimiterRegex = { left: /\S+$/, right: /\s/ }
 ): string {
-    const left = str.slice(0, pos + 1).search(delimiterRegex.left);
-    const right = str.slice(pos).search(delimiterRegex.right);
+    const { start, end } = getWordRangeAt(str, pos, delimiterRegex);
+    return str.slice(start, end);
+}
 
-    if (right < 0) {
-        return str.slice(left);
+/**
+ * Returns start/end offset of a text into a range
+ */
+export function toRange(str: string, start: number, end: number): Range {
+    return Range.create(positionAt(start, str), positionAt(end, str));
+}
+
+/**
+ * Returns the language from the given tags, return the first from which a language is found.
+ * Searches inside lang and type and removes leading 'text/'
+ */
+export function getLangAttribute(...tags: Array<TagInformation | null>): string | null {
+    const tag = tags.find((tag) => tag?.attributes.lang || tag?.attributes.type);
+    if (!tag) {
+        return null;
     }
 
-    return str.slice(left, right + pos);
+    const attribute = tag.attributes.lang || tag.attributes.type;
+    if (!attribute) {
+        return null;
+    }
+
+    return attribute.replace(/^text\//, '');
 }

--- a/packages/language-server/src/plugins/svelte/features/getSelectionRanges.ts
+++ b/packages/language-server/src/plugins/svelte/features/getSelectionRanges.ts
@@ -1,20 +1,18 @@
 import { walk } from 'estree-walker';
-import { Position, Range, SelectionRange } from 'vscode-languageserver';
-import { isInTag, mapSelectionRangeToParent, offsetAt, positionAt } from '../../../lib/documents';
+import { Position, SelectionRange } from 'vscode-languageserver';
+import { isInTag, mapSelectionRangeToParent, offsetAt, toRange } from '../../../lib/documents';
 import { SvelteDocument } from '../SvelteDocument';
-
 
 type OffsetRange = {
     start: number;
     end: number;
 };
 
-export async function getSelectionRange(
-    svelteDoc: SvelteDocument,
-    position: Position
-) {
+export async function getSelectionRange(svelteDoc: SvelteDocument, position: Position) {
     const { script, style, moduleScript } = svelteDoc;
-    const { ast: { html } } = await svelteDoc.getCompiled();
+    const {
+        ast: { html }
+    } = await svelteDoc.getCompiled();
     const transpiled = await svelteDoc.getTranspiled();
     const content = transpiled.getText();
     const offset = offsetAt(transpiled.getGeneratedPosition(position), content);
@@ -60,8 +58,7 @@ export async function getSelectionRange(
     return result ? mapSelectionRangeToParent(transpiled, result) : null;
 
     function createSelectionRange(node: OffsetRange, parent?: SelectionRange) {
-        const range = Range.create(positionAt(node.start, content), positionAt(node.end, content));
-
+        const range = toRange(content, node.start, node.end);
         return SelectionRange.create(range, parent);
     }
 }

--- a/packages/language-server/test/lib/documents/utils.test.ts
+++ b/packages/language-server/test/lib/documents/utils.test.ts
@@ -353,5 +353,21 @@ describe('document/utils', () => {
                 'on:asd-qwd'
             );
         });
+
+        function testEvent(str: string, pos: number, expected: string) {
+            assert.equal(getWordAt(str, pos, { left: /\S+$/, right: /[^\w$:]/ }), expected);
+        }
+
+        it('returns event #1', () => {
+            testEvent('<div on:>', 8, 'on:');
+        });
+
+        it('returns event #2', () => {
+            testEvent('<div on: >', 8, 'on:');
+        });
+
+        it('returns empty string when only whitespace', () => {
+            assert.equal(getWordAt('a  a', 2), '');
+        });
     });
 });

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -99,7 +99,8 @@ describe('CompletionProviderImpl', () => {
                 detail: 'a: CustomEvent<boolean>',
                 documentation: undefined,
                 label: 'on:a',
-                sortText: '-1'
+                sortText: '-1',
+                textEdit: undefined
             },
             {
                 detail: 'b: MouseEvent',
@@ -108,13 +109,99 @@ describe('CompletionProviderImpl', () => {
                     value: '\nTEST\n'
                 },
                 label: 'on:b',
-                sortText: '-1'
+                sortText: '-1',
+                textEdit: undefined
             },
             {
                 detail: 'c: Event',
                 documentation: undefined,
                 label: 'on:c',
-                sortText: '-1'
+                sortText: '-1',
+                textEdit: undefined
+            }
+        ]);
+    });
+
+    it('provides event completions with correct text replacement span', async () => {
+        const { completionProvider, document } = setup('component-events-completion.svelte');
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            Position.create(4, 10),
+            {
+                triggerKind: CompletionTriggerKind.Invoked
+            }
+        );
+
+        assert.ok(
+            Array.isArray(completions && completions.items),
+            'Expected completion items to be an array'
+        );
+        assert.ok(completions!.items.length > 0, 'Expected completions to have length');
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const eventCompletions = completions!.items.filter((item) => item.label.startsWith('on:'));
+
+        assert.deepStrictEqual(eventCompletions, <CompletionItem[]>[
+            {
+                detail: 'a: CustomEvent<boolean>',
+                documentation: undefined,
+                label: 'on:a',
+                sortText: '-1',
+                textEdit: {
+                    newText: 'on:a',
+                    range: {
+                        start: {
+                            line: 4,
+                            character: 7
+                        },
+                        end: {
+                            line: 4,
+                            character: 10
+                        }
+                    }
+                }
+            },
+            {
+                detail: 'b: MouseEvent',
+                documentation: {
+                    kind: 'markdown',
+                    value: '\nTEST\n'
+                },
+                label: 'on:b',
+                sortText: '-1',
+                textEdit: {
+                    newText: 'on:b',
+                    range: {
+                        start: {
+                            line: 4,
+                            character: 7
+                        },
+                        end: {
+                            line: 4,
+                            character: 10
+                        }
+                    }
+                }
+            },
+            {
+                detail: 'c: Event',
+                documentation: undefined,
+                label: 'on:c',
+                sortText: '-1',
+                textEdit: {
+                    newText: 'on:c',
+                    range: {
+                        start: {
+                            line: 4,
+                            character: 7
+                        },
+                        end: {
+                            line: 4,
+                            character: 10
+                        }
+                    }
+                }
             }
         ]);
     });
@@ -211,7 +298,7 @@ describe('CompletionProviderImpl', () => {
             assert.notEqual(
                 mockedDirImportCompletion,
                 undefined,
-                'can\'t provide completions on directory'
+                "can't provide completions on directory"
             );
             assert.equal(mockedDirImportCompletion?.kind, CompletionItemKind.Folder);
         } finally {

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/component-events-completion.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/component-events-completion.svelte
@@ -2,4 +2,4 @@
     import CEI from './component-events-interface.svelte';
 </script>
 
-<CEI  />
+<CEI   on: />


### PR DESCRIPTION
- `:` trigger character now also returns completions in a component context
- add textEdit to specify replacement range of event, fixing a bug where `on:a` would be autocompleted to `on:on:anEvent`