### PR TITLE
Typescript Language Plugin

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -495,9 +495,9 @@
         ],
         "typescriptServerPlugins": [
             {
-                "name": "ts-plugin-svelte",
+                "name": "typescript-svelte-plugin",
                 "enableForWorkspaceTypeScriptVersions": true,
-                "path": "../ts-plugin-svelte",
+                "path": "typescript-plugin",
                 "languages": [
                     "svelte"
                 ]

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -492,6 +492,16 @@
             {
                 "language": "svelte"
             }
+        ],
+        "typescriptServerPlugins": [
+            {
+                "name": "ts-plugin-svelte",
+                "enableForWorkspaceTypeScriptVersions": true,
+                "path": "../ts-plugin-svelte",
+                "languages": [
+                    "svelte"
+                ]
+            }
         ]
     },
     "devDependencies": {

--- a/packages/typescript-plugin/.gitignore
+++ b/packages/typescript-plugin/.gitignore
@@ -3,3 +3,4 @@ src/**/*.d.ts
 src/tsconfig.tsbuildinfo
 node_modules
 tsconfig.tsbuildinfo
+index.js

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -4,7 +4,8 @@
     "description": "A TypeScript Plugin providing Svelte intellisense",
     "main": "src/index.js",
     "scripts": {
-        "build": "tsc -p ./",
+        "build": "esbuild src/index.ts --bundle --platform=node --target=es2020 --external:svelte2tsx --outfile=index.js",
+        "watch": "npm run build -- --watch",
         "test": "echo 'NOOP'"
     },
     "keywords": [
@@ -18,6 +19,11 @@
     "devDependencies": {
         "@tsconfig/node12": "^1.0.0",
         "@types/node": "^13.9.0",
+        "esbuild": "^0.8.51",
         "typescript": "*"
+    },
+    "dependencies": {
+        "sourcemap-codec": "^1.4.8",
+        "svelte2tsx": "^0.1.174"
     }
 }

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -2,7 +2,7 @@
     "name": "typescript-svelte-plugin",
     "version": "0.1.0",
     "description": "A TypeScript Plugin providing Svelte intellisense",
-    "main": "src/index.js",
+    "main": "index.js",
     "scripts": {
         "build": "esbuild src/index.ts --bundle --platform=node --target=es2020 --external:svelte2tsx --outfile=index.js",
         "watch": "npm run build -- --watch",

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -1,13 +1,12 @@
-function init(modules: { typescript: typeof import('typescript/lib/tsserverlibrary') }) {
-    function create(info: ts.server.PluginCreateInfo) {
-        // TODO
-    }
-
-    function getExternalFiles(project: ts.server.ConfiguredProject) {
-        // TODO
-    }
-
-    return { create, getExternalFiles };
-}
-
-export = init;
+import svelte2tsx, { SvelteCompiledToTsx } from "svelte2tsx";
+import { createLanguagePlugin } from "./ts-language-plugin";
+module.exports = createLanguagePlugin({
+	extension: "svelte",
+	transform(fileName, text) {
+		const tsx: SvelteCompiledToTsx = svelte2tsx(text, { filename: fileName, emitOnTemplateError: true });
+		return {
+			content: tsx.code,
+			mappings: tsx.map.mappings,
+		};
+	},
+});

--- a/packages/typescript-plugin/src/ts-language-plugin/debug.ts
+++ b/packages/typescript-plugin/src/ts-language-plugin/debug.ts
@@ -1,0 +1,350 @@
+import { TSPluginContext } from ".";
+import { addSideEffects, override, quote, toLineChar } from "./utils";
+export const debug = new (class Debug {
+	constructor() {
+		this.log("### PLUGIN SCRIPT EVALUATED ###");
+	}
+	enabled = true;
+	readonly pluginName = "[TSPlugin_name_missing]";
+	private directory = "";
+	getFancyPluginName(...args: string[]) {
+		return `TSPlugin<${this.pluginName}${args.length ? ", " + args.join(", ") : ""}>`;
+	}
+	throw(str: string) {
+		if (!this.enabled) return;
+		throw new Error(`${this.pluginName} Error: ${str}`);
+	}
+	private logger: ts.server.Logger = { info: console.log } as any;
+	private allow_regexp = [
+		/^Project \'.*?\' \(Configured\)$/,
+		/^\tFiles ([0-9]+)\n\t/,
+		/^Different program with same set of files:: structureIsReused:: [0-9]+$/,
+		// /^Config: .*? : {\n \"rootNames\"/,
+	];
+	private custom_regexp: [RegExp, (str: string) => string | null][] = [
+		[
+			/^Config: .*? : {\n \"rootNames\"/,
+			(str) => {
+				const index = str.indexOf("{");
+				const o: { rootNames: string[]; options: Record<string, any> } = JSON.parse(str.slice(index));
+				o.rootNames = o.rootNames.map((str) => this.projectPath(str));
+				if ("configFilePath" in o.options) {
+					o.options.configFilePath = this.projectPath(o.options.configFilePath);
+				}
+				const path = str.slice("Config: ".length, index - 3);
+				return `Config | "${path}"\n` + JSON.stringify(o, void 0, "\t");
+			},
+		],
+		[
+			/^event:\n    /,
+			(str) => {
+				const obj: { event: string; body: any } = JSON.parse(str.slice("event:\n    ".length));
+				let text = "";
+				x: {
+					if (["syntaxDiag", "semanticDiag", "suggestionDiag"].includes(obj.event)) {
+						const body = obj.body as { file: string; diagnostics: ts.DiagnosticWithLocation[] };
+						if (body.diagnostics.length === 0) {
+							text = ` | "${this.projectPath(body.file)}" -> (no results)`;
+							break x;
+						}
+					}
+					text = "\n" + JSON.stringify(obj.body, void 0, "\t");
+					if (text.length < 150) text = `-> ${JSON.stringify(obj.body)}`;
+				}
+				return `Event | "${obj.event}"` + text;
+			},
+		],
+		[
+			/^request:\n    /,
+			(str) => {
+				const obj: { command: string; arguments: any; seq: number } = JSON.parse(str.slice("request:\n    ".length));
+				let text = "";
+				if (!obj.arguments) {
+					text = "| (no arguments)";
+				} else {
+					text = "\n" + JSON.stringify(obj.arguments, void 0, "\t");
+					if (text.length < 150 || text.length > 1000) {
+						text = ` -> ${JSON.stringify(obj.arguments)}`;
+					}
+				}
+				return `Request ${obj.seq} | "${obj.command}"` + text;
+			},
+		],
+		[
+			/^response:\n    /,
+			(str) => {
+				const obj: { command: string; success: boolean; body: any; request_seq: number } = JSON.parse(
+					str.slice("response:\n    ".length),
+				);
+				let text = "";
+				if (typeof obj.body !== "object") text = ` -> ${JSON.stringify(obj.body)}`;
+				else if (obj.command === "getApplicableRefactors") {
+					text = ` -> (${obj.body.length} results hidden)`;
+				} else if (obj.command === "getSupportedCodeFixes") {
+					text = " -> number[]";
+				} else {
+					text =
+						"\n" +
+						JSON.stringify(
+							obj.body,
+							function (key, value) {
+								if (key === "file") return debug.projectPath(value);
+								if (key === "start" || key === "end" || key === "contextStart" || key === "contextEnd")
+									return JSON.stringify(value);
+								return value;
+							},
+							"\t",
+						).replace(/"{\\"line\\":([0-9]+),\\"offset\\":([0-9]+)}"/g, `{ "line":$1, "offset": $2}`);
+				}
+				return `Response ${obj.request_seq} | "${obj.command}"` + text + `\n${"-".repeat(30)}`;
+			},
+		],
+		[
+			/^Reloading configured project /,
+			(str) => {
+				const path = str.slice("Reloading configured project".length);
+				return `Reloading configurated project at "${path}"`;
+			},
+		],
+	];
+	private suppress_regexp = [
+		// project
+		/^Search path: /, //
+		/^For info: .*? :: Config file name: /,
+		// plugins
+		/^Loading global plugin /,
+		/^Enabling plugin .*? from candidate paths: /,
+		/^Loading .*? from .*? \(resolved to .*?\)$/,
+		/^typescript-vscode-sh-plugin initialized/,
+		/^Plugin validation succeded$/,
+		// watcher
+		/FileWatcher:: Added:: WatchInfo:/,
+		/DirectoryWatcher:: Added:: WatchInfo:/,
+		/^watchDirectory for .*? uses cached drive information\.$/,
+		// graph
+		/^Starting updateGraphWorker: Project: /,
+		/^Finishing updateGraphWorker: Project: /,
+		// on load/reload
+		/^After ensureProjectForOpenFiles:$/,
+		/^Before ensureProjectForOpenFiles:$/,
+		/^ConfigFilePresence:: Current Watches: Config file:: File: /,
+		/Open files: /,
+		/^-----------------------------------------------$/,
+		/^\tFileName: .*? ProjectRootPath: $/,
+		/^\tFiles ([0-9]+)\n$/,
+		// unsure
+		/^Running: \*ensureProjectForOpenFiles\*$/,
+	];
+	private replace_regexp: [RegExp, string][] = [
+		[/^reload projects\.$/, `### RELOADING PROJECTS ###`], //
+	];
+	private suppressLogs() {
+		if (!this.enabled) return;
+		this.log(`### SUPRESSING/REWRITING TS SERVER LOGS FROM TSPLUGIN "${this.pluginName}" ###`);
+		override(this.logger, {
+			msg: (_, str, type) => {
+				x: if (!str.startsWith(this.pluginName) && type === "Info") {
+					for (const re of this.allow_regexp) {
+						if (re.test(str)) break x;
+					}
+					for (const [re, fn] of this.custom_regexp) {
+						if (re.test(str)) {
+							const r = fn(str);
+							if (r === null) return;
+							else return _(r, type);
+						}
+					}
+					for (const [re, r] of this.replace_regexp) {
+						if (re.test(str)) return _(r, type);
+					}
+					for (const re of this.suppress_regexp) {
+						if (re.test(str)) return;
+					}
+					// if (/^\tFiles ([0-9]+)\n$/.test(str)) return;
+					return _(JSON.stringify(str), type);
+				} else if (type === "Perf") {
+					if (/elapsed time \(in milliseconds\) [\.0-9]+$/.test(str)) {
+						const t = parseFloat(str);
+						if (t < 10) return;
+					}
+				}
+				return _(str, type);
+			},
+		});
+	}
+	init(info: TSPluginContext) {
+		// @ts-expect-error
+		this.enabled = info.ts.server.findArgument("--logVerbosity") === "verbose";
+		// @ts-expect-error
+		this.pluginName = info.config.name;
+		// @ts-expect-error
+		this.directory = info.project.currentDirectory;
+		this.logger = info.project.projectService.logger;
+		if (this.enabled) {
+			this.suppressLogs();
+		}
+		this.log(`### DEBUG ENABLED ###`);
+		return this.enabled;
+	}
+	log(str: any) {
+		if (!this.enabled) return;
+		// if (str.includes("\n")) str = str.replace(/^\n*/, "\n\n").replace(/\n*$/, "\n");
+		str = `${this.pluginName} | ${str}`;
+		this.logger.info(str); // note: vscode does not support ANSI color in .log files
+	}
+	private plogs = new WeakMap<object, string>();
+	logIfChanged(ref: object | undefined, str: string) {
+		if (!this.enabled) return;
+		if (!ref) {
+			this.log(str);
+			return;
+		}
+		if (this.plogs.get(ref) !== str) this.log(str);
+		this.plogs.set(ref, str);
+	}
+	projectPath(str: string) {
+		return str.replace(this.directory, "");
+	}
+	fileName(str: string) {
+		return str.slice(str.lastIndexOf("/") + 1);
+	}
+	baseFileName(str: string) {
+		return str.slice(str.lastIndexOf("/") + 1, str.lastIndexOf("."));
+	}
+	formatCall(objectName: string, methodName: string, ...args: string[]) {
+		if (!this.enabled) return "";
+		return `${objectName}.${methodName}(${args.join(", ")});`;
+	}
+	private stringify(arg: any) {
+		if (typeof arg === "string") {
+			if (/\n/.test(arg)) return `"..."`;
+			return quote(arg);
+		}
+		if (typeof arg === "object") {
+			if (arg.constructor === Object) {
+				for (const key in arg) {
+					const value = arg[key];
+					switch (typeof value) {
+						case "object":
+						case "function":
+							return "{...}";
+					}
+				}
+				return `{ ${Object.keys(arg)
+					.map((key) => `${key}: ${debug.stringify(arg[key])}`)
+					.join(", ")} }`;
+			}
+			if (arg.constructor === Array) {
+				for (const value of arg) {
+					switch (typeof value) {
+						case "object":
+						case "function":
+							return "[...]";
+					}
+				}
+				return `[${arg.map(debug.stringify).join(", ")}]`;
+			}
+			return arg.constructor.name;
+		}
+		return "" + arg;
+	}
+	formatCallFull(objectName: string, methodName: string, args: any[], result?: any) {
+		if (!this.enabled) return "";
+		let str = args
+			.map(this.stringify)
+			.join(", ")
+			.replace(/(, undefined)+$/, "");
+		if (str.length > 100) str = str.slice(0, str.lastIndexOf(", ", 100)) + ", ...";
+		return `${objectName}.${methodName}(${str}) -> ${this.stringify(result)}`;
+	}
+	everyCall(
+		obj: object,
+		config: {
+			name: string;
+			keys?: string[];
+			ifFirstArg?(fileName: string): boolean;
+			format?(objectName: string, methodName: string, args: any[], result?: any): string;
+		},
+	) {
+		if (!this.enabled) return;
+		const overrides = {};
+		for (const key of config.keys ?? Object.keys(obj)) {
+			// @ts-ignore
+			if (typeof obj[key] !== "function") continue;
+			if (config.ifFirstArg) {
+				const format =
+					config.format ??
+					((on, mn, args, r) => this.formatCallFull(on, mn, [quote(this.projectPath(args[0])), ...args.slice(1)], r));
+				// @ts-ignore
+				overrides[key] = (result, fileName, ...args) => {
+					if (typeof fileName === "string" && config.ifFirstArg(fileName)) {
+						this.log(format(config.name, key, [fileName, ...args], result));
+					}
+				};
+			} else {
+				const format = config.format ?? this.formatCallFull.bind(this);
+				// @ts-ignore
+				overrides[key] = (result, ...args) => {
+					this.log(format(config.name, key, args, result));
+				};
+			}
+		}
+		addSideEffects(obj, overrides);
+	}
+	logFileContent(id: object, info: string, language: string, text: string | undefined) {
+		if (!this.enabled) return;
+		let content = typeof text === "string" ? (text ? text : "<EmptyFile>") : "<FileNotFound>";
+		this.logIfChanged(
+			id,
+			`${info}\n` + //
+				`\`\`\`${language}\n` +
+				`${content}\n` +
+				`\`\`\``,
+		);
+	}
+	compareMappings(context: TSPluginContext, a: ComparaisonMap, b: ComparaisonMap, maybeRangeEnd: boolean) {
+		if (!this.enabled) return;
+		const [left, right] = [parseMapping(context, a), parseMapping(context, b)];
+		// todo better than 1char check
+		if (left.lineContent[left.index] !== right.lineContent[right.index]) {
+			if (maybeRangeEnd && left.lineContent[left.index - 1] === right.lineContent[right.index - 1]) {
+				return;
+			}
+			this.log(`Mapping position mismatch\n` + mark(left) + mark(right));
+			debugger;
+			this.throw(`Mapping position mismatch`);
+		}
+	}
+	trace(str: any) {
+		if (!this.enabled) return;
+		this.log(str);
+		console.trace();
+	}
+})();
+interface ComparaisonMap {
+	text: string;
+	position: { line: number; offset: number } | { line: number; character: number } | number;
+	lineStarts?: number[];
+	maybeRangeEndCorrected?: boolean;
+}
+interface MappedType {
+	lineContent: string;
+	lineNumber: number;
+	index: number;
+}
+function parseMapping(context: TSPluginContext, m: ComparaisonMap): MappedType {
+	let { text, position, lineStarts = context.ts.computeLineStarts(m.text) } = m;
+	if (typeof position === "number") {
+		position = context.ts.computeLineAndCharacterOfPosition(lineStarts, position);
+	} else if ("offset" in position) {
+		position = toLineChar(position);
+	}
+	const lineContent = text.slice(lineStarts[position.line], lineStarts[position.line + 1] ?? text.length);
+	return { lineContent: lineContent, index: position.character, lineNumber: position.line + 1 };
+}
+function mark({ lineContent, index, lineNumber }: MappedType) {
+	const x = `${lineNumber}:${index + 1} `;
+	let str = lineContent.replace(/\t/g, " ");
+	if (!str.endsWith("\n")) str += "\n";
+	return `${x}` + lineContent.replace(/\t/g, " ") + " ".repeat(index + x.length) + "^" + "\n";
+}

--- a/packages/typescript-plugin/src/ts-language-plugin/index.ts
+++ b/packages/typescript-plugin/src/ts-language-plugin/index.ts
@@ -1,0 +1,65 @@
+import ts from 'typescript/lib/tsserverlibrary';
+import { enableLanguageSupport } from './internals';
+import { LineChar, _ts } from './types';
+import { getExtensionFromScriptKind, testForExtension } from './utils';
+
+export interface LanguageFileMapper {
+    readonly generatedText: string;
+    readonly originalLineStarts?: number[];
+    readonly generatedlineStarts?: number[];
+    getGeneratedPosition(pos: LineChar): LineChar;
+    getOriginalPosition(pos: LineChar): LineChar;
+}
+export interface TransformedLanguageFile {
+    content: string;
+    mappings: string;
+}
+export interface TSLanguagePlugin {
+    extension: string;
+    scriptKind?: ts.ScriptKind;
+    extensionKind?: ts.Extension;
+    transform(fileName: string, text: string): LanguageFileMapper | TransformedLanguageFile;
+}
+export interface TSLanguagePluginFactory {
+    (host: TSPluginOptions): TSLanguagePlugin;
+}
+interface TSPluginOptions extends ts.server.PluginCreateInfo {
+    ts: typeof ts;
+}
+export interface TSPluginContext extends TSPluginOptions {
+    ts: _ts;
+    // languageServiceHost = project
+    config: any;
+}
+export function createLanguagePlugin(
+    options: TSLanguagePlugin | TSLanguagePluginFactory
+): ts.server.PluginModuleFactory {
+    return (modules) => ({
+        create(info) {
+            if (typeof options === 'function')
+                options = options({ ...info, ts: modules.typescript });
+            const context = { ...info, ts: modules.typescript } as TSPluginContext;
+            const extension = options.extension.replace(/^\.?/, '.');
+            const scriptKind = options.scriptKind ?? context.ts.ScriptKind.TSX;
+            const extensionKind =
+                options.extensionKind ?? getExtensionFromScriptKind(context, scriptKind);
+            enableLanguageSupport(context, {
+                extension,
+                scriptKind,
+                extensionKind,
+                transform: options.transform,
+                disabled: [
+                    'getApplicableRefactors',
+                    'getSemanticDiagnostics',
+                    'getSyntacticDiagnostics',
+                    'getSuggestionDiagnostics',
+                    'getQuickInfoAtPosition',
+                    'getFormattingEditsAfterKeystroke',
+                    'getCodeFixesAtPosition'
+                ],
+                is: testForExtension(extension)
+            });
+            return info.languageService;
+        }
+    });
+}

--- a/packages/typescript-plugin/src/ts-language-plugin/internals.ts
+++ b/packages/typescript-plugin/src/ts-language-plugin/internals.ts
@@ -1,0 +1,644 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { LanguageFileMapper, TransformedLanguageFile, TSPluginContext } from '.';
+import { debug } from './debug';
+import { SourceMapConsumer } from './sourcemaps';
+import { LineChar, tsInternalServerHelpers } from './types';
+import {
+	addSideEffects,
+	extensionFromFileName,
+	getExtensionFromScriptKind,
+	getText,
+	override,
+	quote,
+	toLineChar,
+	toLineOffset,
+	toPosition
+} from './utils';
+
+interface LanguageConfig {
+    extension: string;
+    scriptKind: ts.ScriptKind;
+    extensionKind: ts.Extension;
+    disabled?: (keyof ts.LanguageService)[];
+    is(fileName: string): boolean;
+    transform: (fileName: string, text: string) => LanguageFileMapper | TransformedLanguageFile;
+    enableDebug?(context: TSPluginContext, debug_: typeof debug): void;
+}
+interface TextStorageMapper {
+    getOriginalPosition(position: LineChar): LineChar;
+    getGeneratedPosition(position: LineChar): LineChar;
+    setOriginalText(text: string): void;
+    originalLineStarts: number[];
+    generatedLineStarts: number[];
+    originalText: string;
+    generatedText: string;
+}
+interface ScriptVersionCacheEventListener {
+    create(): void;
+    delete(): void;
+    update(): void;
+}
+const voidPosition = (): LineChar => ({ line: -1, character: -1 });
+const tsInternals = new (class {
+    private addCacheEventListener(
+        textStorage: tsInternalServerHelpers.TextStorage,
+        host: ScriptVersionCacheEventListener
+    ) {
+        let svc = textStorage.svc;
+        if (svc) host.create();
+        addSideEffects(textStorage, {
+            useText() {
+                svc = undefined;
+                host.delete();
+            },
+            switchToScriptVersionCache(current_svc) {
+                if (svc === current_svc) return;
+                else svc = current_svc;
+                host.create();
+                addSideEffects(svc, {
+                    _getSnapshot: (r) => {
+                        const a = getText(r);
+                        host.update();
+                    }
+                });
+            }
+        });
+    }
+    private scriptInfoToMapper = new WeakMap<ts.server.ScriptInfo, TextStorageMapper>();
+    private getMapper(
+        context: TSPluginContext,
+        lang: LanguageConfig,
+        scriptInfo: ts.server.ScriptInfo
+    ): TextStorageMapper {
+        if (!this.scriptInfoToMapper.has(scriptInfo)) {
+            this.scriptInfoToMapper.set(scriptInfo, {
+                originalText: '',
+                generatedText: '',
+                originalLineStarts: [0],
+                generatedLineStarts: [0],
+                setOriginalText(text) {
+                    if ('' === this.originalText && '' === text) return; // init blank calls
+                    const { ts } = context;
+                    const host = lang.transform(scriptInfo.fileName, text);
+                    if ('mappings' in host) {
+                        const mapper = new SourceMapConsumer(host.mappings);
+                        this.generatedText = host.content;
+                        this.getOriginalPosition = mapper.getOriginalPosition.bind(mapper);
+                        this.getGeneratedPosition = mapper.getGeneratedPosition.bind(mapper);
+                    } else {
+                        this.generatedText = host.generatedText;
+                        this.getOriginalPosition = host.getOriginalPosition.bind(host);
+                        this.getGeneratedPosition = host.getGeneratedPosition.bind(host);
+                    }
+                    this.originalText = text;
+                    this.originalLineStarts =
+                        (host as any).originalLineStarts ?? ts.computeLineStarts(this.originalText);
+                    this.generatedLineStarts =
+                        (host as any).generatedlineStarts ??
+                        ts.computeLineStarts(this.generatedText);
+                },
+                getOriginalPosition: voidPosition,
+                getGeneratedPosition: voidPosition
+            });
+        }
+        return this.scriptInfoToMapper.get(scriptInfo);
+    }
+    private rewriteFileContent(
+        context: TSPluginContext,
+        lang: LanguageConfig,
+        scriptInfo: ts.server.ScriptInfo
+    ) {
+        const host = this.getMapper(context, lang, scriptInfo);
+        const textStorage = this.getTextStorage(scriptInfo);
+        const { ScriptVersionCache } = context.ts.server;
+        const { ts } = context;
+        let original_text_svc: tsInternalServerHelpers.ScriptVersionCache;
+        override(textStorage, {
+            reload(_, text) {
+                host.setOriginalText(text);
+                return _(host.generatedText);
+            },
+            edit(_, start, end, newText) {
+                const s = host.getOriginalPosition(
+                    ts.computeLineAndCharacterOfPosition(host.generatedLineStarts, start)
+                );
+                const e = host.getOriginalPosition(
+                    ts.computeLineAndCharacterOfPosition(host.generatedLineStarts, end - 1)
+                );
+                const start2 = host.originalLineStarts[s.line] + s.character;
+                const end2 = host.originalLineStarts[e.line] + e.character + 1;
+                _(start, end, newText);
+                original_text_svc.edit(start2, end2 - start2, newText);
+            }
+        });
+        this.addCacheEventListener(textStorage, {
+            create() {
+                const text = host.originalText;
+                original_text_svc = ScriptVersionCache.fromString(text);
+            },
+            delete() {
+                original_text_svc = undefined;
+            },
+            update() {
+                const snapshot = original_text_svc._getSnapshot();
+                const text = getText(snapshot);
+                debug.logFileContent(
+                    this,
+                    `Updated the cached version of the original file "${debug.projectPath(
+                        scriptInfo.fileName
+                    )}"`,
+                    extensionFromFileName(scriptInfo.fileName),
+                    text
+                );
+                host.setOriginalText(text);
+            }
+        });
+        if (textStorage.text || textStorage.svc) {
+            textStorage.reload(getText(textStorage.getSnapshot()));
+        }
+    }
+    private isRangeEndState(host: TextStorageMapper) {
+        let probablyRangeEnd = false;
+        let prev = -1;
+        return (position: number) => {
+            if (-1 === prev) {
+                queueMicrotask(() => {
+                    if (probablyRangeEnd) {
+                        debug.log(`Info: Previous task did not map a range`);
+                        probablyRangeEnd = false;
+                    }
+                    prev = -1;
+                });
+            } else if (probablyRangeEnd) {
+                if (position < prev) {
+                    probablyRangeEnd = false;
+                    debug.log(`RangeEnd false positive`);
+                } else {
+                }
+            }
+            prev = position;
+            return !(probablyRangeEnd = !probablyRangeEnd);
+        };
+    }
+    private rewriteFileMapping(
+        context: TSPluginContext,
+        lang: LanguageConfig,
+        scriptInfo: ts.server.ScriptInfo
+    ) {
+        const host = this.getMapper(context, lang, scriptInfo);
+        const textStorage = this.getTextStorage(scriptInfo);
+        const getIsRangeEnd1 = this.isRangeEndState(host);
+        const getIsRangeEnd2 = this.isRangeEndState(host);
+        override(textStorage, {
+            // original -> generated
+            lineOffsetToPosition(_, lineOffset_line, lineOffset_offset) {
+                const position_in_original = toLineChar({
+                    line: lineOffset_line,
+                    offset: lineOffset_offset
+                });
+                const { originalLineStarts, generatedLineStarts } = host;
+                const original = toPosition(originalLineStarts, position_in_original);
+                const isRangeEnd = getIsRangeEnd1(original);
+                if (isRangeEnd && position_in_original.character !== 0) {
+                    const position_in_generated = host.getGeneratedPosition({
+                        line: position_in_original.line,
+                        character: position_in_original.character - 1
+                    });
+                    const generated = toPosition(generatedLineStarts, position_in_generated) + 1;
+                    debug.log(`Patched Range end (mapped as ${lineOffset_offset - 1} +1)`);
+                    return generated;
+                } else {
+                    const position_in_generated = host.getGeneratedPosition(position_in_original);
+                    const generated = toPosition(generatedLineStarts, position_in_generated);
+                    return generated;
+                }
+            },
+            // generated -> original
+            positionToLineOffset(_, generated) {
+                const isRangeEnd = getIsRangeEnd2(generated);
+                if (isRangeEnd && generated !== 0) {
+                    const position_in_generated = toLineChar(_(generated - 1));
+                    const { line, character } = host.getOriginalPosition(position_in_generated);
+                    debug.log(`Patched Range end (mapped as ${generated - 1} +1)`);
+                    return toLineOffset({ line, character: character + 1 });
+                } else {
+                    const position_in_generated = toLineChar(_(generated));
+                    const position_in_original = host.getOriginalPosition(position_in_generated);
+                    return toLineOffset(position_in_original);
+                }
+            },
+            // generated
+            lineToTextSpan(_, line) {
+                const lineStarts = host.generatedLineStarts;
+                const start = lineStarts[line];
+                const end = lineStarts[line + 1] ?? host.generatedText.length;
+                return { start, length: end - start };
+            }
+        });
+    }
+    private debugAssertMappings(
+        context: TSPluginContext,
+        lang: LanguageConfig,
+        scriptInfo: ts.server.ScriptInfo
+    ) {
+        const host = this.getMapper(context, lang, scriptInfo);
+        const textStorage = this.getTextStorage(scriptInfo);
+        addSideEffects(textStorage, {
+            lineOffsetToPosition(position_in_generated, line, offset) {
+                const position_in_original = toLineChar({ line, offset });
+                debug.compareMappings(
+                    context,
+                    { text: host.originalText, position: position_in_original },
+                    { text: host.generatedText, position: position_in_generated },
+                    true
+                );
+            },
+            positionToLineOffset(position_in_original, position) {
+                debug.compareMappings(
+                    context,
+                    { text: host.originalText, position: position_in_original },
+                    { text: host.generatedText, position: position },
+                    true
+                );
+            }
+        });
+    }
+    private forEachLanguageFile(
+        context: TSPluginContext,
+        lang: LanguageConfig,
+        cb: (scriptInfo: ts.server.ScriptInfo, wasJustCreated: boolean) => void
+    ) {
+        const scriptInfoMap = this.getScriptInfoMap(context);
+        for (const { 1: scriptInfo } of scriptInfoMap) {
+            if (lang.is(scriptInfo.fileName)) {
+                cb(scriptInfo, false);
+            }
+        }
+        addSideEffects(scriptInfoMap, {
+            set(_, _path, scriptInfo) {
+                if (lang.is(scriptInfo.fileName)) {
+                    cb(scriptInfo, true); // "Typescript@4.3.0\src\server\editorServices.ts:2628"
+                }
+            }
+        });
+    }
+    private disableLanguageFeatures(context: TSPluginContext, lang: LanguageConfig) {
+        if (!lang.disabled || !lang.disabled.length) return;
+        function voidCall(
+            this: (...args: any) => any,
+            returnValue: any,
+            fileName: string,
+            ...args: any[]
+        ) {
+            if (lang.is(fileName)) return returnValue;
+            return this(fileName, ...args);
+        }
+        for (const name of lang.disabled) {
+            if (name in LanguageServiceVoidReturn) {
+                const fn = context.languageService[name].bind(context.languageService);
+                const returnValue = LanguageServiceVoidReturn[name]; // @ts-expect-error
+                context.languageService[name] = voidCall.bind(fn, returnValue);
+            } else if (debug.enabled) {
+                if (!(name in context.languageService)) {
+                    debug.throw(`LanguageService.${name} does not exist`);
+                } else {
+                    debug.throw(`LanguageService.${name}() is not void-able`);
+                }
+            }
+        }
+    }
+    private getGeneratedPluginName(lang: LanguageConfig) {
+        return `AutoGenerated${debug.getFancyPluginName(`"${lang.extension}"`)}`;
+    }
+    private resolveLanguageRootFiles(context: TSPluginContext, lang: LanguageConfig) {
+        const extraFileExtension: ts.FileExtensionInfo = {
+            extension: lang.extension,
+            isMixedContent: false,
+            scriptKind: context.ts.ScriptKind.Deferred
+        };
+        const plugin: ts.server.PluginModuleWithName = {
+            name: this.getGeneratedPluginName(lang),
+            module: {
+                create(o) {
+                    return o.languageService;
+                },
+                getExternalFiles(project) {
+                    return project.getRootFiles().filter(lang.is);
+                }
+            }
+        };
+        this.getHostConfig(context).extraFileExtensions.push(extraFileExtension);
+        const plugins = this.getProjectPlugins(context);
+        if (plugins.some((p) => p.name === plugin.name)) {
+            debug.throw(`Activated an auto-generated plugin twice`);
+        } else {
+            plugins.push(plugin);
+        }
+	}
+	private patchCompilerOptions(context: TSPluginContext, lang: LanguageConfig) {
+		const { ts } = context;
+		switch (lang.scriptKind) {
+			case ts.ScriptKind.JSX:
+			case ts.ScriptKind.TSX: {
+				const compilerOptions = context.project.getCompilerOptions();
+				if (!compilerOptions.jsx) compilerOptions.jsx = ts.JsxEmit.Preserve;
+			}
+		}
+	}
+    private getFailedLookupLocations(
+        context: TSPluginContext,
+        moduleName: string,
+        containingFile: string
+    ): string[] {
+        const r = context.project.getResolvedModuleWithFailedLookupLocationsFromCache!(
+            moduleName,
+            containingFile
+        );
+        // @ts-expect-error
+        return r.failedLookupLocations;
+    }
+    private resolveModuleName(
+        context: TSPluginContext,
+        moduleName: string,
+        containingFile: string
+    ) {
+        const { ts } = context;
+        if (ts.pathIsRelative(moduleName)) {
+            return ts.resolvePath(ts.getDirectoryPath(containingFile), moduleName);
+        } else {
+            const index_ts = '/index.ts';
+            for (const loc of this.getFailedLookupLocations(context, moduleName, containingFile)) {
+                if (loc.endsWith(index_ts)) {
+                    const file = loc.slice(0, index_ts.length);
+                    if (context.project.fileExists(file)) {
+                        return ts.resolvePath(file);
+                    }
+                }
+            }
+        }
+    }
+    private resolveLanguageModules(context: TSPluginContext, lang: LanguageConfig) {
+        return override(context.languageServiceHost, {
+            resolveModuleNames: (_, moduleNames, containingFile, ...rest) => {
+                const langModules: ts.ResolvedModuleFull[] = [];
+                const otherModulesNames: string[] = [];
+                const otherModulesIndex: number[] = [];
+                for (let i = 0, j = 0, k = 0; i !== moduleNames.length; i++) {
+                    if (lang.is(moduleNames[i])) {
+                        const resolvedFileName = this.resolveModuleName(
+                            context,
+                            moduleNames[i],
+                            containingFile
+                        );
+                        if (resolvedFileName) {
+                            const resolvedModule: ts.ResolvedModuleFull = {
+                                extension: lang.extensionKind,
+                                isExternalLibraryImport: false,
+                                resolvedFileName
+                            };
+                            langModules[j++] = resolvedModule;
+                            continue;
+                        }
+                    }
+                    otherModulesNames[k] = moduleNames[i];
+                    otherModulesIndex[k++] = i;
+                }
+                // prettier-ignore
+                const notLangModules = _(otherModulesNames, containingFile, ...rest);
+                const resolvedModules: (
+                    | ts.ResolvedModuleFull
+                    | ts.ResolvedModule
+                    | undefined
+                )[] = [];
+                for (let i = 0, j = 0, k = 0; i !== moduleNames.length; i++) {
+                    if (k < otherModulesIndex.length && otherModulesIndex[k] === i) {
+                        resolvedModules[i] = notLangModules[k++];
+                    } else {
+                        resolvedModules[i] = langModules[j++];
+                    }
+                }
+                return resolvedModules;
+            }
+        });
+    }
+    enableLanguageSupport(context: TSPluginContext, lang: LanguageConfig) {
+        if (!this.TSSupportsLang(context, lang)) {
+            debug.init(context);
+            this.resolveLanguageModules(context, lang);
+            this.resolveLanguageRootFiles(context, lang);
+			this.disableLanguageFeatures(context, lang);
+			this.patchCompilerOptions(context, lang);
+            this.forEachLanguageFile(context, lang, (info) => {
+                this.rewriteFileScriptKind(context, lang, info);
+                this.rewriteFileContent(context, lang, info);
+                this.rewriteFileMapping(context, lang, info);
+            });
+            if (debug.enabled) {
+                this.setupCommonDebugLogs(context, lang);
+                lang.enableDebug?.(context, debug);
+                debug.log(`Reloading Projects with enabled support for "${lang.extension}" files.`);
+            }
+            context.project.projectService.reloadProjects(); // "Typescript@4.3.0\src\server\editorServices.ts:2855"
+        }
+    }
+    private setupCommonDebugLogs(context: TSPluginContext, lang: LanguageConfig) {
+        debug.log(
+            `${debug.pluginName} Initialized with config : ${JSON.stringify(context.config)}`
+        );
+        LanguageService: {
+            debug.everyCall(context.languageService, {
+                ifFirstArg: lang.is,
+                name: 'LanguageService',
+                keys: Object.keys(LanguageServiceVoidReturn).filter(
+                    (key) => !lang?.disabled.includes(key as any)
+                )
+            });
+            if (lang.disabled) {
+                debug.everyCall(context.languageService, {
+                    ifFirstArg: lang.is,
+                    name: 'LanguageService',
+                    keys: lang.disabled,
+                    format(obj, method) {
+                        return `${obj}.${method}(): void (disabled)`;
+                    }
+                });
+            }
+        }
+        Project: {
+            addSideEffects(context.project, {
+                getScriptSnapshot(snapshot, fileName) {
+                    if (!lang.is(fileName)) return;
+                    const { project, ts } = context;
+                    const scriptInfo = project.getScriptInfo(fileName)!;
+                    const call = debug.formatCall(
+                        'Project',
+                        'getScriptSnapshot',
+                        quote(debug.projectPath(fileName))
+                    );
+                    const extension =
+                        getExtensionFromScriptKind(context, scriptInfo?.scriptKind)?.replace(
+                            /^\.?/,
+                            ''
+                        ) ?? extensionFromFileName(fileName);
+                    debug.logFileContent(
+                        scriptInfo,
+                        call,
+                        extension,
+                        snapshot && getText(snapshot)
+                    );
+                }
+            });
+        }
+        ScriptInfo: {
+            this.forEachLanguageFile(context, lang, (scriptInfo, wasJustCreated) => {
+                const { fileName } = scriptInfo;
+                debug.log(
+                    `${wasJustCreated ? 'Created' : 'Patched'} ScriptInfo for "${debug.projectPath(
+                        fileName
+                    )}"`
+                );
+                debug.everyCall(scriptInfo, {
+                    name: `"${debug.projectPath(fileName)}" | ScriptInfo`
+                });
+            });
+        }
+        TextStorage: {
+            this.forEachLanguageFile(context, lang, (scriptInfo) => {
+                const { fileName } = scriptInfo;
+                const textStorage = this.getTextStorage(scriptInfo);
+                debug.everyCall(textStorage, {
+                    name: `"${debug.projectPath(fileName)}" | TextStorage`
+                });
+                this.debugAssertMappings(context, lang, scriptInfo);
+            });
+        }
+        resolveModuleNames: {
+            addSideEffects(context.languageServiceHost, {
+                resolveModuleNames: (resolvedModules, moduleNames) => {
+                    let i = 0;
+                    for (const name of moduleNames) {
+                        if (lang.is(name)) {
+                            const r = resolvedModules[i] as ts.ResolvedModuleFull | undefined;
+                            const as_extension = r?.extension ? ` as a "${r.extension}" file` : '';
+                            if (r)
+                                debug.log(
+                                    `Resolved "${name}" to "${r.resolvedFileName}"${as_extension}`
+                                );
+                            else debug.log(`Failed to resolved module "${name}".`);
+                        }
+                        i++;
+                    }
+                }
+            });
+        }
+        generatedPlugin: {
+            const generated_name = this.getGeneratedPluginName(lang);
+            const own_plugin = this.getProjectPlugins(context).find(
+                (plugin) => plugin.name === generated_name
+            );
+            if (own_plugin)
+                override(own_plugin.module, {
+                    getExternalFiles(_, project) {
+                        const r = _(project);
+                        debug.log(
+                            `AutoGeneratedPlugin.getExternalFiles("${
+                                lang.extension
+                            }") -> ${JSON.stringify(r)}`
+                        );
+                        return r;
+                    }
+                });
+            else {
+                debug.log(`Failed to attach logger to auto-generated plugin.`);
+            }
+        }
+    }
+    private TSSupportsLang(context: TSPluginContext, lang: LanguageConfig) {
+        return (
+            this.getHostConfig(context).extraFileExtensions?.some(
+                (item) => lang.extension === item.extension
+            ) || Object.values(context.ts.Extension).includes(lang.extension as any)
+        );
+    }
+    private rewriteFileScriptKind(
+        context: TSPluginContext,
+        lang: LanguageConfig,
+        scriptInfo: ts.server.ScriptInfo
+    ) {
+        // @ts-expect-error
+        scriptInfo.scriptKind = lang.scriptKind ?? context.ts.ScriptKind.TSX;
+    }
+    private getTextStorage(scriptInfo: ts.server.ScriptInfo): tsInternalServerHelpers.TextStorage {
+        // @ts-expect-error
+        return scriptInfo.textStorage;
+    }
+    private getScriptInfoMap(context: TSPluginContext): Map<string, ts.server.ScriptInfo> {
+        // @ts-expect-error
+        return context.project.projectService.filenameToScriptInfo;
+    }
+    private getHostConfig(context: TSPluginContext): ts.server.HostConfiguration {
+        // @ts-expect-error
+        const config = context.project.projectService.hostConfiguration;
+        if (!config.extraFileExtensions) config.extraFileExtensions = [];
+        return config;
+    }
+    private getProjectPlugins(context: TSPluginContext): ts.server.PluginModuleWithName[] {
+        // @ts-expect-error
+        return context.project.plugins;
+    }
+})();
+const EmptyArray = [];
+const LanguageServiceVoidReturn = {
+    getSyntacticDiagnostics: EmptyArray,
+    getSemanticDiagnostics: EmptyArray,
+    getSuggestionDiagnostics: EmptyArray,
+    getEncodedSyntacticClassifications: { spans: EmptyArray, endOfLineState: 0 },
+    getEncodedSemanticClassifications: { spans: EmptyArray, endOfLineState: 0 },
+    getCompletionsAtPosition: undefined,
+    getCompletionEntryDetails: undefined,
+    getCompletionEntrySymbol: undefined,
+    getQuickInfoAtPosition: undefined,
+    getNameOrDottedNameSpan: undefined,
+    getBreakpointStatementAtPosition: undefined,
+    getSignatureHelpItems: undefined,
+    get getRenameInfo() {
+        return {
+            canRename: false,
+            localizedErrorMessage: `${debug.pluginName} does not support the "getRenameInfo" command.`
+        };
+    },
+    findRenameLocations: undefined,
+    getSmartSelectionRange: { textSpan: { start: -1, length: -1 } },
+    getDefinitionAtPosition: undefined,
+    getDefinitionAndBoundSpan: undefined,
+    getTypeDefinitionAtPosition: undefined,
+    getImplementationAtPosition: undefined,
+    getReferencesAtPosition: undefined,
+    findReferences: undefined,
+    getDocumentHighlights: undefined,
+    getFileReferences: EmptyArray,
+    getNavigationBarItems: EmptyArray,
+    prepareCallHierarchy: undefined,
+    provideCallHierarchyIncomingCalls: EmptyArray,
+    provideCallHierarchyOutgoingCalls: EmptyArray,
+    getOutliningSpans: EmptyArray,
+    getTodoComments: EmptyArray,
+    getBraceMatchingAtPosition: EmptyArray,
+    getIndentationAtPosition: -1,
+    getFormattingEditsForRange: EmptyArray,
+    getFormattingEditsForDocument: EmptyArray,
+    getFormattingEditsAfterKeystroke: EmptyArray,
+    getDocCommentTemplateAtPosition: undefined,
+    isValidBraceCompletionAtPosition: false,
+    getJsxClosingTagAtPosition: undefined,
+    getSpanOfEnclosingComment: undefined,
+    getCodeFixesAtPosition: EmptyArray,
+    getApplicableRefactors: EmptyArray,
+    getEditsForRefactor: undefined,
+    toggleLineComment: EmptyArray,
+    toggleMultilineComment: EmptyArray,
+    commentSelection: EmptyArray,
+    uncommentSelection: EmptyArray
+};
+
+export const enableLanguageSupport = tsInternals.enableLanguageSupport.bind(tsInternals);

--- a/packages/typescript-plugin/src/ts-language-plugin/sourcemaps.ts
+++ b/packages/typescript-plugin/src/ts-language-plugin/sourcemaps.ts
@@ -1,0 +1,69 @@
+import { decode } from "sourcemap-codec";
+import { LineChar } from "./types";
+type FileMapping = LineMapping[];
+type LineMapping = CharacterMapping[]; // FileMapping[generated_line_index] = LineMapping
+type CharacterMapping = [
+	number, // generated character
+	number, // original file
+	number, // original line
+	number, //  original index
+];
+type ReorderedChar = [original_character: number, generated_line: number, generated_character: number];
+interface ReorderedMap {
+	[original_line: number]: ReorderedChar[];
+}
+function binaryInsert(array: number[], value: number): void;
+function binaryInsert<T extends Record<any, number> | number[]>(array: T[], value: T, key: keyof T): void;
+function binaryInsert<A extends Record<any, number>[] | number[]>(array: A, value: A[any], key?: keyof (A[any] & object)) {
+	if (0 === key) key = "0" as keyof A[any];
+	const index = 1 + binarySearch(array, (key ? value[key] : value) as number, key);
+	let i = array.length;
+	while (index !== i--) array[1 + i] = array[i];
+	array[index] = value;
+}
+function binarySearch<T extends object | number>(array: T[], target: number, key?: keyof (T & object)) {
+	if (!array || 0 === array.length) return -1;
+	if (0 === key) key = "0" as keyof T;
+	let low = 0;
+	let high = array.length - 1;
+	while (low <= high) {
+		const i = low + ((high - low) >> 1);
+		const item = undefined === key ? array[i] : array[i][key];
+		if (item === target) return i;
+		if (item < target) low = i + 1;
+		else high = i - 1;
+	}
+	if ((low = ~low) < 0) low = ~low - 1;
+	return low;
+}
+export class SourceMapConsumer {
+	private mappings: FileMapping;
+	private reverseMappings?: ReorderedMap;
+	private computeReversed() {
+		this.reverseMappings = {} as ReorderedMap;
+		for (let generated_line = 0; generated_line !== this.mappings.length; generated_line++) {
+			for (const { 0: generated_index, 2: original_line, 3: original_character_index } of this.mappings[generated_line]) {
+				const reordered_char: ReorderedChar = [original_character_index, generated_line, generated_index];
+				if (original_line in this.reverseMappings) binaryInsert(this.reverseMappings[original_line], reordered_char, 0);
+				else this.reverseMappings[original_line] = [reordered_char];
+			}
+		}
+	}
+	constructor(mappings: FileMapping | string) {
+		if (typeof mappings === "string") this.mappings = decode(mappings) as FileMapping;
+		else this.mappings = mappings;
+	}
+	getOriginalPosition(position: LineChar): LineChar {
+		const lineMap = this.mappings[position.line];
+		const closestMatch = binarySearch(lineMap, position.character, 0);
+		const { 2: line, 3: character } = lineMap[closestMatch];
+		return { line, character };
+	}
+	getGeneratedPosition(position: LineChar): LineChar {
+		if (!this.reverseMappings) this.computeReversed();
+		const lineMap = this.reverseMappings![position.line];
+		const closestMatch = binarySearch(lineMap, position.character, 0);
+		const { 1: line, 2: character } = lineMap[closestMatch];
+		return { line, character };
+	}
+}

--- a/packages/typescript-plugin/src/ts-language-plugin/types.ts
+++ b/packages/typescript-plugin/src/ts-language-plugin/types.ts
@@ -1,0 +1,102 @@
+import type ts from "typescript/lib/tsserverlibrary";
+
+declare namespace tsInternalHelpers {
+	export function pathIsRelative(path: string): boolean;
+	export function normalizeSlashes(path: string): string;
+	export function normalizePath(path: string): string;
+	export function getDirectoryPath(path: string): string;
+	export function resolvePath(path: string, ...paths: (string | undefined)[]): string;
+	export function computeLineStarts(text: string): number[];
+	export function computeLineAndCharacterOfPosition(lineStarts: readonly number[], position: number): ts.LineAndCharacter;
+	export function computePositionOfLineAndCharacter(
+		lineStarts: readonly number[],
+		line: number,
+		character: number,
+		debugText?: string,
+		allowEdits?: true,
+	): number;
+}
+// @ts-expect-error
+interface tsInternalProjectService extends ts.server.ProjectService {
+	filenameToScriptInfo: Map<string, ts.server.ScriptInfo>;
+	hostConfiguration: ts.server.HostConfiguration;
+}
+export type LineOffset = ts.server.protocol.Location;
+export type LineChar = ts.LineAndCharacter;
+
+declare namespace tsInternalServerHelpers {
+	export class ScriptVersionCache {
+		edit(pos: number, deleteLen: number, insertedText?: string): void;
+		getSnapshot(): ts.IScriptSnapshot;
+		_getSnapshot(): ts.IScriptSnapshot;
+		getSnapshotVersion(): number;
+		getAbsolutePositionAndLineText(oneBasedLine: number): { absolutePosition: number; lineText: string | undefined };
+		lineOffsetToPosition(line: number, column: number): number;
+		positionToLineOffset(position: number): ts.server.protocol.Location;
+		lineToTextSpan(line: number): ts.TextSpan;
+		getTextChangesBetweenVersions(oldVersion: number, newVersion: number): ts.TextChangeRange | undefined;
+		getLineCount(): number[];
+		static fromString(script: string): ScriptVersionCache;
+	}
+	export class TextStorage {
+		version: { svc: number; text: number };
+		svc: ScriptVersionCache | undefined;
+		text: string | undefined;
+		lineMap: number[] | undefined;
+		fileSize: number | undefined;
+		isOpen: boolean;
+		ownFileText: boolean;
+		pendingReloadFromDisk: boolean;
+		host: ts.server.ServerHost;
+		info: ts.server.ScriptInfo;
+		getVersion(): string;
+		resetSourceMapInfo(): void;
+		edit(start: number, end: number, newText: string): void;
+		/**
+		 *
+		 * original -> transformed
+		 * @param newText
+		 */
+		reload(newText: string): boolean;
+		reloadWithFileText(tempFileName?: string): string;
+		reloadFromDisk(): void;
+		delayReloadFromFileIntoText(): void;
+		getTelemetryFileSize(): number;
+		getSnapshot(): ts.IScriptSnapshot;
+		getAbsolutePositionAndLineText(line: number): { absolutePosition: number; lineText: string | undefined };
+		/**
+		 * Used on "getReferences" at "Typescript@4.3.0\src\server\session.ts:3111"
+		 * Overriding this method is not enough as it will query text based on a transformed snapshot (see ^:3112)
+		 *
+		 * transformed -> transformed
+		 * @param line starts at 0
+		 */
+		lineToTextSpan(line: number): ts.TextSpan;
+		/**
+		 * Used on "updateOpen" to get edit positions for cached versions
+		 *
+		 * original -> transformed
+		 * @param line starts at 1
+		 * @param offset starts at 1
+		 * @param allowEdits
+		 */
+		lineOffsetToPosition(line: number, offset: number, allowEdits?: true): number;
+		/**
+		 * Used to map results to positions ("findRenameLocations", "findReferences", etc...)
+		 *
+		 * transformed -> original
+		 * @param position
+		 */
+		positionToLineOffset(position: number): LineOffset;
+		getFileTextAndSize(tempFileName?: string): { text: string; fileSize?: number };
+		switchToScriptVersionCache(): ScriptVersionCache;
+		useText(newText?: string): void;
+		useScriptVersionCacheIfValidOrOpen(): ScriptVersionCache | undefined;
+		getOrLoadText(): string;
+		getLineMap(): number[];
+		getLineInfo(): number[];
+	}
+}
+export type _ts = typeof ts & typeof tsInternalHelpers & { server: typeof tsInternalServerHelpers };
+export { tsInternalHelpers as tsInternal, tsInternalServerHelpers };
+

--- a/packages/typescript-plugin/src/ts-language-plugin/utils.ts
+++ b/packages/typescript-plugin/src/ts-language-plugin/utils.ts
@@ -1,0 +1,75 @@
+import { TSPluginContext } from ".";
+import { LineChar, LineOffset } from "./types";
+type ExtractMethods<T extends object> = {
+	[K in keyof T]: Extract<T[K], (...args: any[]) => any>;
+};
+type MethodKeys<T extends object> = keyof ExtractMethods<T>;
+export function override<T extends object, O extends Required<T>>(
+	target: T,
+	obj: {
+		[K in MethodKeys<O>]?: O[K] extends (...args: infer P) => infer R ? (this: T, fn: O[K], ...args: P) => R : never;
+	},
+) {
+	for (const key in obj) {
+		(target as O)[key] = obj[key].bind(target, ((target as O)[key] as any)?.bind(target)) as any;
+	}
+	return target;
+}
+export function addSideEffects<T extends object, O extends Required<T>>(
+	target: T,
+	obj: {
+		[K in MethodKeys<O>]?: O[K] extends (...args: infer P) => infer R ? (this: T, result: R, ...args: P) => void : never;
+	},
+) {
+	const o = {};
+	for (const key in obj) {
+		const fn = obj[key].bind(target); // @ts-ignore
+		o[key] = function (_, ...args) {
+			const result = _(...args);
+			fn(result, ...args);
+			return result;
+		};
+	}
+	override(target, o);
+}
+export function testForExtension(extension: string) {
+	const re = new RegExp(`\\.${extension.replace(/^\./, "")}$`);
+	return re.test.bind(re);
+}
+export function getText(script: ts.IScriptSnapshot) {
+	return script.getText(0, script.getLength());
+}
+export function getExtensionFromScriptKind({ ts }: TSPluginContext, kind: ts.ScriptKind): ts.Extension | undefined {
+	switch (kind) {
+		case ts.ScriptKind.JS:
+			return ts.Extension.Js;
+		case ts.ScriptKind.JSON:
+			return ts.Extension.Json;
+		case ts.ScriptKind.JSX:
+			return ts.Extension.Jsx;
+		case ts.ScriptKind.TS:
+			return ts.Extension.Ts;
+		case ts.ScriptKind.TSX:
+			return ts.Extension.Tsx;
+		case ts.ScriptKind.Deferred:
+		case ts.ScriptKind.External:
+		case ts.ScriptKind.Unknown:
+			return undefined;
+	}
+}
+export function quote(str: string) {
+	return `"${str}"`;
+}
+export function toPosition(lineStarts: number[], o: LineChar | LineOffset) {
+	if ("offset" in o) return lineStarts[o.line - 1] + o.offset - 1;
+	else return lineStarts[o.line] + o.character;
+}
+export function toLineChar(pos: LineOffset): LineChar {
+	return { line: pos.line - 1, character: pos.offset - 1 };
+}
+export function toLineOffset(pos: LineChar): LineOffset {
+	return { line: pos.line + 1, offset: pos.character + 1 };
+}
+export function extensionFromFileName(fileName: string) {
+	return fileName.slice(fileName.lastIndexOf(".") + 1);
+}

--- a/packages/typescript-plugin/tsconfig.json
+++ b/packages/typescript-plugin/tsconfig.json
@@ -3,11 +3,15 @@
     "compilerOptions": {
         "moduleResolution": "node",
         "esModuleInterop": true,
-        "strict": true,
+        "strict": false,
+        "strictFunctionTypes": true,
+        "strictBindCallApply": true,
+        "noImplicitThis": true,
         "declaration": true,
         "outDir": ".",
         "sourceMap": false,
-        "composite": true
+        "composite": true,
+        "skipLibCheck": true
     },
     "include": ["./src/**/*"],
     "exclude": ["./node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,6 +920,11 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+esbuild@^0.8.51:
+  version "0.8.51"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.51.tgz#1a59f1fee34892f143b7009081f9b4901a564b93"
+  integrity sha512-MVIom8fgL1+B6iGqWtrG7QJ1gqd64BycxounlsX1kR/IcIITaSlTo7gghKpg4a+bnxkpo0dwcikuvk4MVSA9ww==
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -2339,7 +2344,7 @@ source-map@^0.6.0, source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sourcemap-codec@^1.4.4:
+sourcemap-codec@^1.4.4, sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -2507,6 +2512,14 @@ svelte-preprocess@~4.6.1:
     "@types/sass" "^1.16.0"
     detect-indent "^6.0.0"
     strip-indent "^3.0.0"
+
+svelte2tsx@^0.1.174:
+  version "0.1.174"
+  resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.1.174.tgz#85f27a03fa06ce043a9f3aa8603528ce92a277a0"
+  integrity sha512-+sOMKaiUw7GADDyg5rhQWi6ajL0LWytZbwRwyH62WP6OTjXGIM8/J9mOCA3uHA9dDI39OsmprcgfhUQp8ymekg==
+  dependencies:
+    dedent-js "^1.0.1"
+    pascal-case "^3.1.1"
 
 svelte@~3.32.1:
   version "3.32.1"


### PR DESCRIPTION
This TSPlugin injects arbitrary languages to the list of files the real TS Language Server supports, when a file of that language is requested it simply transforms its cached contents into another language that TS natively understands (TSX in our case), and maps LanguageService requests back to the source when returning results.

This implementation edits the cached files content back and forth between languages on the fly, svelte essentially becomes tsx in the eyes of the ts language server. Benefits include refactoring, rename, codelens, references, imports, autocomplete and so on...

(WIP) Need to change how things are mapped in svelte2tsx, will submit a PR once #864 is resolved

## Todo
- [ ] Write a short breakdown of what's going on, list mutated parts of the internal API
- [ ] Write tests