### PR TITLE
fix: shorthand transition and animation params

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/animation-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/animation-directive.ts
@@ -20,11 +20,7 @@ export function handleAnimateDirective(
     const nodeType = `__sveltets_mapElementTag('${parent.name}')`;
 
     if (!attr.expression) {
-        if (animationsThatNeedParam.has(attr.name)) {
-            str.appendLeft(attr.end, `(${nodeType},__sveltets_AnimationMove,{}))}`);
-        } else {
-            str.appendLeft(attr.end, `(${nodeType},__sveltets_AnimationMove))}`);
-        }
+        str.appendLeft(attr.end, `(${nodeType},__sveltets_AnimationMove,{}))}`);
         return;
     }
     str.overwrite(
@@ -37,16 +33,3 @@ export function handleAnimateDirective(
         str.remove(attr.end - 1, attr.end);
     }
 }
-
-/**
- * Up to Svelte version 3.32.0, the following built-in animate functions have
- * optional parameters, but according to its typings they were mandatory.
- * To not show unnecessary type errors to those users, `{}` should be added
- * as a fallback parameter if the user did not provide one.
- * It may be the case that someone has a custom animation with the same name
- * that expects different parameters, or that someone did an import alias fly as foo,
- * but those are very unlikely.
- *
- * Remove this "hack" some day.
- */
-const animationsThatNeedParam = new Set(['flip']);

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/transition-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/transition-directive.ts
@@ -25,11 +25,7 @@ export function handleTransitionDirective(
     const nodeType = `__sveltets_mapElementTag('${parent.name}')`;
 
     if (!attr.expression) {
-        if (transitionsThatNeedParam.has(attr.name)) {
-            str.appendLeft(attr.end, `(${nodeType},{}))}`);
-        } else {
-            str.appendLeft(attr.end, `(${nodeType}))}`);
-        }
+        str.appendLeft(attr.end, `(${nodeType},{}))}`);
         return;
     }
 
@@ -43,16 +39,3 @@ export function handleTransitionDirective(
         str.remove(attr.end - 1, attr.end);
     }
 }
-
-/**
- * Up to Svelte version 3.32.0, the following built-in transition functions have
- * optional parameters, but according to its typings they were mandatory.
- * To not show unnecessary type errors to those users, `{}` should be added
- * as a fallback parameter if the user did not provide one.
- * It may be the case that someone has a custom transition with the same name
- * that expects different parameters, or that someone did an import alias fly as foo,
- * but those are very unlikely.
- *
- * Remove this "hack" some day.
- */
-const transitionsThatNeedParam = new Set(['blur', 'fade', 'fly', 'slide', 'scale', 'draw']);

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/animation-bare/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/animation-bare/expected.jsx
@@ -1,1 +1,1 @@
-<><h1 {...__sveltets_ensureAnimation(blink(__sveltets_mapElementTag('h1'),__sveltets_AnimationMove))}>Hello</h1></>
+<><h1 {...__sveltets_ensureAnimation(blink(__sveltets_mapElementTag('h1'),__sveltets_AnimationMove,{}))}>Hello</h1></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/transition-animate-fallbacks/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/transition-animate-fallbacks/expected.jsx
@@ -11,7 +11,7 @@
 
 <h1 {...__sveltets_ensureAnimation(flip(__sveltets_mapElementTag('h1'),__sveltets_AnimationMove,{}))}>Hello</h1>
 
-<h1 {...__sveltets_ensureTransition(foo(__sveltets_mapElementTag('h1')))}>Hello</h1>
-<h1 {...__sveltets_ensureTransition(foo(__sveltets_mapElementTag('h1')))}>Hello</h1>
-<h1 {...__sveltets_ensureTransition(foo(__sveltets_mapElementTag('h1')))}>Hello</h1>
-<h1 {...__sveltets_ensureAnimation(foo(__sveltets_mapElementTag('h1'),__sveltets_AnimationMove))}>Hello</h1></>
+<h1 {...__sveltets_ensureTransition(foo(__sveltets_mapElementTag('h1'),{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(foo(__sveltets_mapElementTag('h1'),{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(foo(__sveltets_mapElementTag('h1'),{}))}>Hello</h1>
+<h1 {...__sveltets_ensureAnimation(foo(__sveltets_mapElementTag('h1'),__sveltets_AnimationMove,{}))}>Hello</h1></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/transition-bare/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/transition-bare/expected.jsx
@@ -1,3 +1,3 @@
-<><h1 {...__sveltets_ensureTransition(blink(__sveltets_mapElementTag('h1')))}>Hello</h1>
-<h1 {...__sveltets_ensureTransition(blink(__sveltets_mapElementTag('h1')))}>Hello</h1>
-<h1 {...__sveltets_ensureTransition(blink(__sveltets_mapElementTag('h1')))}>Hello</h1></>
+<><h1 {...__sveltets_ensureTransition(blink(__sveltets_mapElementTag('h1'),{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(blink(__sveltets_mapElementTag('h1'),{}))}>Hello</h1>
+<h1 {...__sveltets_ensureTransition(blink(__sveltets_mapElementTag('h1'),{}))}>Hello</h1></>


### PR DESCRIPTION
Real fix for #785

I've updated the [REPL](https://svelte.dev/repl/3dfed2eaa77a4ae9b5be415a22420d48?version=3.32.3) to make it extra clear what is happening.

Directive | Nr. args | Empty object
-- | -- | --
use | 1 | false
use={{}} | 2 | true
animate | 3 | true
animate={} | 3 | true
animate={{duration}} | 3 | false
transition | 2 | true
transition={{}} | 2 | true
transition={{duration}} | 2 | false

This demonstrates that unlike the `use` shorthand, the transition and animate shorthand pass an empty object as parameter.
 `<div transition:fade>` is identical to `<div transition:fade={{}}>` as far as the svelte compiler is concerned.

This allows custom transitions like [svelte-transitions-fade-scale](https://github.com/flekschas/svelte-transitions-fade-scale/blob/master/src/index.js):
```js
function fadeScale(node, { delay = 0, duration = 200, easing = x => x, baseScale = 0 })
```
to work as shorthand `<div transition:fadeScale>` without causing `Cannot read property 'duration' of undefined` errors.

In svelte 3.32.0 the params got an empty object as default value ` = {}`, this change hides the fact that svelte2tsx  created the wrong type for the built-in transitions, silencing the "Expected 2 arguments, but got 1." error reported by svelte-check
(This is still a nice change, it makes reusing the built-in transitions with defaults easier)