### PR TITLE
(fix) store access first in expression statement

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/utils/tsAst.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/utils/tsAst.ts
@@ -174,3 +174,14 @@ export function getNamesFromLabeledStatement(node: ts.LabeledStatement): string[
             .filter((name) => !name.startsWith('$'))
     );
 }
+
+export function isFirstInAnExpressionStatement(node: ts.Identifier): boolean {
+    let parent = node.parent;
+    while (parent && !ts.isExpressionStatement(parent)) {
+        parent = parent.parent;
+    }
+    if (!parent) {
+        return false;
+    }
+    return parent.getStart() === node.getStart();
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-assign/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-assign/expected.tsx
@@ -1,0 +1,29 @@
+///<reference types="svelte" />
+<></>;function render() {
+
+    const store = writable([]);let $store = __sveltets_store_get(store);;
+
+    ;(__sveltets_store_get(store), $store)[1] = true;
+    ;(__sveltets_store_get(store), $store).foo = true;
+
+    ;(__sveltets_store_get(store), $store)[1] = true
+    ;(__sveltets_store_get(store), $store).foo = true
+
+    store.set( true)
+    store.set( true);
+
+    hello[(__sveltets_store_get(store), $store)] = true;
+
+    store.set( true),
+    store.set( false),
+    (__sveltets_store_get(store), $store),
+    (__sveltets_store_get(store), $store).a = true
+
+    ;(__sveltets_store_get(store), $store).a = true,
+    (__sveltets_store_get(store), $store).b = false;
+;
+() => (<></>);
+return { props: {}, slots: {}, getters: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-assign/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-assign/input.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    const store = writable([]);
+
+    $store[1] = true;
+    $store.foo = true;
+
+    $store[1] = true
+    $store.foo = true
+
+    $store = true
+    $store = true;
+
+    hello[$store] = true;
+
+    $store = true,
+    $store = false,
+    $store,
+    $store.a = true
+
+    $store.a = true,
+    $store.b = false;
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
@@ -1,6 +1,6 @@
 ///<reference types="svelte" />
 <></>;function render() {
-(__sveltets_store_get(var), $var);
+;(__sveltets_store_get(var), $var);
 () => (<></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
@@ -1,6 +1,6 @@
 ///<reference types="svelte" />
 <></>;function render() {
-   (__sveltets_store_get(var), $var);
+   ;(__sveltets_store_get(var), $var);
 () => (<></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-from-module/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-from-module/expected.tsx
@@ -5,8 +5,8 @@
     const store4 = writable('');let $store4 = __sveltets_store_get(store4);;
 ;<></>;function render() {
 
-    (__sveltets_store_get(store1), $store1);
-    (__sveltets_store_get(store3), $store3);
+    ;(__sveltets_store_get(store1), $store1);
+    ;(__sveltets_store_get(store3), $store3);
 ;
 () => (<>
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-property-access/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-property-access/expected.tsx
@@ -2,15 +2,15 @@
 <></>;function render() {
 
     const store = someStore();let $store = __sveltets_store_get(store);;
-    (__sveltets_store_get(store), $store);
-    (__sveltets_store_get(store), $store).prop;
-    (__sveltets_store_get(store), $store)['prop'];
-    (__sveltets_store_get(store), $store).prop.anotherProp;
-    (__sveltets_store_get(store), $store)['prop'].anotherProp;
-    (__sveltets_store_get(store), $store).prop['anotherProp'];
-    (__sveltets_store_get(store), $store)['prop']['anotherProp'];
-    (__sveltets_store_get(store), $store)?.prop.anotherProp;
-    (__sveltets_store_get(store), $store)?.prop?.anotherProp;
+    ;(__sveltets_store_get(store), $store);
+    ;(__sveltets_store_get(store), $store).prop;
+    ;(__sveltets_store_get(store), $store)['prop'];
+    ;(__sveltets_store_get(store), $store).prop.anotherProp;
+    ;(__sveltets_store_get(store), $store)['prop'].anotherProp;
+    ;(__sveltets_store_get(store), $store).prop['anotherProp'];
+    ;(__sveltets_store_get(store), $store)['prop']['anotherProp'];
+    ;(__sveltets_store_get(store), $store)?.prop.anotherProp;
+    ;(__sveltets_store_get(store), $store)?.prop?.anotherProp;
 ;
 () => (<>
 <p>{(__sveltets_store_get(store), $store)}</p>


### PR DESCRIPTION
The store transformation now is prepended with a semicolon if it's the first thing in an expression statement because the statement above it could end without a semicolon, making JavaScript think that this is a function invocation
#859