### PR TITLE
(fix) sanitize leading invalid attribute chars

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/attribute.ts
@@ -105,6 +105,12 @@ export function handleAttribute(htmlx: string, str: MagicString, attr: Node, par
         }
 
         const equals = htmlx.lastIndexOf('=', attrVal.start);
+
+        const sanitizedName = sanitizeLeadingChars(attr.name);
+        if (sanitizedName !== attr.name) {
+            str.overwrite(attr.start, equals, sanitizedName);
+        }
+
         if (attrVal.type == 'Text') {
             const endsWithQuote =
                 htmlx.lastIndexOf('"', attrVal.end) === attrVal.end - 1 ||
@@ -165,4 +171,17 @@ export function handleAttribute(htmlx: string, str: MagicString, attr: Node, par
     } else {
         str.appendLeft(attr.end, '`}');
     }
+}
+
+function sanitizeLeadingChars(attrName: string): string {
+    let sanitizedName = '';
+    for (let i = 0; i < attrName.length; i++) {
+        if (/[A-Za-z$_]/.test(attrName[i])) {
+            sanitizedName += attrName.substr(i);
+            return sanitizedName;
+        } else {
+            sanitizedName += '_';
+        }
+    }
+    return sanitizedName;
 }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-invalid-jsx-name/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-invalid-jsx-name/expected.jsx
@@ -1,0 +1,2 @@
+<><Hello __custom-prop="foo"></Hello>
+<div __custom-prop="foo"></div></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-invalid-jsx-name/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-invalid-jsx-name/input.svelte
@@ -1,0 +1,2 @@
+<Hello --custom-prop="foo"></Hello>
+<div --custom-prop="foo"></div>


### PR DESCRIPTION
They are valid for Svelte, but invalid for JSX
#862