### PR TITLE
(feat) html rename tags pair

### DIFF
--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -36,7 +36,8 @@ const defaultLSConfig: LSConfig = {
         hover: { enable: true },
         completions: { enable: true, emmet: true },
         tagComplete: { enable: true },
-        documentSymbols: { enable: true }
+        documentSymbols: { enable: true },
+        renameTags: { enable: true }
     },
     svelte: {
         enable: true,
@@ -150,6 +151,9 @@ export interface LSHTMLConfig {
         enable: boolean;
     };
     documentSymbols: {
+        enable: boolean;
+    };
+    renameTags: {
         enable: boolean;
     };
 }

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -222,6 +222,7 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider, RenamePro
 
         return this.lang.doRename(document, position, newName, html);
     }
+
     prepareRename(document: Document, position: Position): Range | null {
         if (!this.featureEnabled('renameTags')) {
             return null;

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -2,7 +2,8 @@ import { getEmmetCompletionParticipants } from 'vscode-emmet-helper';
 import {
     getLanguageService,
     HTMLDocument,
-    CompletionItem as HtmlCompletionItem
+    CompletionItem as HtmlCompletionItem,
+    Node
 } from 'vscode-html-languageservice';
 import {
     CompletionList,
@@ -11,7 +12,9 @@ import {
     SymbolInformation,
     CompletionItem,
     CompletionItemKind,
-    TextEdit
+    TextEdit,
+    Range,
+    WorkspaceEdit
 } from 'vscode-languageserver';
 import {
     DocumentManager,
@@ -21,10 +24,10 @@ import {
 } from '../../lib/documents';
 import { LSConfigManager, LSHTMLConfig } from '../../ls-config';
 import { svelteHtmlDataProvider } from './dataProvider';
-import { HoverProvider, CompletionsProvider } from '../interfaces';
-import { isInsideMoustacheTag } from '../../lib/documents/utils';
+import { HoverProvider, CompletionsProvider, RenameProvider } from '../interfaces';
+import { isInsideMoustacheTag, toRange } from '../../lib/documents/utils';
 
-export class HTMLPlugin implements HoverProvider, CompletionsProvider {
+export class HTMLPlugin implements HoverProvider, CompletionsProvider, RenameProvider {
     private configManager: LSConfigManager;
     private lang = getLanguageService({
         customDataProviders: [svelteHtmlDataProvider],
@@ -40,6 +43,16 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
         });
     }
 
+    /**
+     *
+     * The language service is case insensitive, and would provide
+     * hover info for Svelte components like `Option` which have
+     * the same name like a html tag.
+     */
+    private possiblyComponent(node: Node) {
+        return !!node.tag?.[0].match(/[A-Z]/);
+    }
+
     doHover(document: Document, position: Position): Hover | null {
         if (!this.featureEnabled('hover')) {
             return null;
@@ -51,10 +64,7 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
         }
 
         const node = html.findNodeAt(document.offsetAt(position));
-        if (!node || node.tag?.[0].match(/[A-Z]/)) {
-            // The language service is case insensitive, and would provide
-            // hover info for Svelte components like `Option` which have
-            // the same name like a html tag.
+        if (!node || this.possiblyComponent(node)) {
             return null;
         }
 
@@ -204,6 +214,41 @@ export class HTMLPlugin implements HoverProvider, CompletionsProvider {
         }
 
         return this.lang.findDocumentSymbols(document, html);
+    }
+
+    rename(document: Document, position: Position, newName: string): WorkspaceEdit | null {
+        if (!this.featureEnabled('renameTags')) {
+            return null;
+        }
+        const html = this.documents.get(document);
+        if (!html) {
+            return null;
+        }
+
+        const node = html.findNodeAt(document.offsetAt(position));
+        if (!node || this.possiblyComponent(node)) {
+            return null;
+        }
+
+        return this.lang.doRename(document, position, newName, html);
+    }
+    prepareRename(document: Document, position: Position): Range | null {
+        if (!this.featureEnabled('renameTags')) {
+            return null;
+        }
+
+        const html = this.documents.get(document);
+        if (!html) {
+            return null;
+        }
+
+        const node = html.findNodeAt(document.offsetAt(position));
+        if (!node || this.possiblyComponent(node) || !node.tag) {
+            return null;
+        }
+        const tagNameStart = node.start + '<'.length;
+
+        return toRange(document.getText(), tagNameStart, tagNameStart + node.tag.length);
     }
 
     private featureEnabled(feature: keyof LSHTMLConfig) {

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -121,11 +121,16 @@ describe('HTML Plugin', () => {
         const { plugin, document } = setup('<Div></Div>');
 
         assert.deepStrictEqual(plugin.prepareRename(document, Position.create(0, 2)), null);
+        assert.deepStrictEqual(plugin.rename(document, Position.create(0, 2), 'p'), null);
     });
 
     it('does not provide rename for valid element but incorrect position', () => {
         const { plugin, document } = setup('<div on:click={ab => ab}>asd</div>');
         const newName = 'p';
+
+        assert.deepStrictEqual(plugin.prepareRename(document, Position.create(0, 16)), null);
+        assert.deepStrictEqual(plugin.prepareRename(document, Position.create(0, 5)), null);
+        assert.deepStrictEqual(plugin.prepareRename(document, Position.create(0, 26)), null);
 
         assert.deepStrictEqual(plugin.rename(document, Position.create(0, 16), newName), null);
         assert.deepStrictEqual(plugin.rename(document, Position.create(0, 5), newName), null);
@@ -135,6 +140,16 @@ describe('HTML Plugin', () => {
     it('provides rename for element', () => {
         const { plugin, document } = setup('<div on:click={() => {}}></div>');
         const newName = 'p';
+
+        const pepareRenameInfo = Range.create(Position.create(0, 1), Position.create(0, 4));
+        assert.deepStrictEqual(
+            plugin.prepareRename(document, Position.create(0, 2)),
+            pepareRenameInfo
+        );
+        assert.deepStrictEqual(
+            plugin.prepareRename(document, Position.create(0, 28)),
+            pepareRenameInfo
+        );
 
         const renameInfo = {
             changes: {
@@ -156,7 +171,6 @@ describe('HTML Plugin', () => {
                 ]
             }
         };
-
         assert.deepStrictEqual(plugin.rename(document, Position.create(0, 2), newName), renameInfo);
         assert.deepStrictEqual(
             plugin.rename(document, Position.create(0, 28), newName),

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -116,4 +116,36 @@ describe('HTML Plugin', () => {
             undefined
         );
     });
+
+    it('does not provide rename for element being uppercase', async () => {
+        const { plugin, document } = setup('<Div></Div>');
+
+        assert.deepStrictEqual(plugin.prepareRename(document, Position.create(0, 2)), null);
+    });
+
+    it('provides rename for element', () => {
+        const { plugin, document } = setup('<div on:click={() => {}}></div>');
+        const newName = 'p';
+
+        assert.deepStrictEqual(plugin.rename(document, Position.create(0, 2), newName), {
+            changes: {
+                [document.uri]: [
+                    {
+                        newText: 'p',
+                        range: {
+                            start: { line: 0, character: 1 },
+                            end: { line: 0, character: 4 }
+                        }
+                    },
+                    {
+                        newText: 'p',
+                        range: {
+                            start: { line: 0, character: 27 },
+                            end: { line: 0, character: 30 }
+                        }
+                    }
+                ]
+            }
+        });
+    });
 });

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -123,11 +123,20 @@ describe('HTML Plugin', () => {
         assert.deepStrictEqual(plugin.prepareRename(document, Position.create(0, 2)), null);
     });
 
+    it('does not provide rename for valid element but incorrect position', () => {
+        const { plugin, document } = setup('<div on:click={ab => ab}>asd</div>');
+        const newName = 'p';
+
+        assert.deepStrictEqual(plugin.rename(document, Position.create(0, 16), newName), null);
+        assert.deepStrictEqual(plugin.rename(document, Position.create(0, 5), newName), null);
+        assert.deepStrictEqual(plugin.rename(document, Position.create(0, 26), newName), null);
+    });
+
     it('provides rename for element', () => {
         const { plugin, document } = setup('<div on:click={() => {}}></div>');
         const newName = 'p';
 
-        assert.deepStrictEqual(plugin.rename(document, Position.create(0, 2), newName), {
+        const renameInfo = {
             changes: {
                 [document.uri]: [
                     {
@@ -146,6 +155,12 @@ describe('HTML Plugin', () => {
                     }
                 ]
             }
-        });
+        };
+
+        assert.deepStrictEqual(plugin.rename(document, Position.create(0, 2), newName), renameInfo);
+        assert.deepStrictEqual(
+            plugin.rename(document, Position.create(0, 28), newName),
+            renameInfo
+        );
     });
 });

--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -190,6 +190,10 @@ Enable HTML tag auto closing. _Default_: `true`
 
 Enable document symbols for HTML. _Default_: `true`
 
+##### `svelte.plugin.html.renameTags.enable`
+
+Enable rename tags for the opening/closing tag pairs in HTML. _Default_: `true`
+
 ##### `svelte.plugin.svelte.enable`
 
 Enable the Svelte plugin. _Default_: `true`

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -232,6 +232,12 @@
                     "title": "HTML: Symbols in Outline",
                     "description": "Enable document symbols for HTML"
                 },
+                "svelte.plugin.html.renameTags.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "HTML: Rename tags",
+                    "description": "Enable rename for the opening/closing tag pairs in HTML"
+                },
                 "svelte.plugin.svelte.enable": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
#791
Rename element start and end tag pair. Doesn't apply to components, it is handled by the typescript plugin.