### PR TITLE
(chore) bump lsp

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "lint": "eslint \"packages/**/*.{ts,js}\""
     },
     "dependencies": {
-        "axios": "0.19.2"
+        "axios": "0.19.2",
+        "typescript": "^4.1.3"
     },
     "devDependencies": {
         "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.2.0",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "svelte-language-server",
-    "version": "0.10.3",
+    "version": "0.11.0",
     "description": "A language server for Svelte",
     "main": "dist/src/index.js",
     "typings": "dist/src/index",
@@ -50,21 +50,18 @@
         "cosmiconfig": "^7.0.0",
         "estree-walker": "^2.0.1",
         "lodash": "^4.17.19",
-        "prettier": "2.1.2",
+        "prettier": "2.2.1",
         "prettier-plugin-svelte": "~1.4.1",
         "source-map": "^0.7.3",
-        "svelte": "3.28.0",
+        "svelte": "3.31.0",
         "svelte-preprocess": "~4.6.1",
         "svelte2tsx": "*",
         "typescript": "*",
-        "vscode-css-languageservice": "4.2.0",
-        "vscode-emmet-helper": "1.2.17",
-        "vscode-html-languageservice": "3.1.4",
-        "vscode-languageserver": "6.1.1",
-        "vscode-languageserver-types": "3.15.1",
+        "vscode-css-languageservice": "5.0.0",
+        "vscode-emmet-helper": "2.1.2",
+        "vscode-html-languageservice": "4.0.0",
+        "vscode-languageserver": "7.0.0",
+        "vscode-languageserver-types": "3.16.0",
         "vscode-uri": "2.1.2"
-    },
-    "resolutions": {
-        "vscode-languageserver-types": "3.15.1"
     }
 }

--- a/packages/language-server/src/lib/DiagnosticsManager.ts
+++ b/packages/language-server/src/lib/DiagnosticsManager.ts
@@ -1,7 +1,7 @@
-import { IConnection, TextDocumentIdentifier, Diagnostic } from 'vscode-languageserver';
+import { _Connection, TextDocumentIdentifier, Diagnostic } from 'vscode-languageserver';
 import { DocumentManager, Document } from './documents';
 
-export type SendDiagnostics = IConnection['sendDiagnostics'];
+export type SendDiagnostics = _Connection['sendDiagnostics'];
 export type GetDiagnostics = (doc: TextDocumentIdentifier) => Thenable<Diagnostic[]>;
 
 export class DiagnosticsManager {

--- a/packages/language-server/src/lib/documents/DocumentMapper.ts
+++ b/packages/language-server/src/lib/documents/DocumentMapper.ts
@@ -9,7 +9,9 @@ import {
     LocationLink,
     TextDocumentEdit,
     CodeAction,
-    SelectionRange
+    SelectionRange,
+    TextEdit,
+    InsertReplaceEdit
 } from 'vscode-languageserver';
 import { TagInformation, offsetAt, positionAt } from './utils';
 import { SourceMapConsumer } from 'source-map';
@@ -206,10 +208,14 @@ export function mapRangeToOriginal(
     fragment: Pick<DocumentMapper, 'getOriginalPosition'>,
     range: Range
 ): Range {
-    return Range.create(
-        fragment.getOriginalPosition(range.start),
-        fragment.getOriginalPosition(range.end)
-    );
+    // DON'T use Range.create here! Positions might not be mapped
+    // and therefore return negative numbers, which makes Range.create throw.
+    // These invalid position need to be handled
+    // on a case-by-case basis in the calling functions.
+    return {
+        start: fragment.getOriginalPosition(range.start),
+        end: fragment.getOriginalPosition(range.end)
+    };
 }
 
 export function mapRangeToGenerated(fragment: DocumentMapper, range: Range): Range {
@@ -227,7 +233,10 @@ export function mapCompletionItemToOriginal(
         return item;
     }
 
-    return { ...item, textEdit: mapObjWithRangeToOriginal(fragment, item.textEdit) };
+    return {
+        ...item,
+        textEdit: mapEditToOriginal(fragment, item.textEdit)
+    };
 }
 
 export function mapHoverToParent(
@@ -246,6 +255,26 @@ export function mapObjWithRangeToOriginal<T extends { range: Range }>(
     objWithRange: T
 ): T {
     return { ...objWithRange, range: mapRangeToOriginal(fragment, objWithRange.range) };
+}
+
+export function mapInsertReplaceEditToOriginal(
+    fragment: Pick<DocumentMapper, 'getOriginalPosition'>,
+    edit: InsertReplaceEdit
+): InsertReplaceEdit {
+    return {
+        ...edit,
+        insert: mapRangeToOriginal(fragment, edit.insert),
+        replace: mapRangeToOriginal(fragment, edit.replace)
+    };
+}
+
+export function mapEditToOriginal(
+    fragment: Pick<DocumentMapper, 'getOriginalPosition'>,
+    edit: TextEdit | InsertReplaceEdit
+): TextEdit | InsertReplaceEdit {
+    return TextEdit.is(edit)
+        ? mapObjWithRangeToOriginal(fragment, edit)
+        : mapInsertReplaceEditToOriginal(fragment, edit);
 }
 
 export function mapDiagnosticToGenerated(

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -1,6 +1,6 @@
 import { merge, get } from 'lodash';
 import { UserPreferences } from 'typescript';
-import { EmmetConfiguration } from 'vscode-emmet-helper';
+import { VSCodeEmmetConfig } from 'vscode-emmet-helper';
 
 /**
  * Default config for the language server.
@@ -219,7 +219,7 @@ export class LSConfigManager {
         }
     };
     private prettierConfig: any = {};
-    private emmetConfig: EmmetConfiguration = {};
+    private emmetConfig: VSCodeEmmetConfig = {};
 
     /**
      * Updates config.
@@ -268,11 +268,11 @@ export class LSConfigManager {
         this.listeners.push(callback);
     }
 
-    updateEmmetConfig(config: EmmetConfiguration): void {
+    updateEmmetConfig(config: VSCodeEmmetConfig): void {
         this.emmetConfig = config || {};
     }
 
-    getEmmetConfig(): EmmetConfiguration {
+    getEmmetConfig(): VSCodeEmmetConfig {
         return this.emmetConfig;
     }
 

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -203,7 +203,7 @@ export class CSSPlugin
             .getGlobalVars()
             .map((globalVar) => ({
                 label: `var(${globalVar.name})`,
-                sortText: `-`,
+                sortText: '-',
                 detail: `${globalVar.filename}\n\n${globalVar.name}: ${globalVar.value}`,
                 kind: CompletionItemKind.Value
             }));

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -158,10 +158,13 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
                     insertText:
                         existingCompletion.insertText &&
                         `${existingCompletion.insertText} lang="${lang}"`,
-                    textEdit: existingCompletion.textEdit && {
-                        range: existingCompletion.textEdit.range,
-                        newText: `${existingCompletion.textEdit.newText} lang="${lang}"`
-                    }
+                    textEdit:
+                        existingCompletion.textEdit && TextEdit.is(existingCompletion.textEdit)
+                            ? {
+                                  range: existingCompletion.textEdit.range,
+                                  newText: `${existingCompletion.textEdit.newText} lang="${lang}"`
+                              }
+                            : undefined
                 })
             );
         }

--- a/packages/language-server/src/plugins/svelte/features/getCodeActions/getRefactorings.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCodeActions/getRefactorings.ts
@@ -54,7 +54,7 @@ async function executeExtractComponentCommand(
 
     return <WorkspaceEdit>{
         documentChanges: [
-            TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(svelteDoc.uri, null), [
+            TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(svelteDoc.uri, 0), [
                 TextEdit.replace(range, `<${componentName}></${componentName}>`),
                 createComponentImportTextEdit()
             ]),
@@ -91,7 +91,7 @@ async function executeExtractComponentCommand(
             .map((tag) => tag.text)
             .join('');
 
-        return TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(newFileUri, null), [
+        return TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(newFileUri, 0), [
             TextEdit.insert(Position.create(0, 0), newText)
         ]);
 

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -75,7 +75,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
             changes.map(async (change) => {
                 // Organize Imports will only affect the current file, so no need to check the file path
                 return TextDocumentEdit.create(
-                    VersionedTextDocumentIdentifier.create(document.url, null),
+                    VersionedTextDocumentIdentifier.create(document.url, 0),
                     change.textChanges.map((edit) => {
                         let range = mapRangeToOriginal(fragment, convertRange(fragment, edit.span));
                         // Handle svelte2tsx wrong import mapping:
@@ -131,10 +131,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                             docs.set(change.fileName, doc);
                         }
                         return TextDocumentEdit.create(
-                            VersionedTextDocumentIdentifier.create(
-                                pathToUrl(change.fileName),
-                                null
-                            ),
+                            VersionedTextDocumentIdentifier.create(pathToUrl(change.fileName), 0),
                             change.textChanges.map((edit) => {
                                 if (
                                     fix.fixName === 'import' &&
@@ -214,10 +211,10 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                     ...refactor,
                     title: refactor.title
                         .replace(
-                            'Extract to inner function in function \'render\'',
+                            "Extract to inner function in function 'render'",
                             'Extract to function'
                         )
-                        .replace('Extract to constant in function \'render\'', 'Extract to constant')
+                        .replace("Extract to constant in function 'render'", 'Extract to constant')
                 }))
         );
     }
@@ -295,7 +292,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
 
         const documentChanges = edits?.edits.map((edit) =>
             TextDocumentEdit.create(
-                VersionedTextDocumentIdentifier.create(document.uri, null),
+                VersionedTextDocumentIdentifier.create(document.uri, 0),
                 edit.textChanges.map((edit) => {
                     let range = mapRangeToOriginal(fragment, convertRange(fragment, edit.span));
                     // Some refactorings place the new code at the end of svelte2tsx' render function,

--- a/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
@@ -47,7 +47,7 @@ export class UpdateImportsProviderImpl implements UpdateImportsProvider {
                 }
 
                 return TextDocumentEdit.create(
-                    VersionedTextDocumentIdentifier.create(fragment.getURL(), null),
+                    VersionedTextDocumentIdentifier.create(fragment.getURL(), 0),
                     change.textChanges.map((edit) => {
                         const range = mapRangeToOriginal(
                             fragment!,

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -3,11 +3,8 @@ import {
     ApplyWorkspaceEditParams,
     ApplyWorkspaceEditRequest,
     CodeActionKind,
-    createConnection,
     DocumentUri,
-    IConnection,
-    IPCMessageReader,
-    IPCMessageWriter,
+    _Connection,
     MessageType,
     RenameFile,
     RequestType,
@@ -17,6 +14,7 @@ import {
     TextDocumentSyncKind,
     WorkspaceEdit
 } from 'vscode-languageserver';
+import { IPCMessageReader, IPCMessageWriter, createConnection } from 'vscode-languageserver/node';
 import { DiagnosticsManager } from './lib/DiagnosticsManager';
 import { Document, DocumentManager } from './lib/documents';
 import { Logger } from './logger';
@@ -36,7 +34,6 @@ namespace TagCloseRequest {
     export const type: RequestType<
         TextDocumentPositionParams,
         string | null,
-        any,
         any
     > = new RequestType('html/tag');
 }
@@ -46,7 +43,7 @@ export interface LSOptions {
      * If you have a connection already that the ls should use, pass it in.
      * Else the connection will be created from `process`.
      */
-    connection?: IConnection;
+    connection?: _Connection;
     /**
      * If you want only errors getting logged.
      * Defaults to false.

--- a/packages/language-server/test/plugins/css/CSSPlugin.test.ts
+++ b/packages/language-server/test/plugins/css/CSSPlugin.test.ts
@@ -68,9 +68,8 @@ describe('CSS Plugin', () => {
                 documentation: {
                     kind: 'markdown',
                     value:
-                        'Defines character set of the document.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/CSS/@charset)'
+                        'Defines character set of the document\\.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/CSS/@charset)'
                 },
-                sortText: 'd_0000',
                 textEdit: TextEdit.insert(Position.create(0, 7), '@charset'),
                 tags: []
             });
@@ -338,7 +337,6 @@ describe('CSS Plugin', () => {
                     line: 0
                 }
             }
-
         });
     });
 

--- a/packages/language-server/test/plugins/svelte/SvelteDocument.test.ts
+++ b/packages/language-server/test/plugins/svelte/SvelteDocument.test.ts
@@ -3,7 +3,10 @@ import sinon from 'sinon';
 import { Position } from 'vscode-languageserver';
 import { Document } from '../../../src/lib/documents';
 import * as importPackage from '../../../src/importPackage';
-import { SvelteDocument, TranspiledSvelteDocument } from '../../../src/plugins/svelte/SvelteDocument';
+import {
+    SvelteDocument,
+    TranspiledSvelteDocument
+} from '../../../src/plugins/svelte/SvelteDocument';
 import * as configLoader from '../../../src/lib/documents/configLoader';
 
 describe('Svelte Document', () => {
@@ -56,9 +59,11 @@ describe('Svelte Document', () => {
                     return Promise.resolve({
                         code: getSourceCode(true),
                         dependencies: [],
-                        toString: () => getSourceCode(true)
+                        toString: () => getSourceCode(true),
+                        map: <any>null
                     });
                 },
+                walk: <any>null,
                 VERSION: <any>'',
                 compile: <any>null,
                 parse: <any>null

--- a/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
@@ -289,19 +289,16 @@ describe('SveltePlugin#getCodeAction', () => {
             const result = await extractComponent(path, range);
             assert.deepStrictEqual(result, <WorkspaceEdit>{
                 documentChanges: [
-                    TextDocumentEdit.create(
-                        VersionedTextDocumentIdentifier.create('someUrl', null),
-                        [
-                            TextEdit.replace(range, '<NewComp></NewComp>'),
-                            TextEdit.insert(
-                                doc.script?.startPos || Position.create(0, 0),
-                                '\n  import NewComp from \'./NewComp.svelte\';\n'
-                            )
-                        ]
-                    ),
+                    TextDocumentEdit.create(VersionedTextDocumentIdentifier.create('someUrl', 0), [
+                        TextEdit.replace(range, '<NewComp></NewComp>'),
+                        TextEdit.insert(
+                            doc.script?.startPos || Position.create(0, 0),
+                            "\n  import NewComp from './NewComp.svelte';\n"
+                        )
+                    ]),
                     CreateFile.create('file:///NewComp.svelte', { overwrite: true }),
                     TextDocumentEdit.create(
-                        VersionedTextDocumentIdentifier.create('file:///NewComp.svelte', null),
+                        VersionedTextDocumentIdentifier.create('file:///NewComp.svelte', 0),
                         [
                             TextEdit.insert(
                                 Position.create(0, 0),
@@ -360,30 +357,27 @@ describe('SveltePlugin#getCodeAction', () => {
             assert.deepStrictEqual(result, <WorkspaceEdit>{
                 documentChanges: [
                     TextDocumentEdit.create(
-                        VersionedTextDocumentIdentifier.create(existingFileUri, null),
+                        VersionedTextDocumentIdentifier.create(existingFileUri, 0),
                         [
                             TextEdit.replace(range, '<NewComp></NewComp>'),
                             TextEdit.insert(
                                 doc.script?.startPos || Position.create(0, 0),
-                                '\n  import NewComp from \'../NewComp.svelte\';\n'
+                                "\n  import NewComp from '../NewComp.svelte';\n"
                             )
                         ]
                     ),
                     CreateFile.create(newFileUri, { overwrite: true }),
-                    TextDocumentEdit.create(
-                        VersionedTextDocumentIdentifier.create(newFileUri, null),
-                        [
-                            TextEdit.insert(
-                                Position.create(0, 0),
-                                `<script>
+                    TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(newFileUri, 0), [
+                        TextEdit.insert(
+                            Position.create(0, 0),
+                            `<script>
             import OtherComponent from './path/OtherComponent.svelte';
             import {test} from './test';
             </script>\n\ntoExtract\n\n<style>
             @import './path/style.css';
             </style>\n\n`
-                            )
-                        ]
-                    )
+                        )
+                    ])
                 ]
             });
         });

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -296,8 +296,8 @@ describe('SveltePlugin#getDiagnostics', () => {
                         stats: {
                             warnings: [
                                 {
-                                    start: { line: 0, column: 32 },
-                                    end: { line: 0, column: 33 },
+                                    start: { line: 1, column: 32 },
+                                    end: { line: 1, column: 33 },
                                     message:
                                         "Component has unused export property 'A'. If it is for external reference only, please consider using `export const A`",
                                     code: 'unused-export-let'

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -84,7 +84,7 @@ describe('CodeActionsProvider', () => {
                             ],
                             textDocument: {
                                 uri: getUri('codeactions.svelte'),
-                                version: null
+                                version: 0
                             }
                         }
                     ]
@@ -118,7 +118,8 @@ describe('CodeActionsProvider', () => {
                             edits: [
                                 {
                                     // eslint-disable-next-line max-len
-                                    newText: 'import { A } from \'bla\';\nimport { C } from \'blubb\';\n',
+                                    newText:
+                                        "import { A } from 'bla';\nimport { C } from 'blubb';\n",
                                     range: {
                                         start: {
                                             character: 0,
@@ -159,7 +160,7 @@ describe('CodeActionsProvider', () => {
                             ],
                             textDocument: {
                                 uri: getUri('codeactions.svelte'),
-                                version: null
+                                version: 0
                             }
                         }
                     ]
@@ -234,7 +235,7 @@ describe('CodeActionsProvider', () => {
                             ],
                             textDocument: {
                                 uri: getUri('organize-imports-with-module.svelte'),
-                                version: null
+                                version: 0
                             }
                         }
                     ]
@@ -328,7 +329,7 @@ describe('CodeActionsProvider', () => {
                     ],
                     textDocument: {
                         uri: getUri('codeactions.svelte'),
-                        version: null
+                        version: 0
                     }
                 }
             ]
@@ -369,7 +370,7 @@ describe('CodeActionsProvider', () => {
                     }
                 ],
                 command: 'function_scope_0',
-                title: 'Extract to inner function in function \'render\''
+                title: "Extract to inner function in function 'render'"
             },
             title: 'Extract to function'
         });
@@ -425,7 +426,7 @@ describe('CodeActionsProvider', () => {
                     ],
                     textDocument: {
                         uri: getUri('codeactions.svelte'),
-                        version: null
+                        version: 0
                     }
                 }
             ]

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -11,7 +11,8 @@ import {
     Position,
     Range,
     CompletionTriggerKind,
-    MarkupKind
+    MarkupKind,
+    TextEdit
 } from 'vscode-languageserver';
 import {
     CompletionsProviderImpl,
@@ -466,7 +467,10 @@ describe('CompletionProviderImpl', () => {
             item!
         );
 
-        assert.strictEqual(detail, 'Auto import from svelte\nfunction onMount(fn: any): void');
+        assert.strictEqual(
+            detail,
+            'Auto import from svelte\nfunction onMount(fn: () => any): void'
+        );
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),
@@ -625,7 +629,7 @@ describe('CompletionProviderImpl', () => {
         const end = Position.create(line, character + '*/'.length);
 
         assert.strictEqual(harmonizeNewLines(item?.textEdit?.newText), newText);
-        assert.deepStrictEqual(item?.textEdit?.range, Range.create(start, end));
+        assert.deepStrictEqual((item?.textEdit as TextEdit)?.range, Range.create(start, end));
     };
 
     it('show jsDoc template completion', async () => {

--- a/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
@@ -51,7 +51,7 @@ describe('UpdateImportsProviderImpl', () => {
         });
 
         assert.deepStrictEqual(workspaceEdit?.documentChanges, [
-            TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(fileUri, null), [
+            TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(fileUri, 0), [
                 TextEdit.replace(
                     Range.create(Position.create(1, 17), Position.create(1, 37)),
                     './documentation.svelte'

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -49,9 +49,9 @@
         "rollup-plugin-cleanup": "^3.0.0",
         "rollup-plugin-copy": "^3.0.0",
         "svelte-language-server": "*",
-        "vscode-languageserver": "6.1.1",
-        "vscode-languageserver-protocol": "3.15.3",
-        "vscode-languageserver-types": "3.15.1",
+        "vscode-languageserver": "7.0.0",
+        "vscode-languageserver-protocol": "3.16.0",
+        "vscode-languageserver-types": "3.16.0",
         "vscode-uri": "2.1.2"
     }
 }

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -33,7 +33,7 @@ async function openAllDocuments(
     filePathsToIgnore: string[],
     svelteCheck: SvelteCheck
 ) {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         glob(
             '**/*.svelte',
             {

--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -21,7 +21,7 @@ This extension comes bundled with a formatter for Svelte files. To let this exte
 
 The formatter is a [Prettier](https://prettier.io/) [plugin](https://prettier.io/docs/en/plugins.html), which means some formatting options of Prettier apply. There are also Svelte specific settings like the sort order of scripts, markup, styles. More info about them and how to configure it can be found [here](https://github.com/sveltejs/prettier-plugin-svelte).
 
-You need at least VSCode version `1.41.0`.
+You need at least VSCode version `1.52.0`.
 
 Do you want to use TypeScript/SCSS/Less/..? [See the docs](/docs/README.md#language-specific-setup).
 

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -37,7 +37,7 @@
         "Formatters"
     ],
     "engines": {
-        "vscode": "^1.41.0"
+        "vscode": "^1.52.0"
     },
     "activationEvents": [
         "onLanguage:svelte",
@@ -414,6 +414,6 @@
     "dependencies": {
         "lodash": "^4.17.19",
         "svelte-language-server": "*",
-        "vscode-languageclient": "^6.1.1"
+        "vscode-languageclient": "^7.0.0"
     }
 }

--- a/packages/svelte-vscode/src/CompiledCodeContentProvider.ts
+++ b/packages/svelte-vscode/src/CompiledCodeContentProvider.ts
@@ -1,4 +1,4 @@
-import { LanguageClient } from 'vscode-languageclient';
+import { LanguageClient } from 'vscode-languageclient/node';
 import {
     Uri,
     TextDocumentContentProvider,

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -15,10 +15,7 @@ import {
     extensions
 } from 'vscode';
 import {
-    LanguageClient,
     LanguageClientOptions,
-    ServerOptions,
-    TransportKind,
     TextDocumentPositionParams,
     RequestType,
     RevealOutputChannelOn,
@@ -26,13 +23,14 @@ import {
     TextDocumentEdit,
     ExecuteCommandRequest
 } from 'vscode-languageclient';
+import { LanguageClient, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import { activateTagClosing } from './html/autoClose';
 import { EMPTY_ELEMENTS } from './html/htmlEmptyTagsShared';
 import CompiledCodeContentProvider from './CompiledCodeContentProvider';
 import * as path from 'path';
 
 namespace TagCloseRequest {
-    export const type: RequestType<TextDocumentPositionParams, string, any, any> = new RequestType(
+    export const type: RequestType<TextDocumentPositionParams, string, any> = new RequestType(
         'html/tag'
     );
 }

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -35,7 +35,7 @@
         "svelte": "3.28.0",
         "tiny-glob": "^0.2.6",
         "tslib": "^1.10.0",
-        "typescript": "^4.1.2"
+        "typescript": "^4.1.3"
     },
     "peerDependencies": {
         "svelte": "^3.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,24 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@emmetio/extract-abbreviation@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@emmetio/extract-abbreviation/-/extract-abbreviation-0.1.6.tgz#e4a9856c1057f0aff7d443b8536477c243abe28c"
-  integrity sha512-Ce3xE2JvTSEbASFbRbA1gAIcMcZWdS2yUYRaQbeM0nbOzaZrUYfa3ePtcriYRZOZmr+CkKA+zbjhvTpIOAYVcw==
+"@emmetio/abbreviation@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@emmetio/abbreviation/-/abbreviation-2.1.1.tgz#7f4c69c69f3ace6dc9cf9eac7e53286e43d752ec"
+  integrity sha512-2U9lDODdlaqZn6J84gG/czuJ5u7mHx3NfTEt0ZKeKBFnNdcM60ryWM7SEexh/UbdQmCNQIJE4m/wTNulilApOA==
+  dependencies:
+    "@emmetio/scanner" "^1.0.0"
+
+"@emmetio/css-abbreviation@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@emmetio/css-abbreviation/-/css-abbreviation-2.1.2.tgz#4a5d96f2576dd827a2c1a060374ffa8a5408cc1c"
+  integrity sha512-CvYTzJltVpLqJaCZ1Qn97LVAKsl2Uwl2fzir1EX/WuMY3xWxgc3BWRCheL6k65km6GyDrLVl6RhrrNb/pxOiAQ==
+  dependencies:
+    "@emmetio/scanner" "^1.0.0"
+
+"@emmetio/scanner@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emmetio/scanner/-/scanner-1.0.0.tgz#065b2af6233fe7474d44823e3deb89724af42b5f"
+  integrity sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -328,9 +342,9 @@
     "@types/vfile-message" "*"
 
 "@types/vscode@*":
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.42.0.tgz#0ad891a9487e91e34be7c56985058a179031eb76"
-  integrity sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.52.0.tgz#61917968dd403932127fc4004a21fd8d69e4f61c"
+  integrity sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==
 
 "@typescript-eslint/eslint-plugin@^4.3.0":
   version "4.3.0"
@@ -831,6 +845,14 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+emmet@^2.1.5:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/emmet/-/emmet-2.2.1.tgz#5d44d5361e2029def9f6a09f0451ee70b9fa488c"
+  integrity sha512-sX/Vyu7V84uwvJeuF+lQUeNa5njMPjF9DGoYEXBqueO+OFQVptMyG44RuBLiD+PSPNWk2hmaewWLeP3R+2/5jg==
+  dependencies:
+    "@emmetio/abbreviation" "^2.1.1"
+    "@emmetio/css-abbreviation" "^2.1.2"
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -1588,10 +1610,10 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-1.0.3.tgz#1d53d7160e401a783dbceabaad82473f80e6ad7e"
-  integrity sha512-hk/69oAeaIzchq/v3lS50PXuzn5O2ynldopMC+SWBql7J2WtdptfB9dy8Y7+Og5rPkTCpn83zTiO8FMcqlXJ/g==
+jsonc-parser@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.3.1.tgz#59549150b133f2efacca48fe9ce1ec0659af2342"
+  integrity sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -1674,6 +1696,13 @@ lower-case@^2.0.1:
   integrity sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
   dependencies:
     tslib "^1.10.0"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 magic-string@^0.25.5, magic-string@^0.25.7:
   version "0.25.7"
@@ -2105,10 +2134,10 @@ prettier-plugin-svelte@~1.4.1:
   resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-1.4.1.tgz#2f0f7a149190f476dc9b4ba9da8d482bd196f1e2"
   integrity sha512-6y0m37Xw01GRf/WIHau+Kp3uXj2JB1agtEmNVKb9opMy34A6OMOYhfneVpNIlrghQSw/jIV+t3e5Ngt4up2CMA==
 
-prettier@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
-  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+prettier@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 progress@^2.0.0:
   version "2.0.3"
@@ -2252,15 +2281,17 @@ run-parallel@^1.1.9:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
 semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -2511,6 +2542,11 @@ svelte@3.28.0:
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.28.0.tgz#e257fab5666701cf230bea583ceb470bdda1344c"
   integrity sha512-WJW8wD+aTmU5GUnTUjdhVF35mve2MjylubLgB6fGWoXHpYENdwcwWsWvjMQLayzMynqNH733h1Ck8wJzNR7gdQ==
 
+svelte@3.31.0:
+  version "3.31.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.31.0.tgz#13966e5f55b975bc86675469bb2c58dd0e558d97"
+  integrity sha512-r+n8UJkDqoQm1b+3tA3Lh6mHXKpcfOSOuEuIo5gE2W9wQYi64RYX/qE6CZBDDsP/H4M+N426JwY7XGH4xASvGQ==
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -2596,10 +2632,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@*, typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@*, typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
@@ -2641,89 +2677,83 @@ vfile-message@*:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
 
-vscode-css-languageservice@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-4.2.0.tgz#56081374857ce8aa4dd4c98f97e4e10a30b7242f"
-  integrity sha512-HIjl5bofrrxMMF05K/nq83270EdvteuAIio44FWd6tDdfhgg4vbofiAuXRSpXFi335f5+ekKdrzvPZm9ahqzsg==
+vscode-css-languageservice@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-5.0.0.tgz#04fd899e25407a2fccd8f59a5896e2f020269bda"
+  integrity sha512-DTMa8QbVmujFPvD3NxoC5jjIXCyCG+cvn3hNzwQRhvhsk8LblNymBZBwzfcDdgEtqsi4O/2AB5HnMIRzxhzEzg==
   dependencies:
     vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "^3.15.1"
-    vscode-nls "^4.1.2"
-    vscode-uri "^2.1.1"
-
-vscode-emmet-helper@1.2.17:
-  version "1.2.17"
-  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.2.17.tgz#f0c6bfcebc4285d081fb2618e6e5b9a08c567afa"
-  integrity sha512-X4pzcrJ8dE7M3ArFuySF5fgipKDd/EauXkiJwtjBIVRWpVNq0tF9+lNCyuC7iDUwP3Oq7ow/TGssD3GdG96Jow==
-  dependencies:
-    "@emmetio/extract-abbreviation" "0.1.6"
-    jsonc-parser "^1.0.0"
-    vscode-languageserver-types "^3.6.0-next.1"
-
-vscode-html-languageservice@3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-3.1.4.tgz#0316dff77ee38dc176f40560cbf55e4f64f4f433"
-  integrity sha512-3M+bm+hNvwQcScVe5/ok9BXvctOiGJ4nlOkkFf+WKSDrYNkarZ/RByKOa1/iylbvZxJUPzbeziembWPe/dMvhw==
-  dependencies:
-    vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "3.16.0-next.2"
+    vscode-languageserver-types "^3.16.0"
     vscode-nls "^5.0.0"
     vscode-uri "^2.1.2"
 
-vscode-jsonrpc@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
-  integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
-
-vscode-languageclient@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-6.1.1.tgz#91b62e416c5abbf2013ae3726f314a19c22a8457"
-  integrity sha512-mB6d8Tg+82l8EFUfR+SBu0+lCshyKVgC5E5+MQ0/BJa+9AgeBjtG5npoGaCo4/VvWzK0ZRGm85zU5iRp1RYPIA==
+vscode-emmet-helper@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-2.1.2.tgz#2978060ebb736a7e0f6e6f1d649bd026880528c3"
+  integrity sha512-Fy6UNawSgxE3Kuqi54vSXohf03iOIrp1A74ReAgzvGP9Yt7fUAvkqF6No2WAc34/w0oWAHAeqoBNqmKKWh6U5w==
   dependencies:
-    semver "^6.3.0"
-    vscode-languageserver-protocol "^3.15.3"
+    emmet "^2.1.5"
+    jsonc-parser "^2.3.0"
+    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-types "^3.15.1"
+    vscode-nls "^5.0.0"
+    vscode-uri "^2.1.2"
 
-vscode-languageserver-protocol@3.15.3, vscode-languageserver-protocol@^3.15.3:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
-  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
+vscode-html-languageservice@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-4.0.0.tgz#a562cb1dfe7e40a9d1f50dbd8c4ec2d02f393f01"
+  integrity sha512-UmC+GS0IqBeZnOAmdtQvaDzoH1c5/un+b7qALUziu/Y4SOPXso5dF+YkJeTqsde6YU2pLm78RtMDzl9BParwbw==
   dependencies:
-    vscode-jsonrpc "^5.0.1"
-    vscode-languageserver-types "3.15.1"
+    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-types "^3.16.0"
+    vscode-nls "^5.0.0"
+    vscode-uri "^2.1.2"
+
+vscode-jsonrpc@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
+  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
+
+vscode-languageclient@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz#b505c22c21ffcf96e167799757fca07a6bad0fb2"
+  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
+  dependencies:
+    minimatch "^3.0.4"
+    semver "^7.3.4"
+    vscode-languageserver-protocol "3.16.0"
+
+vscode-languageserver-protocol@3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
+  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
+  dependencies:
+    vscode-jsonrpc "6.0.0"
+    vscode-languageserver-types "3.16.0"
 
 vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
   integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
 
-vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.1, vscode-languageserver-types@^3.6.0-next.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
-  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.15.1, vscode-languageserver-types@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
+  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
-vscode-languageserver-types@3.16.0-next.2:
-  version "3.16.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz#940bd15c992295a65eae8ab6b8568a1e8daa3083"
-  integrity sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==
-
-vscode-languageserver@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz#d76afc68172c27d4327ee74332b468fbc740d762"
-  integrity sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==
+vscode-languageserver@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz#49b068c87cfcca93a356969d20f5d9bdd501c6b0"
+  integrity sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==
   dependencies:
-    vscode-languageserver-protocol "^3.15.3"
-
-vscode-nls@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-4.1.2.tgz#ca8bf8bb82a0987b32801f9fddfdd2fb9fd3c167"
-  integrity sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==
+    vscode-languageserver-protocol "3.16.0"
 
 vscode-nls@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
 
-vscode-uri@2.1.2, vscode-uri@^2.1.1, vscode-uri@^2.1.2:
+vscode-uri@2.1.2, vscode-uri@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
   integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
@@ -2784,6 +2814,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0:
   version "1.10.0"


### PR DESCRIPTION
#715  
Bump to new language server protocol version 3.16 with corresponding types. Also bump vscode-languageserver/languageclient.

Caveat: Range/Position is now checked - all lines/columns must be 0 <= X <= MAX_INT, which means we cannot use Range.create on all occasions anymore. We need the temporary creation of invalid positions/ranges to deal with them later case-by-case

### BREAKING CHANGE
vscode extension now requires a minimum vscode version of 1.52.0

##### Notes
- We possibly can refactor the `getEditsForFileRename`-thing we currently have setup "by hand", there's a [workspace_didRenameFiles](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_didRenameFiles) command now. _Update_: I player around with it and I don't think it suits our needs: `willRenameFiles` is done before the rename operation, and computing all update-locations might take too long, so that's bad UX. `didRenameFiles` is a notification, not a request, so we cannot send something back.