### PR TITLE
(fix) template highlighting

### DIFF
--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
@@ -82,7 +82,7 @@ injections:
 
   # Default (just introduces a new scope)
   'L:meta.template.svelte - meta.lang - (meta source)':
-    patterns: [{begin: '(?<=>)\s', end: '(?=</)', patterns: [{ include: '#scope' }]}]
+    patterns: [{begin: '(?<=>)\s', end: '(?=</template)', patterns: [{ include: '#scope' }]}]
 
   # ---- LANGUAGE EXTENSIONS
 


### PR DESCRIPTION
Match `</template` specifically so it does not end prematurely on inner closing tags
#694