### PR TITLE
(fix) adjust end of range mapping

### DIFF
--- a/packages/language-server/src/lib/documents/DocumentMapper.ts
+++ b/packages/language-server/src/lib/documents/DocumentMapper.ts
@@ -212,10 +212,22 @@ export function mapRangeToOriginal(
     // and therefore return negative numbers, which makes Range.create throw.
     // These invalid position need to be handled
     // on a case-by-case basis in the calling functions.
-    return {
+    const originalRange = {
         start: fragment.getOriginalPosition(range.start),
         end: fragment.getOriginalPosition(range.end)
     };
+
+    // Range may be mapped one character short - reverse that for "in the same line" cases
+    if (
+        originalRange.start.line === originalRange.end.line &&
+        range.start.line === range.end.line &&
+        originalRange.end.character - originalRange.start.character ===
+            range.end.character - range.start.character - 1
+    ) {
+        originalRange.end.character += 1;
+    }
+
+    return originalRange;
 }
 
 export function mapRangeToGenerated(fragment: DocumentMapper, range: Range): Range {

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -258,28 +258,28 @@ describe('TypescriptPlugin', () => {
         it('(within script simple)', async () => {
             await test$StoreDef(
                 Position.create(7, 1),
-                Range.create(Position.create(7, 1), Position.create(7, 5))
+                Range.create(Position.create(7, 1), Position.create(7, 6))
             );
         });
 
         it('(within script if)', async () => {
             await test$StoreDef(
                 Position.create(8, 7),
-                Range.create(Position.create(8, 5), Position.create(8, 9))
+                Range.create(Position.create(8, 5), Position.create(8, 10))
             );
         });
 
         it('(within template simple)', async () => {
             await test$StoreDef(
                 Position.create(13, 3),
-                Range.create(Position.create(13, 2), Position.create(13, 6))
+                Range.create(Position.create(13, 2), Position.create(13, 7))
             );
         });
 
         it('(within template if)', async () => {
             await test$StoreDef(
                 Position.create(14, 7),
-                Range.create(Position.create(14, 6), Position.create(14, 10))
+                Range.create(Position.create(14, 6), Position.create(14, 11))
             );
         });
     });
@@ -321,28 +321,28 @@ describe('TypescriptPlugin', () => {
         it('(within script simple)', async () => {
             await test$StoreDef(
                 Position.create(9, 1),
-                Range.create(Position.create(9, 1), Position.create(9, 5))
+                Range.create(Position.create(9, 1), Position.create(9, 6))
             );
         });
 
         it('(within script if)', async () => {
             await test$StoreDef(
                 Position.create(10, 7),
-                Range.create(Position.create(10, 5), Position.create(10, 9))
+                Range.create(Position.create(10, 5), Position.create(10, 10))
             );
         });
 
         it('(within template simple)', async () => {
             await test$StoreDef(
                 Position.create(16, 3),
-                Range.create(Position.create(16, 2), Position.create(16, 6))
+                Range.create(Position.create(16, 2), Position.create(16, 7))
             );
         });
 
         it('(within template if)', async () => {
             await test$StoreDef(
                 Position.create(17, 7),
-                Range.create(Position.create(17, 6), Position.create(17, 10))
+                Range.create(Position.create(17, 6), Position.create(17, 11))
             );
         });
     });

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -152,7 +152,7 @@ describe('CodeActionsProvider', () => {
                                             line: 3
                                         },
                                         end: {
-                                            character: 22,
+                                            character: 23,
                                             line: 3
                                         }
                                     }
@@ -228,7 +228,7 @@ describe('CodeActionsProvider', () => {
                                         },
                                         end: {
                                             line: 7,
-                                            character: 22
+                                            character: 23
                                         }
                                     }
                                 }

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -104,7 +104,7 @@ describe('DiagnosticsProvider', () => {
                     "Argument of type 'string' is not assignable to parameter of type 'SvelteStore<any>'.",
                 range: {
                     end: {
-                        character: 5,
+                        character: 6,
                         line: 2
                     },
                     start: {
@@ -122,7 +122,7 @@ describe('DiagnosticsProvider', () => {
                     "Argument of type 'string' is not assignable to parameter of type 'SvelteStore<any>'.",
                 range: {
                     end: {
-                        character: 8,
+                        character: 9,
                         line: 3
                     },
                     start: {
@@ -140,7 +140,7 @@ describe('DiagnosticsProvider', () => {
                     "Argument of type 'string' is not assignable to parameter of type 'SvelteStore<any>'.",
                 range: {
                     end: {
-                        character: 6,
+                        character: 7,
                         line: 6
                     },
                     start: {
@@ -158,7 +158,7 @@ describe('DiagnosticsProvider', () => {
                     "Argument of type 'string' is not assignable to parameter of type 'SvelteStore<any>'.",
                 range: {
                     end: {
-                        character: 10,
+                        character: 11,
                         line: 7
                     },
                     start: {


### PR DESCRIPTION
If a range is in the same line, and the mapped range has one character more than the original range, add +1 to the end character of the original range.
Assumption is that we never alter the length of a mapped token.

This "one character short" mapping happens because a range's end is exclusive, so the character at the range's end is not part of the range. That means the end character can be on a character which was added as part of the transformation and is not present in the original output. The mapper rightfully maps this to the first mapped character before it - which means that the range then is one character short.

#762