### PR TITLE
Make Options.target optional

### DIFF
--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -50,7 +50,7 @@ interface Svelte2TsxComponentConstructorParameters<Props extends {}> {
     /**
      * An HTMLElement to render to. This option is required.
      */
-    target: Element;
+    target?: Element;
     /**
      * A child of `target` to render the component immediately before.
      */


### PR DESCRIPTION
A target is only required when a component is created manually, the compiler does not use it

Copy pasting the compiled result of the following component in its own `script` throws
`Property 'target' is missing in type '{}' but required in type 'Svelte2TsxComponentConstructorParameters<Partial<{ prop: any }>>'.ts(2345)`
```svelte
<script lang="ts">
	import Component from "./Component.svelte";
</script>

<Component />
```

Another option that is compiler-only is `$$inline`, should we add a different interface for options used by the compiler ? 

I've published [a gist at this url](https://gist.github.com/pushkine/d2ebc3e7131f7a658e5ca7bdf0150574) with accurate typings of svelte's internals for more information