### PR TITLE
Fix default export return type

### DIFF
--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -24,23 +24,7 @@ declare class Svelte2TsxComponent<
      */
     $$slot_def: Slots;
     // https://svelte.dev/docs#Client-side_component_API
-    constructor(options: {
-        /**
-         * An HTMLElement to render to. This option is required.
-         */
-        target: Element;
-        /**
-         * A child of `target` to render the component immediately before.
-         */
-        anchor?: Element;
-        /**
-         * An object of properties to supply to the component.
-         */
-        props?: Props;
-        hydrate?: boolean;
-        intro?: boolean;
-        $$inline?: boolean;
-    });
+    constructor(options: Svelte2TsxComponentConstructorParameters<Props>);
     /**
      * Causes the callback function to be called whenever the component dispatches an event.
      * A function is returned that will remove the event listener when called.
@@ -62,7 +46,30 @@ declare class Svelte2TsxComponent<
     $inject_state(): void;
 }
 
-type AConstructorTypeOf<T> = new (...args: any[]) => T;
+interface Svelte2TsxComponentConstructorParameters<Props extends {}> {
+    /**
+     * An HTMLElement to render to. This option is required.
+     */
+    target: Element;
+    /**
+     * A child of `target` to render the component immediately before.
+     */
+    anchor?: Element;
+    /**
+     * An object of properties to supply to the component.
+     */
+    props?: Props;
+    hydrate?: boolean;
+    intro?: boolean;
+    $$inline?: boolean;
+}
+
+// TODO: Update all `AConstructorTypeOf` references to pass constructor args when it makes sense.
+// Check if should add prototype... seems to work fine without it thus far
+type AConstructorTypeOf<T, U extends any[] = any[]> = new (...args: U) => T;
+
+// TODO: Replace AConstructorTypeOf with more specific types so intellisense shows helpful hits like 'options' instead of args[0]
+type SvelteComponentConstructor<T, U extends Svelte2TsxComponentConstructorParameters<any>> = new (options: U) => T;
 
 type SvelteAction<U extends any[], El extends any> = (node: El, ...args:U) => {
 	update?: (...args:U) => void,
@@ -174,7 +181,7 @@ declare function __sveltets_each<T>(
 
 declare function createSvelte2TsxComponent<Props, Events, Slots>(
     render: () => {props?: Props, events?: Events, slots?: Slots }
-): AConstructorTypeOf<Svelte2TsxComponent<Props, Events, Slots>>;
+): SvelteComponentConstructor<Svelte2TsxComponent<Props, Events, Slots>,Svelte2TsxComponentConstructorParameters<Props>>;
 
 declare function __sveltets_unwrapArr<T>(arr: ArrayLike<T>): T
 declare function __sveltets_unwrapPromiseLike<T>(promise: PromiseLike<T> | T): T

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -64,11 +64,7 @@ interface Svelte2TsxComponentConstructorParameters<Props extends {}> {
     $$inline?: boolean;
 }
 
-// TODO: Update all `AConstructorTypeOf` references to pass constructor args when it makes sense.
-// Check if should add prototype... seems to work fine without it thus far
 type AConstructorTypeOf<T, U extends any[] = any[]> = new (...args: U) => T;
-
-// TODO: Replace AConstructorTypeOf with more specific types so intellisense shows helpful hits like 'options' instead of args[0]
 type SvelteComponentConstructor<T, U extends Svelte2TsxComponentConstructorParameters<any>> = new (options: U) => T;
 
 type SvelteAction<U extends any[], El extends any> = (node: El, ...args:U) => {


### PR DESCRIPTION
Currently the tsx we generate seems to loose type information and generate invalid d.ts files.
The type loss seems to be due to the use of [`AConstructorTypeOf`](https://stackoverflow.com/questions/39614311/class-constructor-type-in-typescript#comment107698653_56760166). 

This currently affects the svelte-vscode package. In a non-mythical `B.svelte` I get
```ts
<script lang="ts">
import A from './A.svelte'
const a = new A({})
//             ^ `(alias) new A(...args: any[]): A new A() = ()` 
//                Type resolves incorrectly.
//                Attempts to autocomplete target/props in the brackets will fail.
</script>
<A></A>
<!-- ^ JSX is fine. Resolved properly! Hurray!! -->
```

I did not understand why we are using virtual functions here to begin with (or how to make it work in this case) so I eliminated it and just extended Svelte2TsxComponent directly. This fixes the issue above along with the problems I was having writing my own package which depends on svelte2tsx.

I have yet to update the tests. This invalidates all svelte2tsx sample tests.
I still need to double check the types I generate. Especially the types for events/slots. (should these be partial?) Will try to check what the jsx thinks it is and act accordingly.

For anyone who wants to test the vscode svelte plugin with this change. Here is a working snipit to install it. Other than `new Component({})` now being properly typed in svelte files, I believe there is no noticeable change.
If there are any new issues, I imagine they will probably be blatantly obvious like... no types working for svelte files, all svelte imports having wrong types, or svelte-check not working at all.
```bash
#!/bin/bash

# ensure we die on error
set -e

# Fetch modified repo
# git clean -fxd
# git checkout -- ./
# git pull

# optionaly rename the vscode extension so you do not have to remove the existing extension, just disable it.
sed --in-place -e 's/^\(\s*"name": \)"[^"]*"/\1"svelte-vscode-unstableer"/' packages/svelte-vscode/package.json

# here is the deal. yarn is not working for us at all. It hates local packages as much as it loathes me, and one of the tasks of your github workflow is to kill it anyways....
rm --force yarn.lock package.json packages/svelte-vscode/yarn.lock

# Build and pack our changes
pushd packages/svelte2tsx
npm i
npm run build
npm pack
popd

# Install changes into language-server
pushd packages/language-server
npm i
npm i ../svelte2tsx/svelte2tsx-0.1.4.tgz
npm run build 
npm pack
popd

# And the new language-server into svelte-check
pushd packages/svelte-check
npm i
npm i ../language-server/svelte-language-server-0.10.3.tgz
npm run build 
npm pack
popd

# And the new language-server into vscode
pushd packages/svelte-vscode
npm i
npm i ../language-server/svelte-language-server-0.10.3.tgz
# FIXME: this needs to go in devDeps or somewhere
npm i --no-save js-yaml
npm run build
npx vsce package
popd

# undo the wierdness
git checkout -- ./
```
After running the above, you can install the new vscode extension via
```bash
# assumes vscode is installed as the `code` binary.
code --install-extension ./packages/svelte-vscode/svelte-vscode-unstableer-0.5.0.vsix
```
Additionally, each of the other packages have their own `.tgz` file that you can install for testing as well. such as `packages/svelte-check/svelte-check-1.1.0.tgz`

Despite the fact it is intended as a fix, this is probably a breaking change... for some project somewhere.... just like it breaks our tests