### PR TITLE
(fix) more missing attributes

### DIFF
--- a/packages/language-server/src/plugins/html/dataProvider.ts
+++ b/packages/language-server/src/plugins/html/dataProvider.ts
@@ -245,11 +245,18 @@ const videoAttributes: IAttributeData[] = [
     }
 ];
 
+const indeterminateAttribute: IAttributeData = {
+    name: 'indeterminate',
+    description: 'Available for type="checkbox"'
+};
+
 const addAttributes: Record<string, IAttributeData[]> = {
     select: [{ name: 'bind:value' }],
     input: [
         { name: 'bind:value' },
-        { name: 'bind:group', description: 'Available for type="radio" and type="checkbox"' }
+        { name: 'bind:group', description: 'Available for type="radio" and type="checkbox"' },
+        indeterminateAttribute,
+        {...indeterminateAttribute, name: 'bind:indeterminate'}
     ],
     textarea: [{ name: 'bind:value' }],
     video: [...mediaAttributes, ...videoAttributes],

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -296,6 +296,7 @@ declare namespace svelte.JSX {
       inputmode?: string;
       integrity?: string;
       is?: string;
+      ismap?: boolean;
       keyparams?: string;
       keytype?: string;
       kind?: string;

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -685,6 +685,7 @@ declare namespace svelte.JSX {
     interface SvelteInputProps extends HTMLProps<HTMLInputElement> {
       group?: any;
       files?: FileList | null;
+      indeterminate?: boolean;
     }
 
     interface SvelteWindowProps  {

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -229,6 +229,7 @@ declare namespace svelte.JSX {
       allow?: string;
       allowfullscreen?: boolean;
       allowtransparency?: boolean;
+      allowpaymentrequest?: boolean;
       alt?: string;
       async?: boolean;
       autocomplete?: string;


### PR DESCRIPTION
#628 
checked with this:

https://github.com/sveltejs/svelte/blob/82dc26a31c37906153e07686b73d3af08dd50154/src/compiler/compile/render_dom/wrappers/Element/Attribute.ts#L291 

indeterminate seems to be a svelte specific attribute but it wasn't mentioned in the official doc.