### PR TITLE
Do tag-based deployment for svelte-check

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -44,4 +44,5 @@ jobs:
           OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
         with:
           sort: '["svelte2tsx", "svelte-language-server", "svelte-check", "svelte-vscode-nightly"]'
+          only: '["svelte2tsx", "svelte-language-server", "svelte-vscode-nightly"]'
           install: "true"

--- a/.github/workflows/DeployExtensionsProd.yml
+++ b/.github/workflows/DeployExtensionsProd.yml
@@ -3,7 +3,7 @@ name: Tagged Production Deploys
 on:
   push:
     tags:
-      - "*"
+      - "extensions-*"
 
 jobs:
   deploy:
@@ -24,7 +24,7 @@ jobs:
       - run: "npm install -g json"
 
       # Setup the environment
-      - run: 'json -I -f packages/svelte-vscode/package.json -e "this.version=\`${{ github.ref }}\`.split(\`/\`).pop()"'
+      - run: 'json -I -f packages/svelte-vscode/package.json -e "this.version=\`${{ github.ref }}\`.split(\`-\`).pop()"'
 
       # To deploy we need isolated node_modules folders which yarn won't do because it is a workspace
       # So, remove the workspace

--- a/.github/workflows/DeploySvelteCheckProd.yml
+++ b/.github/workflows/DeploySvelteCheckProd.yml
@@ -1,0 +1,36 @@
+name: Tagged Production Deploys
+
+on:
+  push:
+    tags:
+      - "svelte-check-*"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+
+      # Ensure everything is compiling
+      - run: "yarn install"
+      - run: "yarn build"
+
+      # Lets us use one-liner JSON manipulations the package.json files
+      - run: "npm install -g json"
+
+      # Setup the environment
+      - run: 'json -I -f packages/svelte-check/package.json -e "this.version=\`${{ github.ref }}\`.split(\`-\`).pop()"'
+
+      # Ship it
+      - run: |
+         cd packages/svelte-check
+         npm install
+         npm publish
+
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`svelte-check` now is deployed only when a tag starting with `svelte-check-` is pushed. The VS Code extension now is deployed only when a tag starting with `extensions-` is pushed.

Reason is that quite some people rely on `svelte-check` by now which demands a more manual deployment with dedicated changelogs.