### PR TITLE
vscode: improved Svelte-Pug syntax highlighting

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -298,6 +298,38 @@
                     "source.ts": "typescript"
                 }
             },
+						{
+							"scopeName": "svelte.pug",
+							"path": "./syntaxes/pug-svelte.json",
+							"injectTo": [
+								"source.svelte"
+							],
+							"embeddedLanguages": {
+								"source.ts": "typescript",
+								"text.pug": "jade"
+							}
+						},			
+						{
+							"scopeName": "svelte.pug.tags",
+							"path": "./syntaxes/pug-svelte-tags.json",
+							"injectTo": [
+								"source.svelte"
+							],
+							"embeddedLanguages": {
+								"source.ts": "typescript",
+								"text.pug": "jade"
+							}
+						},			
+						{
+							"scopeName": "svelte.pug.dotblock",
+							"path": "./syntaxes/pug-svelte-dotblock.json",
+							"injectTo": [
+								"source.svelte"
+							],
+							"embeddedLanguages": {
+								"source.ts": "typescript"
+							}
+						},
             {
                 "scopeName": "markdown.svelte.codeblock",
                 "path": "./syntaxes/markdown-svelte.json",

--- a/packages/svelte-vscode/syntaxes/pug-svelte-dotblock.json
+++ b/packages/svelte-vscode/syntaxes/pug-svelte-dotblock.json
@@ -1,0 +1,55 @@
+{
+  "scopeName": "svelte.pug.dotblock",
+  "fileTypes": [],
+  "injectionSelector": "L:text.block.pug -meta.embedded.ts",
+  "patterns": [
+    {
+      "include": "#interp-object-literal"
+    },
+    {
+      "include": "#interp"
+    }
+  ],
+  "repository": {
+    "interp-object-literal": {
+      "contentName": "meta.interpolation meta.embedded.ts",
+      "begin": "(?![!$#]){\\s*?(?={)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.begin"
+        }
+      },
+      "end": "(?<=})\\s*?}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.end"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.ts#object-literal"
+        }
+      ]
+    },
+    "interp": {
+      "contentName": "meta.interpolation meta.embedded.ts",
+      "begin": "(?![!$#]){",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.begin"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.end"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.ts"
+        }
+      ]
+    }
+  }
+}

--- a/packages/svelte-vscode/syntaxes/pug-svelte-tags.json
+++ b/packages/svelte-vscode/syntaxes/pug-svelte-tags.json
@@ -1,7 +1,7 @@
 {
   "scopeName": "svelte.pug.tags",
   "fileTypes": [],
-  "injectionSelector": "L:meta.tag.other -meta.embedded.ts",
+  "injectionSelector": "L:text.pug meta.tag.other -meta.embedded.ts",
   "patterns": [
     {
       "include": "#interp-object-literal"

--- a/packages/svelte-vscode/syntaxes/pug-svelte-tags.json
+++ b/packages/svelte-vscode/syntaxes/pug-svelte-tags.json
@@ -1,0 +1,201 @@
+{
+  "scopeName": "svelte.pug.tags",
+  "fileTypes": [],
+  "injectionSelector": "L:meta.tag.other -meta.embedded.ts",
+  "patterns": [
+    {
+      "include": "#interp-object-literal"
+    },
+    {
+      "include": "#interp"
+    },
+    {
+      "include": "#attr-function"
+    },
+    {
+      "include": "#attr-interp"
+    },
+    {
+      "include": "#attr-interp-invalid-quotes"
+    },
+    {
+      "include": "#attr-interp-invalid-noquotes"
+    },
+    {
+      "include": "#attr-event"
+    },
+    {
+      "include": "#attr-variable"
+    }
+  ],
+  "repository": {
+    "interp-object-literal": {
+      "contentName": "meta.interpolation meta.embedded.ts",
+      "begin": "(?![!$#]){\\s*?(?={)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.begin"
+        }
+      },
+      "end": "(?<=})\\s*?}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.end"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.ts#object-literal"
+        }
+      ]
+    },
+    "interp": {
+      "contentName": "meta.interpolation meta.embedded.ts",
+      "begin": "(?![!$#]){",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.begin"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.end"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.ts"
+        }
+      ]
+    },
+    "attr-interp": {
+      "match": "\\b(?<=[\\w$\\-_]*)\\s*?(!=|=)\\s*?([`'\"])((?![$!#]){.*})(\\k<2>)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "match": "=",
+              "name": "invalid.illegal"
+            },
+            {
+              "match": "!=",
+              "name": "keyword.operator.assignment"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.section.interpolation.begin"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#interp"
+            }
+          ]
+        },
+        "4": {
+          "name": "punctuation.section.interpolation.begin"
+        }
+      }
+    },
+    "attr-interp-invalid-quotes": {
+      "match": "\\b(?<=[\\w$\\-_]*)\\s*?(!=|=)\\s*?([`'\"])((?![$!#]){.*})(?!\\k<2>)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "match": "=",
+              "name": "invalid.illegal"
+            },
+            {
+              "match": "!=",
+              "name": "keyword.operator.assignment"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.section.interpolation.begin"
+        },
+        "3": {
+          "name": "invalid.illegal"
+        },
+        "4": {
+          "name": "invalid.illegal"
+        }
+      }
+    },
+    "attr-interp-invalid-noquotes": {
+      "match": "\\b(?<=[\\w$\\-_]*)\\s*?(!=|=)\\s*?(?![`'\"])((?![$!#]){.*})(?![`'\"])",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "match": "=",
+              "name": "invalid.illegal"
+            },
+            {
+              "match": "!=",
+              "name": "keyword.operator.assignment"
+            }
+          ]
+        },
+        "2": {
+          "name": "invalid.illegal"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#interp"
+            }
+          ]
+        },
+        "4": {
+          "name": "invalid.illegal"
+        }
+      }
+    },
+    "attr-function": {
+      "match": "\\b(use|transition|in|out|animate)(:)(\\w+)",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name"
+        },
+        "2": {
+          "name": "keyword.operator.assignment"
+        },
+        "3": {
+          "name": "variable.function"
+        }
+      }
+    },
+    "attr-event": {
+      "match": "\\b(on)(:)(\\w+)",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name"
+        },
+        "2": {
+          "name": "keyword.operator.assignment"
+        },
+        "3": {
+          "name": "entity.name.type"
+        }
+      }
+    },
+    "attr-variable": {
+      "match": "\\b(bind|class|let)(:)(\\w+)",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name"
+        },
+        "2": {
+          "name": "keyword.operator.assignment"
+        },
+        "3": {
+          "name": "variable.parameter"
+        }
+      }
+    }
+  }
+}

--- a/packages/svelte-vscode/syntaxes/pug-svelte.json
+++ b/packages/svelte-vscode/syntaxes/pug-svelte.json
@@ -65,7 +65,7 @@
     },
     "tag-component": {
       "name": "meta.tag.svelte",
-      "begin": "(?<=^\\s*?|#\\[\\s*?|:\\s*?)([A-Z][a-zA-Z0-9_]*)\\s*?(?=\\()",
+      "begin": "(?<=^\\s*?|#\\[\\s*?|:\\s+?)([A-Z][a-zA-Z0-9_]*)\\s*?(?=\\()",
       "beginCaptures": {
         "0": {
           "name": "support.class.component.svelte"
@@ -85,7 +85,7 @@
     },
     "tag-component-no-params": {
       "name": "meta.tag.svelte",
-      "match": "(?<=^\\s*?|#\\[\\s*?|:\\s*?)([A-Z][a-zA-Z0-9_]*)",
+      "match": "(?<=^\\s*?|#\\[\\s*?|:\\s+?)([A-Z][a-zA-Z0-9_]*)",
       "captures": {
         "0": {
           "name": "support.class.component.svelte"
@@ -93,7 +93,7 @@
       }
     },
     "mixin-svelte": {
-      "match": "(?<=^\\s*?|#\\[\\s*?|:\\s*?)(\\+)(debug|if|elseif|then|catch|each|await|html|key)\\s*?(\\()\\s*?([`'\"])(.*?)(\\k<4>)\\s*?(\\))",
+      "match": "(?<=^\\s*?|#\\[\\s*?|:\\s+?)(\\+)(debug|if|elseif|then|catch|each|await|html|key)\\s*?(\\()\\s*?([`'\"])(.*?)(\\k<4>)\\s*?(\\))",
       "captures": {
         "1": {
           "name": "punctuation.definition.keyword"
@@ -279,7 +279,7 @@
       }
     },
     "mixin-else": {
-      "match": "(?<=^\\s*?|#\\[\\s*?|:\\s*?)(\\+)(else)",
+      "match": "(?<=^\\s*?|#\\[\\s*?|:\\s+?)(\\+)(else)",
       "captures": {
         "1": {
           "name": "punctuation.definition.keyword"

--- a/packages/svelte-vscode/syntaxes/pug-svelte.json
+++ b/packages/svelte-vscode/syntaxes/pug-svelte.json
@@ -1,0 +1,293 @@
+{
+  "scopeName": "svelte.pug",
+  "fileTypes": [],
+  "injectionSelector": "L:text.pug -meta.embedded.ts -meta.tag.other -text.block.pug, L:inline.pug -meta.embedded.ts -meta.tag.other",
+  "patterns": [
+    {
+      "include": "#interp-object-literal"
+    },
+    {
+      "include": "#interp"
+    },
+    {
+      "include": "#tag-component"
+    },
+    {
+      "include": "#tag-component-no-params"
+    },
+    {
+      "include": "#mixin-svelte"
+    },
+    {
+      "include": "#mixin-else"
+    }
+  ],
+  "repository": {
+    "interp-object-literal": {
+      "contentName": "meta.interpolation meta.embedded.ts",
+      "begin": "(?![!$#]){\\s*?(?={)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.begin"
+        }
+      },
+      "end": "(?<=})\\s*?}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.end"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.ts#object-literal"
+        }
+      ]
+    },
+    "interp": {
+      "contentName": "meta.interpolation meta.embedded.ts",
+      "begin": "(?![!$#]){",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.begin"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.interpolation.end"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.ts"
+        }
+      ]
+    },
+    "tag-component": {
+      "name": "meta.tag.svelte",
+      "begin": "(?<=^\\s*?|#\\[\\s*?|:\\s*?)([A-Z][a-zA-Z0-9_]*)\\s*?(?=\\()",
+      "beginCaptures": {
+        "0": {
+          "name": "support.class.component.svelte"
+        }
+      },
+      "end": "(?<=\\))",
+      "endCaptures": {
+        "0": {
+          "name": "constant.name.attribute.tag"
+        }
+      },
+      "patterns": [
+        {
+          "include": "text.pug#tag_attributes"
+        }
+      ]
+    },
+    "tag-component-no-params": {
+      "name": "meta.tag.svelte",
+      "match": "(?<=^\\s*?|#\\[\\s*?|:\\s*?)([A-Z][a-zA-Z0-9_]*)",
+      "captures": {
+        "0": {
+          "name": "support.class.component.svelte"
+        }
+      }
+    },
+    "mixin-svelte": {
+      "match": "(?<=^\\s*?|#\\[\\s*?|:\\s*?)(\\+)(debug|if|elseif|then|catch|each|await|html|key)\\s*?(\\()\\s*?([`'\"])(.*?)(\\k<4>)\\s*?(\\))",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.keyword"
+        },
+        "2": {
+          "patterns": [
+            {
+              "match": "debug",
+              "name": "keyword.other.debugger"
+            },
+            {
+              "match": "if|elseif",
+              "name": "keyword.control.conditional"
+            },
+            {
+              "match": "then|catch|await",
+              "name": "keyword.control.flow"
+            },
+            {
+              "match": "each",
+              "name": "keyword.control"
+            },
+            {
+              "match": "html|key",
+              "name": "support.function"
+            }
+          ]
+        },
+        "3": {
+          "name": "meta.brace.round"
+        },
+        "4": {
+          "name": "punctuation.definition.generic.begin"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "(?<=each\\s*?\\(\\s*?')(.*)\\s+?(as\\s+?(.*?)(\\s*?,\\s*?)(.*?|)(\\s+?\\(.*\\)|)$)",
+              "captures": {
+                "1": {
+                  "name": "meta.embedded.ts",
+                  "patterns": [
+                    {
+                      "include": "source.ts"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "keyword.control.as"
+                },
+                "3": {
+                  "name": "meta.embedded.t",
+                  "patterns": [
+                    {
+                      "include": "source.ts"
+                    }
+                  ]
+                },
+                "4": {
+                  "name": "punctuation.separator"
+                },
+                "5": {
+                  "name": "meta.embedded.t",
+                  "patterns": [
+                    {
+                      "include": "source.ts"
+                    }
+                  ]
+                },
+                "6": {
+                  "patterns": [
+                    {
+                      "match": "(\\()(.*)(\\))",
+                      "captures": {
+                        "1": {
+                          "name": "meta.brace.round"
+                        },
+                        "2": {
+                          "name": "variable"
+                        },
+                        "3": {
+                          "name": "meta.brace.round"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "match": "(?<=each\\s*?\\(\\s*?')(.*)\\s+?(as\\s+?(.*?)(\\s+?\\(.*\\)|)$)",
+              "captures": {
+                "1": {
+                  "name": "meta.embedded.ts",
+                  "patterns": [
+                    {
+                      "include": "source.ts"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "keyword.control.as"
+                },
+                "3": {
+                  "name": "meta.embedded.t",
+                  "patterns": [
+                    {
+                      "include": "source.ts"
+                    }
+                  ]
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "(\\()(.*)(\\))",
+                      "captures": {
+                        "1": {
+                          "name": "meta.brace.round"
+                        },
+                        "2": {
+                          "name": "variable"
+                        },
+                        "3": {
+                          "name": "meta.brace.round"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "match": "(?<=await\\s*?\\(\\s*?')(.*)\\s+?(then(.*)$)",
+              "captures": {
+                "1": {
+                  "name": "meta.embedded.ts",
+                  "patterns": [
+                    {
+                      "include": "source.ts"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "keyword.control.flow"
+                },
+                "3": {
+                  "name": "variable"
+                }
+              }
+            },
+            {
+              "match": "(?<=debug\\s*?\\(\\s*?')(\\w+?)(,|$)",
+              "captures": {
+                "1": {
+                  "name": "variable"
+                },
+                "2": {
+                  "name": "punctuation.separator"
+                }
+              }
+            },
+            {
+              "match": "(.*)$",
+              "captures": {
+                "0": {
+                  "name": "meta.embedded.ts",
+                  "patterns": [
+                    {
+                      "include": "source.ts"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.definition.generic.end"
+        },
+        "7": {
+          "name": "meta.brace.round"
+        }
+      }
+    },
+    "mixin-else": {
+      "match": "(?<=^\\s*?|#\\[\\s*?|:\\s*?)(\\+)(else)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.keyword"
+        },
+        "2": {
+          "name": "keyword.control.conditional"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Practically fixes https://github.com/sveltejs/language-tools/issues/295, and helps with https://github.com/sveltejs/language-tools/issues/106

#### About
Adds improved syntax highlighting when using Pug with Svelte. It assumes the user is using `svelte-preprocessor`, as the highlighting matches against the mixins that come with that plugin.  As far as I can tell, all of the usual features of Svelte appear mostly natural in Pug now, albeit surrounded in quotation marks for anything embedded.

Please note: this is only a bunch of Textmate bundles. This does not add any additional functionality beyond highlighting and embedding, unfortunately. If less clunky Pug support was to be added, I suspect it would require a modified Pug compiler, or at least a lot of preprocessing with regex.

#### Neat Features:
* Does not clone the original Pug grammar, it instead injects into Pug whenever Pug appears inside a `source.svelte` scope
* Has absolutely no effect on normal Pug files, and probably allows for any extensions interacting with Pug to continue to do so within Svelte
* Validates interpolated `{...}` blocks in certain contexts
  - Checks for mismatched quotes on attribute assignment selections
  - Warns against using a single unsafe `=` instead of `!=`
  - Checks if you just forgot quotes entirely
* Specially handles Svelte's element directives, making it more clear about what type of value you are binding/assigning
* Has a special `{...}` interpolation case, `{{...}}` for object literals instead of statement blocks. This means that when setting opts. objects for functions the syntax highlighting will be appropriate for a JS/TS object
* Handles Pug's wacky shorthand syntax, e.g. `div: Component()`
* Handles inlined Pug, e.g. `p Some text #[+if('someVar') more text] even more text`
* It may actually be more feature-rich than Svelte's native highlighting which I find funny

#### Compromises:
* Requires three separate injected grammars to work properly. I couldn't find any other way to do this - you cannot override an embedded language from a parent language as far as I can tell.
* Most of the scopes only work on one line. This was to make the grammar less agonizing to create. I suspect in 95% of use cases this will be suitable.
* Some of the ways the highlighting works is... dubious, due to it's inherit 'duct-tape on top of duct-tape' nature. I suspect there is edge cases I haven't seen.

#### What's missing?
* Doesn't do anything special with the `svelte:[something]` elements. Doesn't break the highlighting either, though.

#### The bad:
* It's not particularly tested, but I figured I'd rather get it out there and trialed by fire. It's simply too difficult to know how the grammar will be used.
* Textmate grammars are terrible.
* I think Regex took my soul.

#### Some images
![Code_RwJdTdoFvw](https://user-images.githubusercontent.com/34875062/97650964-91a94f80-1a20-11eb-9907-2f02e7d28c26.png)
![Code_R3OhOElzqf](https://user-images.githubusercontent.com/34875062/97651009-a5ed4c80-1a20-11eb-9868-878379894d03.png)
![Code_MB7ry1UTdL](https://user-images.githubusercontent.com/34875062/97652212-7a1f9600-1a23-11eb-8b82-57dcb672a030.png)

