### PR TITLE
fix remove declaration code action of the last import

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -48,13 +48,13 @@ describe('CodeActionsProvider', () => {
 
         const codeActions = await provider.getCodeActions(
             document,
-            Range.create(Position.create(5, 4), Position.create(5, 5)),
+            Range.create(Position.create(6, 4), Position.create(6, 5)),
             {
                 diagnostics: [
                     {
                         code: 6133,
                         message: "'a' is declared but its value is never read.",
-                        range: Range.create(Position.create(5, 4), Position.create(5, 5)),
+                        range: Range.create(Position.create(6, 4), Position.create(6, 5)),
                         source: 'ts'
                     }
                 ],
@@ -73,11 +73,11 @@ describe('CodeActionsProvider', () => {
                                     range: {
                                         start: {
                                             character: 0,
-                                            line: 5
+                                            line: 6
                                         },
                                         end: {
                                             character: 0,
-                                            line: 6
+                                            line: 7
                                         }
                                     }
                                 }
@@ -152,8 +152,21 @@ describe('CodeActionsProvider', () => {
                                             line: 3
                                         },
                                         end: {
-                                            character: 23,
-                                            line: 3
+                                            character: 0,
+                                            line: 4
+                                        }
+                                    }
+                                },
+                                {
+                                    newText: '',
+                                    range: {
+                                        start: {
+                                            character: 0,
+                                            line: 4
+                                        },
+                                        end: {
+                                            character: 21,
+                                            line: 4
                                         }
                                     }
                                 }
@@ -251,7 +264,7 @@ describe('CodeActionsProvider', () => {
 
         const actions = await provider.getCodeActions(
             document,
-            Range.create(Position.create(7, 8), Position.create(7, 42)),
+            Range.create(Position.create(8, 8), Position.create(8, 42)),
             { diagnostics: [], only: [CodeActionKind.Refactor] }
         );
         const action = actions[1];
@@ -266,16 +279,16 @@ describe('CodeActionsProvider', () => {
                         originalRange: {
                             start: {
                                 character: 8,
-                                line: 7
+                                line: 8
                             },
                             end: {
                                 character: 42,
-                                line: 7
+                                line: 8
                             }
                         },
                         textRange: {
-                            pos: 162,
-                            end: 196
+                            pos: 184,
+                            end: 218
                         }
                     }
                 ],
@@ -305,11 +318,11 @@ describe('CodeActionsProvider', () => {
                             range: {
                                 start: {
                                     character: 0,
-                                    line: 7
+                                    line: 8
                                 },
                                 end: {
                                     character: 0,
-                                    line: 7
+                                    line: 8
                                 }
                             }
                         },
@@ -318,11 +331,11 @@ describe('CodeActionsProvider', () => {
                             range: {
                                 start: {
                                     character: 8,
-                                    line: 7
+                                    line: 8
                                 },
                                 end: {
                                     character: 42,
-                                    line: 7
+                                    line: 8
                                 }
                             }
                         }
@@ -341,7 +354,7 @@ describe('CodeActionsProvider', () => {
 
         const actions = await provider.getCodeActions(
             document,
-            Range.create(Position.create(7, 8), Position.create(7, 42)),
+            Range.create(Position.create(8, 8), Position.create(8, 42)),
             { diagnostics: [], only: [CodeActionKind.Refactor] }
         );
         const action = actions[0];
@@ -356,16 +369,16 @@ describe('CodeActionsProvider', () => {
                         originalRange: {
                             start: {
                                 character: 8,
-                                line: 7
+                                line: 8
                             },
                             end: {
                                 character: 42,
-                                line: 7
+                                line: 8
                             }
                         },
                         textRange: {
-                            pos: 162,
-                            end: 196
+                            pos: 184,
+                            end: 218
                         }
                     }
                 ],
@@ -394,11 +407,11 @@ describe('CodeActionsProvider', () => {
                             range: {
                                 start: {
                                     character: 8,
-                                    line: 7
+                                    line: 8
                                 },
                                 end: {
                                     character: 42,
-                                    line: 7
+                                    line: 8
                                 }
                             }
                         },
@@ -415,11 +428,11 @@ describe('CodeActionsProvider', () => {
                             range: {
                                 start: {
                                     character: 0,
-                                    line: 8
+                                    line: 9
                                 },
                                 end: {
                                     character: 0,
-                                    line: 8
+                                    line: 9
                                 }
                             }
                         }

--- a/packages/language-server/test/plugins/typescript/testfiles/codeactions.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/codeactions.svelte
@@ -2,6 +2,7 @@
 import {C} from 'blubb';
 import {B} from 'bla';
 import {A} from 'bla';
+import {D} from 'd';
 
 let a = true;
 A;C;


### PR DESCRIPTION
```
<script>
import {} from 'b'
</script>
```
fix remove the unused declaration code action of the last import. Because the next line of the last import would be mapped to the start of the script. Fixing it by reusing the logic in the organizes imports