### PR TITLE
Jsdoc tag info on hover/completion

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -22,6 +22,7 @@ import { flatten, getRegExpMatches, isNotNullOrUndefined, pathToUrl } from '../.
 import { AppCompletionItem, AppCompletionList, CompletionsProvider } from '../../interfaces';
 import { SvelteDocumentSnapshot, SvelteSnapshotFragment } from '../DocumentSnapshot';
 import { LSAndTSDocResolver } from '../LSAndTSDocResolver';
+import { getMarkdownDocumentation } from '../previewer';
 import {
     convertRange,
     getCommitCharactersForScriptElement,
@@ -318,7 +319,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
     }
 
     private getCompletionDocument(compDetail: ts.CompletionEntryDetails) {
-        const { source, documentation: tsDocumentation, displayParts } = compDetail;
+        const { source, documentation: tsDocumentation, displayParts, tags } = compDetail;
         let detail: string = this.changeSvelteComponentName(ts.displayPartsToString(displayParts));
 
         if (source) {
@@ -326,8 +327,9 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             detail = `Auto import from ${importPath}\n${detail}`;
         }
 
-        const documentation: MarkupContent | undefined = tsDocumentation
-            ? { value: ts.displayPartsToString(tsDocumentation), kind: MarkupKind.Markdown }
+        const markdownDoc = getMarkdownDocumentation(tsDocumentation, tags);
+        const documentation: MarkupContent | undefined = markdownDoc
+            ? { value: markdownDoc, kind: MarkupKind.Markdown }
             : undefined;
 
         return {

--- a/packages/language-server/src/plugins/typescript/features/HoverProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/HoverProvider.ts
@@ -40,12 +40,13 @@ export class HoverProviderImpl implements HoverProvider {
             .concat(documentation ? ['---', documentation] : [])
             .join('\n');
         const tags = info.tags?.map((tag) => getTagDocumentation(tag))
-            .filter(isNotNullOrUndefined)
-            .join('\n\n');
+            .filter(isNotNullOrUndefined);
 
         return mapObjWithRangeToOriginal(fragment, {
             range: convertRange(fragment, info.textSpan),
-            contents: contents + (tags ? '\n\n' + tags : '')
+            contents: tags ?
+                [contents].concat(tags).join('\n\n') :
+                contents
         });
     }
 

--- a/packages/language-server/src/plugins/typescript/features/HoverProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/HoverProvider.ts
@@ -1,9 +1,11 @@
 import ts from 'typescript';
 import { Hover, Position } from 'vscode-languageserver';
 import { Document, getWordAt, mapObjWithRangeToOriginal } from '../../../lib/documents';
+import { isNotNullOrUndefined } from '../../../utils';
 import { HoverProvider } from '../../interfaces';
 import { SvelteDocumentSnapshot, SvelteSnapshotFragment } from '../DocumentSnapshot';
 import { LSAndTSDocResolver } from '../LSAndTSDocResolver';
+import { getTagDocumentation } from '../previewer';
 import { convertRange } from '../utils';
 import { getComponentAtPosition } from './utils';
 
@@ -37,10 +39,13 @@ export class HoverProviderImpl implements HoverProvider {
         const contents = ['```typescript', declaration, '```']
             .concat(documentation ? ['---', documentation] : [])
             .join('\n');
+        const tags = info.tags?.map((tag) => getTagDocumentation(tag))
+            .filter(isNotNullOrUndefined)
+            .join('\n\n');
 
         return mapObjWithRangeToOriginal(fragment, {
             range: convertRange(fragment, info.textSpan),
-            contents
+            contents: contents + (tags ? '\n\n' + tags : '')
         });
     }
 

--- a/packages/language-server/src/plugins/typescript/previewer.ts
+++ b/packages/language-server/src/plugins/typescript/previewer.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * adopted from https://github.com/microsoft/vscode/blob/10722887b8629f90cc38ee7d90d54e8246dc895f/extensions/typescript-language-features/src/utils/previewer.ts
+ */
+
+import ts from 'typescript';
+
+function replaceLinks(text: string): string {
+    return (
+        text
+            // Http(s) links
+            .replace(
+                /\{@(link|linkplain|linkcode) (https?:\/\/[^ |}]+?)(?:[| ]([^{}\n]+?))?\}/gi,
+                (_, tag: string, link: string, text?: string) => {
+                    switch (tag) {
+                        case 'linkcode':
+                            return `[\`${text ? text.trim() : link}\`](${link})`;
+
+                        default:
+                            return `[${text ? text.trim() : link}](${link})`;
+                    }
+                }
+            )
+    );
+}
+
+function processInlineTags(text: string): string {
+    return replaceLinks(text);
+}
+
+function getTagBodyText(tag: ts.JSDocTagInfo): string | undefined {
+    if (!tag.text) {
+        return undefined;
+    }
+
+    // Convert to markdown code block if it is not already one
+    function makeCodeblock(text: string): string {
+        if (text.match(/^\s*[~`]{3}/g)) {
+            return text;
+        }
+        return '```\n' + text + '\n```';
+    }
+
+    function makeExampleTag(text: string) {
+        // check for caption tags, fix for https://github.com/microsoft/vscode/issues/79704
+        const captionTagMatches = text.match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/);
+        if (captionTagMatches && captionTagMatches.index === 0) {
+            return (
+                captionTagMatches[1] +
+                '\n\n' +
+                makeCodeblock(text.substr(captionTagMatches[0].length))
+            );
+        } else {
+            return makeCodeblock(text);
+        }
+    }
+
+    function makeEmailTag(text: string) {
+        // fix obsucated email address, https://github.com/microsoft/vscode/issues/80898
+        const emailMatch = text.match(/(.+)\s<([-.\w]+@[-.\w]+)>/);
+
+        if (emailMatch === null) {
+            return text;
+        } else {
+            return `${emailMatch[1]} ${emailMatch[2]}`;
+        }
+    }
+
+    switch (tag.name) {
+        case 'example':
+            return makeExampleTag(tag.text);
+        case 'author':
+            return makeEmailTag(tag.text);
+        case 'default':
+            return makeCodeblock(tag.text);
+    }
+
+    return processInlineTags(tag.text);
+}
+
+export function getTagDocumentation(tag: ts.JSDocTagInfo): string | undefined {
+    function getWithType() {
+        const body = (tag.text || '').split(/^(\S+)\s*-?\s*/);
+        if (body?.length === 3) {
+            const param = body[1];
+            const doc = body[2];
+            const label = `*@${tag.name}* \`${param}\``;
+            if (!doc) {
+                return label;
+            }
+            return (
+                label +
+                (doc.match(/\r\n|\n/g)
+                    ? '  \n' + processInlineTags(doc)
+                    : ` — ${processInlineTags(doc)}`)
+            );
+        }
+    }
+
+    switch (tag.name) {
+        case 'augments':
+        case 'extends':
+        case 'param':
+        case 'template':
+            return getWithType();
+    }
+
+    // Generic tag
+    const label = `*@${tag.name}*`;
+    const text = getTagBodyText(tag);
+    if (!text) {
+        return label;
+    }
+    return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` — ${text}`);
+}

--- a/packages/language-server/src/plugins/typescript/previewer.ts
+++ b/packages/language-server/src/plugins/typescript/previewer.ts
@@ -8,6 +8,7 @@
  */
 
 import ts from 'typescript';
+import { isNotNullOrUndefined } from '../../utils';
 
 function replaceLinks(text: string): string {
     return (
@@ -116,4 +117,24 @@ export function getTagDocumentation(tag: ts.JSDocTagInfo): string | undefined {
         return label;
     }
     return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` — ${text}`);
+}
+
+export function plain(parts: ts.SymbolDisplayPart[] | string): string {
+    return processInlineTags(typeof parts === 'string' ? parts : ts.displayPartsToString(parts));
+}
+
+export function getMarkdownDocumentation(
+    documentation: ts.SymbolDisplayPart[] | undefined,
+    tags: ts.JSDocTagInfo[] | undefined
+) {
+    let result: Array<string | undefined> = [];
+    if (documentation) {
+        result.push(plain(documentation));
+    }
+
+    if (tags) {
+        result = result.concat(tags.map(getTagDocumentation));
+    }
+
+    return result.filter(isNotNullOrUndefined).join('\n\n');
 }

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -272,7 +272,7 @@ describe('CompletionProviderImpl', () => {
         });
 
         assert.deepStrictEqual(detail, '(alias) function foo(): boolean\nimport foo');
-        assert.deepStrictEqual(documentation, { value: 'bars', kind: MarkupKind.Markdown });
+        assert.deepStrictEqual(documentation, { value: 'bars\n\n*@author* — John', kind: MarkupKind.Markdown });
     });
 
     it('provides import completions for directory', async () => {

--- a/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
@@ -83,7 +83,7 @@ describe('HoverProvider', () => {
 
         assert.deepStrictEqual(await provider.doHover(document, Position.create(9, 10)), <Hover>{
             contents:
-                '```typescript\nconst withJsDocTag: true\n```\n\n*@author* — foo',
+                '```typescript\nconst withJsDocTag: true\n```\n---\n\n\n*@author* — foo',
             range: {
                 start: {
                     character: 10,

--- a/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
@@ -72,9 +72,28 @@ describe('HoverProvider', () => {
     it('provides formatted hover info for component events', async () => {
         const { provider, document } = setup('hoverinfo.svelte');
 
-        assert.deepStrictEqual(await provider.doHover(document, Position.create(9, 26)), <Hover>{
+        assert.deepStrictEqual(await provider.doHover(document, Position.create(12, 26)), <Hover>{
             contents:
                 '```typescript\nabc: MouseEvent\n```\n\nTEST\n```ts\nconst abc: boolean = true;\n```\n'
+        });
+    });
+
+    it('provides formatted hover info for jsDoc tags', async () => {
+        const { provider, document } = setup('hoverinfo.svelte');
+
+        assert.deepStrictEqual(await provider.doHover(document, Position.create(9, 10)), <Hover>{
+            contents:
+                '```typescript\nconst withJsDocTag: true\n```\n\n*@author* — foo',
+            range: {
+                start: {
+                    character: 10,
+                    line: 9
+                },
+                end: {
+                    character: 22,
+                    line: 9
+                }
+            }
         });
     });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/documentation.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/documentation.ts
@@ -1,4 +1,5 @@
 /**
  * bars
+ * @author John
  */
 export function foo() { return false; }

--- a/packages/language-server/test/plugins/typescript/testfiles/hover/hoverinfo.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/hover/hoverinfo.svelte
@@ -5,6 +5,9 @@
     const withDocs = true
 
     const withoutDocs = true
+
+    /**@author foo */
+    const withJsDocTag = true;
 </script>
 
 <HoverEventsInterface on:abc="{e => e}" />


### PR DESCRIPTION
part 2 of #572 
Not actually much code. Most are adopted from VSCode's codebase. Been trying to avoid copying that previewer file for a long time lol