### PR TITLE
(fix) handle negative lines in mapper

### DIFF
--- a/packages/language-server/src/lib/documents/DocumentMapper.ts
+++ b/packages/language-server/src/lib/documents/DocumentMapper.ts
@@ -130,6 +130,10 @@ export class SourceMapDocumentMapper implements DocumentMapper {
             generatedPosition = this.parent.getOriginalPosition(generatedPosition);
         }
 
+        if (generatedPosition.line < 0) {
+            return { line: -1, character: -1 };
+        }
+
         const mapped = this.consumer.originalPositionFor({
             line: generatedPosition.line + 1,
             column: generatedPosition.character

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -414,4 +414,46 @@ describe('SveltePlugin#getDiagnostics', () => {
             }
         ]);
     });
+
+    it('should correctly determine diagnostic position for script when theres also context="module"', async () => {
+        const { plugin, document } = setupFromFile('diagnostics-module-and-instance.svelte');
+        const diagnostics = await plugin.getDiagnostics(document);
+
+        assert.deepStrictEqual(diagnostics, [
+            {
+                code: 'unused-export-let',
+                message:
+                    "Component has unused export property 'unused1'. If it is for external reference only, please consider using `export const unused1`",
+                range: {
+                    end: {
+                        line: 4,
+                        character: 18
+                    },
+                    start: {
+                        line: 4,
+                        character: 18
+                    }
+                },
+                severity: 2,
+                source: 'svelte'
+            },
+            {
+                code: 'unused-export-let',
+                message:
+                    "Component has unused export property 'unused2'. If it is for external reference only, please consider using `export const unused2`",
+                range: {
+                    end: {
+                        line: 6,
+                        character: 28
+                    },
+                    start: {
+                        line: 6,
+                        character: 8
+                    }
+                },
+                severity: 2,
+                source: 'svelte'
+            }
+        ]);
+    });
 });

--- a/packages/language-server/test/plugins/svelte/testfiles/diagnostics-module-and-instance.svelte
+++ b/packages/language-server/test/plugins/svelte/testfiles/diagnostics-module-and-instance.svelte
@@ -1,0 +1,8 @@
+<script context="module" lang="ts">
+  let unsuedVar: undefined;
+</script>
+
+<script lang="ts">
+  export let unused1 = true;
+  export let unused2 = true;
+</script>


### PR DESCRIPTION
Now the warnings of #666 are shown, but at the wrong lines. The problem is that the module script is transpiled, too, but that is not taken into account in our mapping. I'm hesitant to fix this since a preprocessor source map handling is coming to svelte core, so I prefer to wait on that.