### PR TITLE
(fix) no html hover info for Svelte components

### DIFF
--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -50,6 +50,14 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
             return null;
         }
 
+        const node = html.findNodeAt(document.offsetAt(position));
+        if (!node || node.tag?.[0].match(/[A-Z]/)) {
+            // The language service is case insensitive, and would provide
+            // hover info for Svelte components like `Option` which have
+            // the same name like a html tag.
+            return null;
+        }
+
         return this.lang.doHover(document, position, html);
     }
 

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -38,6 +38,12 @@ describe('HTML Plugin', () => {
         assert.strictEqual(plugin.doHover(document, Position.create(0, 10)), null);
     });
 
+    it('does not provide hover info for component having the same name as a html element but being uppercase', async () => {
+        const { plugin, document } = setup('<Div></Div>');
+
+        assert.deepStrictEqual(plugin.doHover(document, Position.create(0, 2)), null);
+    });
+
     it('provides completions', async () => {
         const { plugin, document } = setup('<');
 


### PR DESCRIPTION
The HTML language service is case insensitive, and would provide hover info for Svelte components like `Option` which have the same name like a html tag. Prevent that by returning early.
#711