### PR TITLE
Fallback ts, js watcher for clients don't support didChangeWatchedFiles

### DIFF
--- a/packages/language-server/src/lib/FallbackWatcher.ts
+++ b/packages/language-server/src/lib/FallbackWatcher.ts
@@ -9,19 +9,16 @@ export class FallbackWatcher {
     private readonly watcher: FSWatcher;
     private readonly callbacks: DidChangeHandler[] = [];
 
-    constructor(glob: string, private readonly workspacePath: string) {
-        this.watcher = watch(glob, {
-            cwd: workspacePath
-        });
+    constructor(glob: string, workspacePaths: string[]) {
+        this.watcher = watch(workspacePaths.map((workspacePath) => join(workspacePath, glob)));
 
-        this.watcher.on('add', (path) => this.callback(path, FileChangeType.Created));
-        this.watcher.on('unlink', (path) => this.callback(path, FileChangeType.Deleted));
-        this.watcher.on('change', (path) => this.callback(path, FileChangeType.Changed));
+        this.watcher
+            .on('add', (path) => this.callback(path, FileChangeType.Created))
+            .on('unlink', (path) => this.callback(path, FileChangeType.Deleted))
+            .on('change', (path) => this.callback(path, FileChangeType.Changed));
     }
 
-    private convert(relativePath: string, type: FileChangeType): DidChangeWatchedFilesParams {
-        const path = join(this.workspacePath, relativePath);
-
+    private convert(path: string, type: FileChangeType): DidChangeWatchedFilesParams {
         const event: FileEvent = {
             type,
             uri: pathToUrl(path)

--- a/packages/language-server/src/lib/FallbackWatcher.ts
+++ b/packages/language-server/src/lib/FallbackWatcher.ts
@@ -1,0 +1,47 @@
+import { FSWatcher, watch } from 'chokidar';
+import { join } from 'path';
+import { DidChangeWatchedFilesParams, FileChangeType, FileEvent } from 'vscode-languageserver';
+import { pathToUrl } from '../utils';
+
+type DidChangeHandler = (para: DidChangeWatchedFilesParams) => void;
+
+export class FallbackWatcher {
+    private readonly watcher: FSWatcher;
+    private readonly callbacks: DidChangeHandler[] = [];
+
+    constructor(glob: string, private readonly workspacePath: string) {
+        this.watcher = watch(glob, {
+            cwd: workspacePath
+        });
+
+        this.watcher.on('add', (path) => this.callback(path, FileChangeType.Created));
+        this.watcher.on('unlink', (path) => this.callback(path, FileChangeType.Deleted));
+        this.watcher.on('change', (path) => this.callback(path, FileChangeType.Changed));
+    }
+
+    private convert(relativePath: string, type: FileChangeType): DidChangeWatchedFilesParams {
+        const path = join(this.workspacePath, relativePath);
+
+        const event: FileEvent = {
+            type,
+            uri: pathToUrl(path)
+        };
+
+        return {
+            changes: [event]
+        };
+    }
+
+    private callback(path: string, type: FileChangeType) {
+        const para = this.convert(path, type);
+        this.callbacks.forEach((callback) => callback(para));
+    }
+
+    onDidChangeWatchedFiles(callback: DidChangeHandler) {
+        this.callbacks.push(callback);
+    }
+
+    dispose() {
+        this.watcher.close();
+    }
+}


### PR DESCRIPTION
When a language server client doesn't support `didChangeWatchedFiles`. Initialize our own fallback file watcher. 
This should fix the [ts, js file doesn't get updated issue](https://discordapp.com/channels/457912077277855764/689494103380983930/777836134318473246) on the sublime text. Since sublime text LSP doesn't support this notification. (https://github.com/sublimelsp/LSP/issues/892)
