### PR TITLE
(chore) bundle svelte-check

### DIFF
--- a/packages/language-server/src/importPackage.ts
+++ b/packages/language-server/src/importPackage.ts
@@ -4,12 +4,21 @@ import * as svelte from 'svelte/compiler';
 import sveltePreprocess from 'svelte-preprocess';
 import { Logger } from './logger';
 
+/**
+ * This function encapsulates the require call in one place
+ * so we can replace its content inside rollup builds
+ * so it's not transformed.
+ */
+function dynamicRequire(dynamicFileToRequire: string): any {
+    return require(dynamicFileToRequire);
+}
+
 export function getPackageInfo(packageName: string, fromPath: string) {
     const packageJSONPath = require.resolve(`${packageName}/package.json`, {
         paths: [fromPath, __dirname]
     });
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { version } = require(packageJSONPath);
+    const { version } = dynamicRequire(packageJSONPath);
     const [major, minor, patch] = version.split('.');
 
     return {
@@ -27,19 +36,19 @@ export function importPrettier(fromPath: string): typeof prettier {
     const pkg = getPackageInfo('prettier', fromPath);
     const main = resolve(pkg.path);
     Logger.log('Using Prettier v' + pkg.version.full, 'from', main);
-    return require(main);
+    return dynamicRequire(main);
 }
 
 export function importSvelte(fromPath: string): typeof svelte {
     const pkg = getPackageInfo('svelte', fromPath);
     const main = resolve(pkg.path, 'compiler');
     Logger.log('Using Svelte v' + pkg.version.full, 'from', main);
-    return require(main);
+    return dynamicRequire(main);
 }
 
 export function importSveltePreprocess(fromPath: string): typeof sveltePreprocess {
     const pkg = getPackageInfo('svelte-preprocess', fromPath);
     const main = resolve(pkg.path);
     Logger.log('Using svelte-preprocess v' + pkg.version.full, 'from', main);
-    return require(main);
+    return dynamicRequire(main);
 }

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -41,7 +41,7 @@ Usage:
 
 Installation:
 
-`npm i svelte-check -g`
+`npm i svelte-check svelte -g`
 
 Usage:
 
@@ -49,17 +49,18 @@ Usage:
 2. `svelte-check`
 
 ### Args:
-|Flag|Description|
-|---|---|
-|`--workspace <path>`| Path to your workspace. All subdirectories except node_modules and those listed in `--ignore` are checked
-|`--output <human\|human-verbose\|machine>`|
-|`--watch`| Will not exit after one pass but keep watching files for changes and rerun diagnostics
-|`--ignore <path1,path2>`| Files/folders to ignore - relative to workspace root, comma-separated, inside quotes. Example: `--ignore "dist,build"`
-|`--fail-on-warnings`| Will also exit with error code when there are warnings
-|`--fail-on-hints`| Will also exit with error code when there are hints
-|`--compiler-warnings <code1:error\|ignore,code2:error\|ignore>`| A list of Svelte compiler warning codes. Each entry defines whether that warning should be ignored or treated as an error. Warnings are comma-separated, between warning code and error level is a colon; all inside quotes. Example: `--compiler-warnings "css-unused-selector:ignore,unused-export-let:error"`
-|`--diagnostic-sources <js,svelte,css>`| A list of diagnostic sources which should run diagnostics on your code. Possible values are `js` (includes TS), `svelte`, `css`. Comma-separated, inside quotes. By default all are active. Example: `--diagnostic-sources "js,svelte"`
-|`--threshold <error\|warning>`| Filters the diagnostics to display. `error` will output only errors while `warning` will output warnings and errors.
+
+| Flag                                                            | Description                                                                                                                                                                                                                                                                                                      |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--workspace <path>`                                            | Path to your workspace. All subdirectories except node_modules and those listed in `--ignore` are checked                                                                                                                                                                                                        |
+| `--output <human\|human-verbose\|machine>`                      |
+| `--watch`                                                       | Will not exit after one pass but keep watching files for changes and rerun diagnostics                                                                                                                                                                                                                           |
+| `--ignore <path1,path2>`                                        | Files/folders to ignore - relative to workspace root, comma-separated, inside quotes. Example: `--ignore "dist,build"`                                                                                                                                                                                           |
+| `--fail-on-warnings`                                            | Will also exit with error code when there are warnings                                                                                                                                                                                                                                                           |
+| `--fail-on-hints`                                               | Will also exit with error code when there are hints                                                                                                                                                                                                                                                              |
+| `--compiler-warnings <code1:error\|ignore,code2:error\|ignore>` | A list of Svelte compiler warning codes. Each entry defines whether that warning should be ignored or treated as an error. Warnings are comma-separated, between warning code and error level is a colon; all inside quotes. Example: `--compiler-warnings "css-unused-selector:ignore,unused-export-let:error"` |
+| `--diagnostic-sources <js,svelte,css>`                          | A list of diagnostic sources which should run diagnostics on your code. Possible values are `js` (includes TS), `svelte`, `css`. Comma-separated, inside quotes. By default all are active. Example: `--diagnostic-sources "js,svelte"`                                                                          |
+| `--threshold <error\|warning>`                                  | Filters the diagnostics to display. `error` will output only errors while `warning` will output warnings and errors.                                                                                                                                                                                             |
 
 ### More docs, preprocessor setup and troubleshooting
 

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-check",
     "description": "Svelte Code Checker Terminal Interface",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "main": "./dist/src/index.js",
     "bin": "./bin/svelte-check",
     "author": "The Svelte Community",
@@ -22,21 +22,34 @@
         "chalk": "^4.0.0",
         "chokidar": "^3.4.1",
         "glob": "^7.1.6",
+        "import-fresh": "^3.2.1",
         "minimist": "^1.2.5",
+        "source-map": "^0.7.3",
+        "svelte-preprocess": "^4.0.0",
+        "typescript": "*"
+    },
+    "peerDependencies": {
+        "svelte": "^3.24.0"
+    },
+    "scripts": {
+        "build": "rollup -c",
+        "test": "echo 'NOOP'"
+    },
+    "devDependencies": {
+        "@rollup/plugin-typescript": "^6.0.0",
+        "@rollup/plugin-commonjs": "^15.0.0",
+        "@rollup/plugin-json": "^4.0.0",
+        "@rollup/plugin-node-resolve": "^9.0.0",
+        "@rollup/plugin-replace": "2.3.3",
+        "@tsconfig/node12": "^1.0.0",
+        "@types/glob": "^7.1.1",
+        "@types/minimist": "^1.2.0",
+        "rollup": "^2.28.0",
+        "rollup-plugin-cleanup": "^3.0.0",
         "svelte-language-server": "*",
         "vscode-languageserver": "6.1.1",
         "vscode-languageserver-protocol": "3.15.3",
         "vscode-languageserver-types": "3.15.1",
         "vscode-uri": "2.1.2"
-    },
-    "scripts": {
-        "build": "tsc",
-        "test": "echo 'NOOP'"
-    },
-    "devDependencies": {
-        "@tsconfig/node12": "^1.0.0",
-        "@types/glob": "^7.1.1",
-        "@types/minimist": "^1.2.0",
-        "typescript": "*"
     }
 }

--- a/packages/svelte-check/rollup.config.js
+++ b/packages/svelte-check/rollup.config.js
@@ -1,0 +1,54 @@
+import typescript from '@rollup/plugin-typescript';
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import json from '@rollup/plugin-json';
+import replace from '@rollup/plugin-replace';
+import cleanup from 'rollup-plugin-cleanup';
+import builtins from 'builtin-modules';
+
+export default [
+    {
+        input: 'src/index.ts',
+        output: [
+            {
+                sourcemap: false,
+                format: 'cjs',
+                file: 'dist/src/index.js'
+            }
+        ],
+        plugins: [
+            // The replace-steps are a hacky workaround to not transform the dynamic
+            // requires inside importPackage.ts of svelte-language-server in any way
+            replace({
+                'return require(dynamicFileToRequire);': 'return "XXXXXXXXXXXXXXXXXXXXX";',
+                delimiters: ['', '']
+            }),
+            resolve({ browser: false, preferBuiltins: true }),
+            commonjs(),
+            json(),
+            typescript(),
+            replace({
+                'return "XXXXXXXXXXXXXXXXXXXXX";': 'return require(dynamicFileToRequire);',
+                delimiters: ['', '']
+            }),
+            cleanup({ comments: ['some', 'ts', 'ts3s'] })
+        ],
+        watch: {
+            clearScreen: false
+        },
+        external: [
+            ...builtins,
+            // svelte-check dependencies that are system-dependent and should
+            // be installed as dependencies through npm
+            'chalk',
+            'chokidar',
+            // Dependencies of svelte-language-server
+            // we don't want to bundle and instead require them as dependencies
+            'typescript',
+            'svelte',
+            'svelte-preprocess',
+            'import-fresh', // because of https://github.com/sindresorhus/import-fresh/issues/18
+            'source-map'
+        ]
+    }
+];

--- a/packages/svelte-check/src/writers.ts
+++ b/packages/svelte-check/src/writers.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import { sep } from 'path';
 import { Writable } from 'stream';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-protocol';
@@ -11,17 +11,20 @@ export interface Writer {
         fileCount: number,
         errorCount: number,
         warningCount: number,
-        hintCount: number,
+        hintCount: number
     ) => void;
     failure: (err: Error) => void;
 }
 
-export type DiagnosticFilter = (diagnostic: Diagnostic) => boolean
+export type DiagnosticFilter = (diagnostic: Diagnostic) => boolean;
 export const DEFAULT_FILTER: DiagnosticFilter = () => true;
 
 export class HumanFriendlyWriter implements Writer {
-    constructor(private stream: Writable, private isVerbose = true,
-        private diagnosticFilter: DiagnosticFilter = DEFAULT_FILTER) {}
+    constructor(
+        private stream: Writable,
+        private isVerbose = true,
+        private diagnosticFilter: DiagnosticFilter = DEFAULT_FILTER
+    ) {}
 
     start(workspaceDir: string) {
         if (this.isVerbose) {

--- a/packages/svelte-check/tsconfig.json
+++ b/packages/svelte-check/tsconfig.json
@@ -3,9 +3,7 @@
     "compilerOptions": {
         "moduleResolution": "node",
         "strict": true,
-        "declaration": true,
-        "outDir": "dist",
-        "composite": true,
-        "esModuleInterop": false
-    }
+        "esModuleInterop": true
+    },
+    "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "references": [
         { "path": "./packages/language-server" },
-        { "path": "./packages/svelte-vscode" },
-        { "path": "./packages/svelte-check" }
+        { "path": "./packages/svelte-vscode" }
     ],
     "files": [],
     "include": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,6 +83,14 @@
     is-module "^1.0.0"
     resolve "^1.17.0"
 
+"@rollup/plugin-replace@2.3.3":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz#cd6bae39444de119f5d905322b91ebd4078562e7"
+  integrity sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+    magic-string "^0.25.5"
+
 "@rollup/plugin-typescript@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-6.0.0.tgz#08635d9d04dc3a099ef0150c289ba5735200bc63"
@@ -1062,6 +1070,11 @@ estraverse@^5.1.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
   integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
 
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
 estree-walker@^1.0.0, estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
@@ -1483,6 +1496,15 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+js-cleanup@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/js-cleanup/-/js-cleanup-1.2.0.tgz#8dbc65954b1d38b255f1e8cf02cd17b3f7a053f9"
+  integrity sha512-JeDD0yiiSt80fXzAVa/crrS0JDPQljyBG/RpOtaSbyDq03VHa9szJWMaWOYU/bcTn412uMN2MxApXq8v79cUiQ==
+  dependencies:
+    magic-string "^0.25.7"
+    perf-regexes "^1.0.1"
+    skip-regex "^1.0.2"
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1598,7 +1620,7 @@ lower-case@^2.0.1:
   dependencies:
     tslib "^1.10.0"
 
-magic-string@^0.25.7:
+magic-string@^0.25.5, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -1983,6 +2005,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+perf-regexes@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/perf-regexes/-/perf-regexes-1.0.1.tgz#6da1d62f5a94bf9353a0451bccacf69068b75d0b"
+  integrity sha512-L7MXxUDtqr4PUaLFCDCXBfGV/6KLIuSEccizDI7JxT+c9x1G1v04BQ4+4oag84SHaCdrBgQAIs/Cqn+flwFPng==
+
 periscopic@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/periscopic/-/periscopic-2.0.2.tgz#17cb0fd368b6e7774cbaa62fa74897c01c7a1bf3"
@@ -2120,12 +2147,27 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-cleanup@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-cleanup/-/rollup-plugin-cleanup-3.2.1.tgz#8cbc92ecf58babd7c210051929797f137bbf777c"
+  integrity sha512-zuv8EhoO3TpnrU8MX8W7YxSbO4gmOR0ny06Lm3nkFfq0IVKdBUtHwhVzY1OAJyNCIAdLiyPnOrU0KnO0Fri1GQ==
+  dependencies:
+    js-cleanup "^1.2.0"
+    rollup-pluginutils "^2.8.2"
+
 rollup-plugin-delete@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-delete/-/rollup-plugin-delete-2.0.0.tgz#262acf80660d48c3b167fb0baabd0c3ab985c153"
   integrity sha512-/VpLMtDy+8wwRlDANuYmDa9ss/knGsAgrDhM+tEwB1npHwNu4DYNmDfUL55csse/GHs9Q+SMT/rw9uiaZ3pnzA==
   dependencies:
     del "^5.1.0"
+
+rollup-pluginutils@^2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
+  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
+  dependencies:
+    estree-walker "^0.6.1"
 
 rollup@^2.28.0:
   version "2.32.0"
@@ -2183,6 +2225,11 @@ sinon@^9.0.0:
     diff "^4.0.2"
     nise "^4.0.1"
     supports-color "^7.1.0"
+
+skip-regex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/skip-regex/-/skip-regex-1.0.2.tgz#ac655d77e7c771ac2b9f37585fea37bff56ad65b"
+  integrity sha512-pEjMUbwJ5Pl/6Vn6FsamXHXItJXSRftcibixDmNCWbWhic0hzHrwkMZo0IZ7fMRH9KxcWDFSkzhccB4285PutA==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -2372,6 +2419,16 @@ supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+svelte-preprocess@^4.0.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.5.2.tgz#37976d1e0d866eb382411d486f7468d2275087e9"
+  integrity sha512-ClUX5NecnGBwI+nJnnBvKKy0XutCq5uHTIKe6cPhpvuOj9AAnyvef9wOZAE93yr85OKPutGCNIJa/X1TrJ7O0Q==
+  dependencies:
+    "@types/pug" "^2.0.4"
+    "@types/sass" "^1.16.0"
+    detect-indent "^6.0.0"
+    strip-indent "^3.0.0"
 
 svelte-preprocess@~4.3.0:
   version "4.3.0"


### PR DESCRIPTION
Bundle the language-server and svelte-check into one file, removing the "language-server/svelte2tsx out of sync"-problems you get when only updating svelte-check. Also hopefully less to download from npm.
Also made one small performance improvement by switch to async glob.