### PR TITLE
(fix) $store declaration generation for declaration list

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ImplicitStoreValues.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ImplicitStoreValues.ts
@@ -59,8 +59,11 @@ export class ImplicitStoreValues {
             toAppend += `;let $${storeNames[i]} = __sveltets_store_get(${storeNames[i]});`;
         }
 
-        const endPos = node.getEnd() + astOffset;
-        str.appendRight(endPos, toAppend);
+        const nodeEnd =
+            ts.isVariableDeclarationList(node.parent) && node.parent.declarations.length > 1
+                ? node.parent.declarations[node.parent.declarations.length - 1].getEnd()
+                : node.getEnd();
+        str.appendRight(nodeEnd + astOffset, toAppend);
     }
 
     private attachStoreValueDeclarationToReactiveAssignment(

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/expected.tsx
@@ -2,9 +2,9 @@
 <></>;function render() {
 
     const store1 = '', store2 = '';let $store1 = __sveltets_store_get(store1);;let $store2 = __sveltets_store_get(store2);;
-    const { store3 } = '', [ store ] = '';let $store3 = __sveltets_store_get(store3);;
-    let  {store5} = __sveltets_invalidate(() => '');;let $store5 = __sveltets_store_get(store5);
-    let  [store6] = __sveltets_invalidate(() => '');;let $store6 = __sveltets_store_get(store6);
+    const { store3, store4 } = '', [ store5, store6 ] = '';let $store3 = __sveltets_store_get(store3);;let $store4 = __sveltets_store_get(store4);;let $store5 = __sveltets_store_get(store5);;let $store6 = __sveltets_store_get(store6);;
+    let  {store7, store8} = __sveltets_invalidate(() => '');;let $store7 = __sveltets_store_get(store7);;let $store8 = __sveltets_store_get(store8);
+    let  [store9, store10] = __sveltets_invalidate(() => '');;let $store9 = __sveltets_store_get(store9);;let $store10 = __sveltets_store_get(store10);
 ;
 () => (<>
 
@@ -13,7 +13,11 @@
 {(__sveltets_store_get(store3), $store3)}
 {(__sveltets_store_get(store4), $store4)}
 {(__sveltets_store_get(store5), $store5)}
-{(__sveltets_store_get(store6), $store6)}</>);
+{(__sveltets_store_get(store6), $store6)}
+{(__sveltets_store_get(store7), $store7)}
+{(__sveltets_store_get(store8), $store8)}
+{(__sveltets_store_get(store9), $store9)}
+{(__sveltets_store_get(store10), $store10)}</>);
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/expected.tsx
@@ -1,0 +1,20 @@
+///<reference types="svelte" />
+<></>;function render() {
+
+    const store1 = '', store2 = '';let $store1 = __sveltets_store_get(store1);;let $store2 = __sveltets_store_get(store2);;
+    const { store3 } = '', [ store ] = '';let $store3 = __sveltets_store_get(store3);;
+    let  {store5} = __sveltets_invalidate(() => '');;let $store5 = __sveltets_store_get(store5);
+    let  [store6] = __sveltets_invalidate(() => '');;let $store6 = __sveltets_store_get(store6);
+;
+() => (<>
+
+{(__sveltets_store_get(store1), $store1)}
+{(__sveltets_store_get(store2), $store2)}
+{(__sveltets_store_get(store3), $store3)}
+{(__sveltets_store_get(store4), $store4)}
+{(__sveltets_store_get(store5), $store5)}
+{(__sveltets_store_get(store6), $store6)}</>);
+return { props: {}, slots: {}, getters: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/input.svelte
@@ -1,8 +1,8 @@
 <script>
     const store1 = '', store2 = '';
-    const { store3 } = '', [ store ] = '';
-    $: ({store5} = '');
-    $: [store6] = '';
+    const { store3, store4 } = '', [ store5, store6 ] = '';
+    $: ({store7, store8} = '');
+    $: [store9, store10] = '';
 </script>
 
 {$store1}
@@ -11,3 +11,7 @@
 {$store4}
 {$store5}
 {$store6}
+{$store7}
+{$store8}
+{$store9}
+{$store10}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/input.svelte
@@ -1,0 +1,13 @@
+<script>
+    const store1 = '', store2 = '';
+    const { store3 } = '', [ store ] = '';
+    $: ({store5} = '');
+    $: [store6] = '';
+</script>
+
+{$store1}
+{$store2}
+{$store3}
+{$store4}
+{$store5}
+{$store6}


### PR DESCRIPTION
#856
Fixes code generation for store declarations like `const store1 = writable(''), store2 = writable('');`