### PR TITLE
(fix) fallback param for built-in transition/animate

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/animation-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/animation-directive.ts
@@ -37,7 +37,8 @@ export function handleAnimateDirective(htmlx: string, str: MagicString, attr: No
  * To not show unnecessary type errors to those users, `{}` should be added
  * as a fallback parameter if the user did not provide one.
  * It may be the case that someone has a custom animation with the same name
- * that expects different parameters, but that possibility is far less likely.
+ * that expects different parameters, or that someone did an import alias fly as foo,
+ * but those are very unlikely.
  *
  * Remove this "hack" some day.
  */

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/transition-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/transition-directive.ts
@@ -18,7 +18,11 @@ export function handleTransitionDirective(htmlx: string, str: MagicString, attr:
     }
 
     if (!attr.expression) {
-        str.appendLeft(attr.end, '(__sveltets_ElementNode))}');
+        if (transitionsThatNeedParam.has(attr.name)) {
+            str.appendLeft(attr.end, '(__sveltets_ElementNode,{}))}');
+        } else {
+            str.appendLeft(attr.end, '(__sveltets_ElementNode))}');
+        }
         return;
     }
 
@@ -32,3 +36,15 @@ export function handleTransitionDirective(htmlx: string, str: MagicString, attr:
         str.remove(attr.end - 1, attr.end);
     }
 }
+
+/**
+ * Up to Svelte version 3.32.0, the following built-in transition functions have
+ * optional parameters, but according to its typings they were mandatory.
+ * To not show unnecessary type errors to those users, `{}` should be added
+ * as a fallback parameter if the user did not provide one.
+ * It may be the case that someone has a custom transition with the same name
+ * that expects different parameters, but that possibility is far less likely.
+ *
+ * Remove this "hack" some day.
+ */
+const transitionsThatNeedParam = new Set(['blur', 'fade', 'fly', 'slide', 'scale', 'draw']);

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/transition-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/transition-directive.ts
@@ -43,7 +43,8 @@ export function handleTransitionDirective(htmlx: string, str: MagicString, attr:
  * To not show unnecessary type errors to those users, `{}` should be added
  * as a fallback parameter if the user did not provide one.
  * It may be the case that someone has a custom transition with the same name
- * that expects different parameters, but that possibility is far less likely.
+ * that expects different parameters, or that someone did an import alias fly as foo,
+ * but those are very unlikely.
  *
  * Remove this "hack" some day.
  */

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/transition-animate-fallbacks/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/transition-animate-fallbacks/expected.jsx
@@ -1,0 +1,17 @@
+<>
+<h1 {...__sveltets_ensureTransition(blur(__sveltets_ElementNode,{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(fade(__sveltets_ElementNode,{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(fly(__sveltets_ElementNode,{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(slide(__sveltets_ElementNode,{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(scale(__sveltets_ElementNode,{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(draw(__sveltets_ElementNode,{}))}>Hello</h1>
+
+<h1 {...__sveltets_ensureTransition(blur(__sveltets_ElementNode,{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(blur(__sveltets_ElementNode,{}))}>Hello</h1>
+
+<h1 {...__sveltets_ensureAnimation(flip(__sveltets_ElementNode,__sveltets_AnimationMove,{}))}>Hello</h1>
+
+<h1 {...__sveltets_ensureTransition(foo(__sveltets_ElementNode))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(foo(__sveltets_ElementNode))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(foo(__sveltets_ElementNode))}>Hello</h1>
+<h1 {...__sveltets_ensureAnimation(foo(__sveltets_ElementNode,__sveltets_AnimationMove))}>Hello</h1></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/transition-animate-fallbacks/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/transition-animate-fallbacks/input.svelte
@@ -1,0 +1,17 @@
+<!-- transitions -->
+<h1 transition:blur>Hello</h1>
+<h1 transition:fade>Hello</h1>
+<h1 transition:fly>Hello</h1>
+<h1 transition:slide>Hello</h1>
+<h1 transition:scale>Hello</h1>
+<h1 transition:draw>Hello</h1>
+<!-- also for in/out transitions -->
+<h1 in:blur>Hello</h1>
+<h1 out:blur>Hello</h1>
+<!-- animate -->
+<h1 animate:flip>Hello</h1>
+<!-- not others -->
+<h1 transition:foo>Hello</h1>
+<h1 in:foo>Hello</h1>
+<h1 out:foo>Hello</h1>
+<h1 animate:foo>Hello</h1>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/transition-modifiers/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/transition-modifiers/expected.jsx
@@ -1,3 +1,3 @@
-<><div {...__sveltets_ensureTransition(slide(__sveltets_ElementNode))}>
+<><div {...__sveltets_ensureTransition(slide(__sveltets_ElementNode,{}))}>
     {item}
 </div></>


### PR DESCRIPTION
Up to Svelte version 3.32.0, the built-in animate/transition functions have optional parameters, but according to its typings they were mandatory. To not show unnecessary type errors to those users, `{}` should be added as a fallback parameter if the user did not provide one.
It may be the case that someone has a custom animation/transition with the same name that expects different parameters, or that someone did an import alias `fly as foo`, but those are very unlikely.
#785