### PR TITLE
(fix) correct classname generation for all-invalid filenames

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/index.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/index.ts
@@ -324,11 +324,15 @@ function classNameFromFilename(filename: string): string | undefined {
             // Although "-" is invalid, we leave it in, pascal-case-handling will throw it out later
             .filter((char) => /[A-Za-z$_\d-]/.test(char))
             .join('');
-        const withoutLeadingInvalidCharacters = withoutInvalidCharacters.substr(
-            withoutInvalidCharacters.split('').findIndex((char) => /[A-Za-z_$]/.test(char))
-        );
+        const firstValidCharIdx = withoutInvalidCharacters
+            .split('')
+            // Although _ and $ are valid first characters for classes, they are invalid first characters
+            // for tag names. For a better import autocompletion experience, we therefore throw them out.
+            .findIndex((char) => /[A-Za-z]/.test(char));
+        const withoutLeadingInvalidCharacters = withoutInvalidCharacters.substr(firstValidCharIdx);
         const inPascalCase = pascalCase(withoutLeadingInvalidCharacters);
-        return `${inPascalCase}${COMPONENT_SUFFIX}`;
+        const finalName = firstValidCharIdx === -1 ? `A${inPascalCase}` : inPascalCase;
+        return `${finalName}${COMPONENT_SUFFIX}`;
     } catch (error) {
         console.warn(`Failed to create a name for the component class from filename ${filename}`);
         return undefined;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifiers-only/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifiers-only/expected.tsx
@@ -1,0 +1,7 @@
+///<reference types="svelte" />
+<></>;function render() {
+<></>
+return { props: {}, slots: {}, getters: {}, events: {} }}
+
+export default class A0__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {
+}


### PR DESCRIPTION
Filenames where all characters are invalid first class characters will have `A` prepended to their name now to make it a valid class name.
Also, `$` and `_` are no longer kept as first characters. Although they are valid first characters for classes, they are invalid first characters for tag names. For a better import autocompletion experience, we therefore throw them out.