### PR TITLE
add typescript-plugin skeleton

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,8 @@ packages/svelte2tsx/test/sourcemaps/*.html
 packages/language-server/test/**/*.svelte
 packages/language-server/test/**/testfiles/**/*.ts
 packages/svelte-vscode/syntaxes/*.yaml
+packages/typescript-plugin/src/**/*.js
+packages/typescript-plugin/src/**/*.d.ts
 **/dist
 .github/**
 .history/**

--- a/packages/typescript-plugin/.gitignore
+++ b/packages/typescript-plugin/.gitignore
@@ -1,0 +1,5 @@
+src/**/*.js
+src/**/*.d.ts
+src/tsconfig.tsbuildinfo
+node_modules
+tsconfig.tsbuildinfo

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -4,8 +4,8 @@
     "description": "A TypeScript Plugin providing Svelte intellisense",
     "main": "src/index.js",
     "scripts": {
-        "test": "test",
-        "build": "tsc -p ./"
+        "build": "tsc -p ./",
+        "test": "echo 'NOOP'"
     },
     "keywords": [
         "svelte",

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "typescript-svelte-plugin",
+    "version": "0.1.0",
+    "description": "A TypeScript Plugin providing Svelte intellisense",
+    "main": "src/index.js",
+    "scripts": {
+        "test": "test",
+        "build": "tsc -p ./"
+    },
+    "keywords": [
+        "svelte",
+        "typescript",
+        "javascript",
+        "plugin"
+    ],
+    "author": "The Svelte Community",
+    "license": "MIT",
+    "devDependencies": {
+        "@tsconfig/node12": "^1.0.0",
+        "@types/node": "^13.9.0",
+        "typescript": "*"
+    }
+}

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -1,0 +1,13 @@
+function init(modules: { typescript: typeof import('typescript/lib/tsserverlibrary') }) {
+    function create(info: ts.server.PluginCreateInfo) {
+        // TODO
+    }
+
+    function getExternalFiles(project: ts.server.ConfiguredProject) {
+        // TODO
+    }
+
+    return { create, getExternalFiles };
+}
+
+export = init;

--- a/packages/typescript-plugin/tsconfig.json
+++ b/packages/typescript-plugin/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "@tsconfig/node12/tsconfig.json",
+    "compilerOptions": {
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "strict": true,
+        "declaration": true,
+        "outDir": ".",
+        "sourceMap": false,
+        "composite": true
+    },
+    "include": ["./src/**/*"],
+    "exclude": ["./node_modules"]
+}


### PR DESCRIPTION
Can be incorporated into the extension by adding
```
        "typescriptServerPlugins": [
            {
                "name": "typescript-svelte-plugin",
                "enableForWorkspaceTypeScriptVersions": true
            }
        ],
```
and
```
        "typescript-svelte-plugin": "*",
```
to the package.json of the svelte-vscode package and running `yarn install` afterwards in the root of this repo.

@pushkine FYI