### PR TITLE
Autocompletion schemas for prettier-plugin-svelte options in .prettierrc files

### DIFF
--- a/packages/svelte-vscode/package-json-schema.json
+++ b/packages/svelte-vscode/package-json-schema.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "properties": {
+        "prettier": {
+            "description": "Prettier-Plugin-Svelte configuration",
+            "$ref": "./prettier-options.json"
+        }
+    }
+}

--- a/packages/svelte-vscode/package-json-schema.json
+++ b/packages/svelte-vscode/package-json-schema.json
@@ -3,7 +3,7 @@
     "properties": {
         "prettier": {
             "description": "Prettier-Plugin-Svelte configuration",
-            "$ref": "./prettier-options.json"
+            "$ref": "./prettier-options-schema.json"
         }
     }
 }

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -348,6 +348,26 @@
                     ".svelte"
                 ],
                 "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "json",
+                "filenames": [
+                    ".prettierrc"
+                ]
+            }
+        ],
+        "jsonValidation": [
+            {
+                "fileMatch": ".prettierrc",
+                "url": "./prettier-options-schema.json"
+            },
+            {
+                "fileMatch": ".prettierrc.json",
+                "url": "./prettier-options-schema.json"
+            },
+            {
+                "fileMatch": "package.json",
+                "url": "./package-json-schema.json"
             }
         ],
         "grammars": [

--- a/packages/svelte-vscode/prettier-options-schema.json
+++ b/packages/svelte-vscode/prettier-options-schema.json
@@ -1,0 +1,106 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Prettier-plugin-svelte schema for .prettierrc",
+    "definitions": {
+        "optionsDefinition": {
+            "type": "object",
+            "properties": {
+                "svelteSortOrder": {
+                    "description": "Sort order for <svelte:options>, scripts, markup, and styles.",
+                    "default": "options-scripts-markup-styles",
+                    "enum": [
+                        "options-scripts-markup-styles",
+                        "options-scripts-styles-markup",
+                        "options-markup-scripts-styles",
+                        "options-markup-styles-scripts",
+                        "options-styles-scripts-markup",
+                        "options-styles-markup-scripts",
+                        "scripts-options-markup-styles",
+                        "scripts-options-styles-markup",
+                        "scripts-markup-options-styles",
+                        "scripts-markup-styles-options",
+                        "scripts-styles-options-markup",
+                        "scripts-styles-markup-options",
+                        "markup-options-scripts-styles",
+                        "markup-options-styles-scripts",
+                        "markup-scripts-options-styles",
+                        "markup-scripts-styles-options",
+                        "markup-styles-options-scripts",
+                        "markup-styles-scripts-options",
+                        "styles-options-scripts-markup",
+                        "styles-options-markup-scripts",
+                        "styles-scripts-options-markup",
+                        "styles-scripts-markup-options",
+                        "styles-markup-options-scripts",
+                        "styles-markup-scripts-options"
+                    ]
+                },
+                "svelteStrictMode": {
+                    "description": "More strict HTML syntax: less self-closed tags, quotes in attributes, no attribute shorthand (overrules svelteAllowShorthand).",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "svelteBracketNewLine": {
+                    "description": "Put the > of a multiline element on a new line. Roughly the Svelte equivalent of the jsxBracketSameLine rule.",
+                    "default": false,
+                    "type": "boolean"
+                },
+                "svelteAllowShorthand": {
+                    "description": "Option to enable/disable component attribute shorthand if attribute name and expression are same.",
+                    "default": false,
+                    "type": "boolean"
+                },
+                "svelteIndentScriptAndStyle": {
+                    "description": "Whether or not to indent the code inside <script> and <style> tags in Svelte files. This saves an indentation level, but might break code folding in your editor.",
+                    "default": false,
+                    "type": "boolean"
+                }
+            }
+        },
+        "overridesDefinition": {
+            "type": "object",
+            "properties": {
+                "overrides": {
+                    "type": "array",
+                    "description": "Provide a list of patterns to override prettier configuration.",
+                    "items": {
+                        "type": "object",
+                        "required": ["files"],
+                        "properties": {
+                            "files": {
+                                "description": "Include these files in this override.",
+                                "oneOf": [
+                                    { "type": "string" },
+                                    { "type": "array", "items": { "type": "string" } }
+                                ]
+                            },
+                            "excludeFiles": {
+                                "description": "Exclude these files from this override.",
+                                "oneOf": [
+                                    { "type": "string" },
+                                    { "type": "array", "items": { "type": "string" } }
+                                ]
+                            },
+                            "options": {
+                                "type": "object",
+                                "description": "The options to apply for this override.",
+                                "$ref": "#/definitions/optionsDefinition"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                }
+            }
+        }
+    },
+    "oneOf": [
+        {
+            "type": "object",
+            "allOf": [
+                { "$ref": "#/definitions/optionsDefinition" },
+                { "$ref": "#/definitions/overridesDefinition" }
+            ]
+        },
+        { "type": "string" }
+    ]
+}

--- a/packages/svelte-vscode/prettier-options-schema.json
+++ b/packages/svelte-vscode/prettier-options-schema.json
@@ -32,7 +32,13 @@
                         "styles-scripts-options-markup",
                         "styles-scripts-markup-options",
                         "styles-markup-options-scripts",
-                        "styles-markup-scripts-options"
+                        "styles-markup-scripts-options",
+                        "scripts-markup-styles",
+                        "scripts-styles-markup",
+                        "markup-styles-scripts",
+                        "markup-scripts-styles",
+                        "styles-markup-scripts",
+                        "styles-scripts-markup"
                     ]
                 },
                 "svelteStrictMode": {


### PR DESCRIPTION
I don't know how to test the extension but it seems to work on online json validators

sourced from
http://json.schemastore.org/prettierrc
https://github.com/prettier/prettier-vscode/blob/d4505c8cb3aa51ad255c7e19db752bc2afc6bd23/package.json#L337-L357
https://github.com/prettier/prettier-vscode/blob/d4505c8cb3aa51ad255c7e19db752bc2afc6bd23/package-json-schema.json

descriptions are from the readme over at sveltejs/prettier-plugin-svelte