### PR TITLE
ignore html end-tag-like inside moustache

### DIFF
--- a/packages/language-server/src/lib/documents/Document.ts
+++ b/packages/language-server/src/lib/documents/Document.ts
@@ -1,6 +1,7 @@
 import { urlToPath } from '../../utils';
 import { WritableDocument } from './DocumentBase';
-import { extractScriptTags, extractStyleTag, TagInformation, parseHtml } from './utils';
+import { extractScriptTags, extractStyleTag, TagInformation } from './utils';
+import { parseHtml } from './parseHtml';
 import { SvelteConfig, loadConfig } from './configLoader';
 import { HTMLDocument } from 'vscode-html-languageservice';
 

--- a/packages/language-server/src/lib/documents/parseHtml.ts
+++ b/packages/language-server/src/lib/documents/parseHtml.ts
@@ -1,0 +1,70 @@
+import { getLanguageService, HTMLDocument, TokenType } from 'vscode-html-languageservice';
+import { isInsideMoustacheTag } from './utils';
+
+const parser = getLanguageService();
+
+/**
+ * Parses text as HTML
+ */
+export function parseHtml(text: string): HTMLDocument {
+    const preprocessed = preprocess(text);
+
+    // We can safely only set getText because only this is used for parsing
+    const parsedDoc = parser.parseHTMLDocument(<any>{ getText: () => preprocessed });
+
+    return parsedDoc;
+}
+
+const OPEN_TAG_SELF_CLOSE = '/>';
+const blankRegex = /(=>|>=)/g;
+
+function preprocess(text: string) {
+    const scanner = parser.createScanner(text);
+    let result = text;
+    let token = scanner.scan();
+    let currentStartTagStart: number | null = null;
+    let currentStartTagEndShort = false;
+
+    while (token !== TokenType.EOS) {
+        const offset = scanner.getTokenOffset();
+
+        if (token === TokenType.StartTagOpen) {
+            removeEnd(offset);
+            currentStartTagEndShort = false;
+            currentStartTagStart = offset;
+        }
+
+        if (token === TokenType.StartTagClose) {
+            if (
+                currentStartTagStart !== null &&
+                isInsideMoustacheTag(text, currentStartTagStart, offset)
+            ) {
+                currentStartTagEndShort = true;
+            }
+        }
+
+        if (token === TokenType.EndTagOpen) {
+            removeEnd(offset);
+            currentStartTagStart = null;
+            currentStartTagEndShort = false;
+        }
+
+        token = scanner.scan();
+    }
+
+    return result;
+
+    function removeEnd(offset: number) {
+        if (currentStartTagStart === null) {
+            return;
+        }
+
+        const contentWithin = text.substring(currentStartTagStart, offset);
+        if (currentStartTagEndShort && contentWithin.includes(OPEN_TAG_SELF_CLOSE)) {
+            result =
+                result.substring(0, currentStartTagStart) +
+                contentWithin.replace(blankRegex, '  ') +
+                result.substring(offset);
+        }
+    }
+}

--- a/packages/language-server/src/lib/documents/parseHtml.ts
+++ b/packages/language-server/src/lib/documents/parseHtml.ts
@@ -27,6 +27,9 @@ const createScanner = parser.createScanner as (
     initialState?: ScannerState
 ) => Scanner;
 
+/**
+ * scan the text and remove any `>` that cause the tag to end short
+ */
 function preprocess(text: string) {
     let scanner = createScanner(text);
     let token = scanner.scan();
@@ -39,14 +42,13 @@ function preprocess(text: string) {
             currentStartTagStart = offset;
         }
 
-        if (token === TokenType.StartTagClose) {
-            if (
-                currentStartTagStart !== null &&
-                isInsideMoustacheTag(text, currentStartTagStart, offset)
-            ) {
-                text = text.substring(0, offset) + ' ' + text.substring(offset + 1);
-                scanner = createScanner(text, offset, ScannerState.AfterAttributeName);
-            }
+        if (
+            token === TokenType.StartTagClose &&
+            currentStartTagStart !== null &&
+            isInsideMoustacheTag(text, currentStartTagStart, offset)
+        ) {
+            text = text.substring(0, offset) + ' ' + text.substring(offset + 1);
+            scanner = createScanner(text, offset, ScannerState.AfterAttributeName);
         }
 
         token = scanner.scan();

--- a/packages/language-server/src/lib/documents/parseHtml.ts
+++ b/packages/language-server/src/lib/documents/parseHtml.ts
@@ -45,7 +45,7 @@ function preprocess(text: string) {
                 currentStartTagStart !== null &&
                 isInsideMoustacheTag(text, currentStartTagStart, offset)
             ) {
-                removeTagEndLike(offset);
+                result = result.substring(0, offset) + ' ' + result.substring(offset + 1);
                 scanner = createScanner(text, offset, ScannerState.AfterAttributeName);
                 scanner.scan();
             }
@@ -55,12 +55,4 @@ function preprocess(text: string) {
     }
 
     return result;
-
-    function removeTagEndLike(offset: number) {
-        if (currentStartTagStart === null) {
-            return;
-        }
-
-        result = result.substring(0, offset) + ' ' + result.substring(offset + 1);
-    }
 }

--- a/packages/language-server/src/lib/documents/parseHtml.ts
+++ b/packages/language-server/src/lib/documents/parseHtml.ts
@@ -48,7 +48,7 @@ function preprocess(text: string) {
             isInsideMoustacheTag(text, currentStartTagStart, offset)
         ) {
             text = text.substring(0, offset) + ' ' + text.substring(offset + 1);
-            scanner = createScanner(text, offset, ScannerState.AfterAttributeName);
+            scanner = createScanner(text, offset, ScannerState.WithinTag);
         }
 
         token = scanner.scan();

--- a/packages/language-server/src/lib/documents/parseHtml.ts
+++ b/packages/language-server/src/lib/documents/parseHtml.ts
@@ -29,7 +29,6 @@ const createScanner = parser.createScanner as (
 
 function preprocess(text: string) {
     let scanner = createScanner(text);
-    let result = text;
     let token = scanner.scan();
     let currentStartTagStart: number | null = null;
 
@@ -45,14 +44,13 @@ function preprocess(text: string) {
                 currentStartTagStart !== null &&
                 isInsideMoustacheTag(text, currentStartTagStart, offset)
             ) {
-                result = result.substring(0, offset) + ' ' + result.substring(offset + 1);
+                text = text.substring(0, offset) + ' ' + text.substring(offset + 1);
                 scanner = createScanner(text, offset, ScannerState.AfterAttributeName);
-                scanner.scan();
             }
         }
 
         token = scanner.scan();
     }
 
-    return result;
+    return text;
 }

--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -1,7 +1,8 @@
 import { clamp, isInRange, regexLastIndexOf } from '../../utils';
 import { Position, Range } from 'vscode-languageserver';
-import { Node, getLanguageService, HTMLDocument } from 'vscode-html-languageservice';
+import { Node, HTMLDocument } from 'vscode-html-languageservice';
 import * as path from 'path';
+import { parseHtml } from './parseHtml';
 
 export interface TagInformation {
     content: string;
@@ -36,16 +37,6 @@ function parseAttributes(
         }
         return attrValue;
     }
-}
-
-const parser = getLanguageService();
-
-/**
- * Parses text as HTML
- */
-export function parseHtml(text: string): HTMLDocument {
-    // We can safely only set getText because only this is used for parsing
-    return parser.parseHTMLDocument(<any>{ getText: () => text });
 }
 
 const regexIf = new RegExp('{#if\\s.*?}', 'gms');
@@ -374,4 +365,9 @@ export function getLangAttribute(...tags: Array<TagInformation | null>): string 
     }
 
     return attribute.replace(/^text\//, '');
+}
+
+export function isInsideMoustacheTag(html: string, tagStart: number, position: number) {
+    const charactersInNode = html.substring(tagStart, position);
+    return charactersInNode.lastIndexOf('{') > charactersInNode.lastIndexOf('}');
 }

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -22,6 +22,7 @@ import {
 import { LSConfigManager, LSHTMLConfig } from '../../ls-config';
 import { svelteHtmlDataProvider } from './dataProvider';
 import { HoverProvider, CompletionsProvider } from '../interfaces';
+import { isInsideMoustacheTag } from '../../lib/documents/utils';
 
 export class HTMLPlugin implements HoverProvider, CompletionsProvider {
     private configManager: LSConfigManager;
@@ -180,8 +181,7 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
     private isInsideMoustacheTag(html: HTMLDocument, document: Document, position: Position) {
         const offset = document.offsetAt(position);
         const node = html.findNodeAt(offset);
-        const charactersInNode = document.getText().substring(node.start, offset);
-        return charactersInNode.lastIndexOf('{') > charactersInNode.lastIndexOf('}');
+        return isInsideMoustacheTag(document.getText(), node.start, offset);
     }
 
     getDocumentSymbols(document: Document): SymbolInformation[] {

--- a/packages/language-server/test/lib/documents/parseHtml.test.ts
+++ b/packages/language-server/test/lib/documents/parseHtml.test.ts
@@ -1,28 +1,40 @@
 import assert from 'assert';
+import { HTMLDocument } from 'vscode-html-languageservice';
 import { parseHtml } from '../../../src/lib/documents/parseHtml';
 
 describe('parseHtml', () => {
-    it('ignore arrow inside moustache', () => {
-        const { roots } = parseHtml(
-            `<Foo on:click={() => console.log('ya!!!')} />
-            <style></style>`
-        );
-
-        assert.deepStrictEqual(roots.map(r => r.tag), [
+    const testRootElements = (document: HTMLDocument) => {
+        assert.deepStrictEqual(document.roots.map(r => r.tag), [
             'Foo',
             'style'
         ]);
+    };
+
+    it('ignore arrow inside moustache', () => {
+        testRootElements(parseHtml(
+            `<Foo on:click={() => console.log('ya!!!')} />
+            <style></style>`
+        ));
     });
 
     it('ignore bigger than inside moustache', () => {
-        const { roots } = parseHtml(
+        testRootElements(parseHtml(
             `<Foo checked={a > 1} />
             <style></style>`
-        );
+        ));
+    });
 
-        assert.deepStrictEqual(roots.map(r => r.tag), [
-            'Foo',
-            'style'
-        ]);
+    it('parse baseline html', () => {
+        testRootElements(parseHtml(
+            `<Foo checked />
+            <style></style>`
+        ));
+    });
+
+    it('parse baseline html with moustache', () => {
+        testRootElements(parseHtml(
+            `<Foo checked={a} />
+            <style></style>`
+        ));
     });
 });

--- a/packages/language-server/test/lib/documents/parseHtml.test.ts
+++ b/packages/language-server/test/lib/documents/parseHtml.test.ts
@@ -2,9 +2,21 @@ import assert from 'assert';
 import { parseHtml } from '../../../src/lib/documents/parseHtml';
 
 describe('parseHtml', () => {
-    it('ignore html end-tag-like inside moustache', () => {
+    it('ignore arrow inside moustache', () => {
         const { roots } = parseHtml(
             `<Foo on:click={() => console.log('ya!!!')} />
+            <style></style>`
+        );
+
+        assert.deepStrictEqual(roots.map(r => r.tag), [
+            'Foo',
+            'style'
+        ]);
+    });
+
+    it('ignore bigger than inside moustache', () => {
+        const { roots } = parseHtml(
+            `<Foo checked={a > 1} />
             <style></style>`
         );
 

--- a/packages/language-server/test/lib/documents/parseHtml.test.ts
+++ b/packages/language-server/test/lib/documents/parseHtml.test.ts
@@ -4,37 +4,73 @@ import { parseHtml } from '../../../src/lib/documents/parseHtml';
 
 describe('parseHtml', () => {
     const testRootElements = (document: HTMLDocument) => {
-        assert.deepStrictEqual(document.roots.map(r => r.tag), [
-            'Foo',
-            'style'
-        ]);
+        assert.deepStrictEqual(
+            document.roots.map((r) => r.tag),
+            ['Foo', 'style']
+        );
     };
 
     it('ignore arrow inside moustache', () => {
-        testRootElements(parseHtml(
-            `<Foo on:click={() => console.log('ya!!!')} />
-            <style></style>`
-        ));
+        testRootElements(
+            parseHtml(
+                `<Foo on:click={() => console.log('ya!!!')} />
+                <style></style>`
+            )
+        );
     });
 
-    it('ignore bigger than inside moustache', () => {
-        testRootElements(parseHtml(
-            `<Foo checked={a > 1} />
-            <style></style>`
-        ));
+    it('ignore greater than operator inside moustache', () => {
+        testRootElements(
+            parseHtml(
+                `<Foo checked={a > 1} />
+                <style></style>`
+            )
+        );
+    });
+
+    it('ignore less than operator inside moustache', () => {
+        testRootElements(
+            parseHtml(
+                `<Foo checked={a < 1} />
+                <style></style>`
+            )
+        );
+    });
+
+    it('ignore less than operator inside moustache with tag not self closed', () => {
+        testRootElements(
+            parseHtml(
+                `<Foo checked={a < 1}>
+                </Foo>
+                <style></style>`
+            )
+        );
     });
 
     it('parse baseline html', () => {
-        testRootElements(parseHtml(
-            `<Foo checked />
-            <style></style>`
-        ));
+        testRootElements(
+            parseHtml(
+                `<Foo checked />
+                <style></style>`
+            )
+        );
     });
 
     it('parse baseline html with moustache', () => {
-        testRootElements(parseHtml(
-            `<Foo checked={a} />
-            <style></style>`
-        ));
+        testRootElements(
+            parseHtml(
+                `<Foo checked={a} />
+                <style></style>`
+            )
+        );
+    });
+
+    it('parse baseline html with possibly un-closed start tag', () => {
+        testRootElements(
+            parseHtml(
+                `<Foo checked={a}
+                <style></style>`
+            )
+        );
     });
 });

--- a/packages/language-server/test/lib/documents/parseHtml.test.ts
+++ b/packages/language-server/test/lib/documents/parseHtml.test.ts
@@ -1,0 +1,16 @@
+import assert from 'assert';
+import { parseHtml } from '../../../src/lib/documents/parseHtml';
+
+describe('parseHtml', () => {
+    it('ignore html start/end tag like inside moustache', () => {
+        const { roots } = parseHtml(
+            `<Foo on:click={() => console.log('ya!!!')} />
+            <style></style>`
+        );
+
+        assert.deepStrictEqual(roots.map(r => r.tag), [
+            'Foo',
+            'style'
+        ]);
+    });
+});


### PR DESCRIPTION
related #309 

kind of hacky, but it would fix some situation where style tag not being extracted when it's after a self-closed tag with a arrow function props or a event handler.
```svelte
<Foo on:click={() => console.log('yeah!!!')} />
<style></style>
```
There're cases like this:
```svelte
<Foo selected={a > b} />
```
not being covered, But I think dealing with that with this method would have a higher change removing the actual tag end.

Another approach is to use `html-language-service`'s internal api, like [this branch](https://github.com/jasonlyu123/language-tools/blob/enhance-parser-internal/packages/language-server/src/lib/documents/parseHtml.ts)

Or we can alter the `html-language-service`'s `htmlScanner`. [vetur](https://github.com/vuejs/vetur/blob/master/server/src/modes/template/parser/htmlScanner.ts) has a similar scanner to [it](https://github.com/microsoft/vscode-html-languageservice/blob/master/src/parser/htmlScanner.ts). 