### PR TITLE
Add missing attribute as

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -232,6 +232,7 @@ declare namespace svelte.JSX {
       allowtransparency?: boolean;
       allowpaymentrequest?: boolean;
       alt?: string;
+      as?: string;
       async?: boolean;
       autocomplete?: string;
       autofocus?: boolean;


### PR DESCRIPTION
The `as` attribute is used by the `link` element: `<link rel="preload" src="my-video.mp4" as="video">`.

On another note: Do we really need an extra copy of all this? Can we not use the TypeScript-native implementation?