### PR TITLE
(chore) make svelte/compiler imports named

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx/index.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/index.ts
@@ -1,6 +1,6 @@
 import { Node } from 'estree-walker';
 import MagicString from 'magic-string';
-import svelte from 'svelte/compiler';
+import { walk } from 'svelte/compiler';
 import { parseHtmlx } from '../utils/htmlxparser';
 import { getSlotName } from '../utils/svelteAst';
 import { handleActionDirective } from './nodes/action-directive';
@@ -55,7 +55,7 @@ export function convertHtmlxToJsx(
 
     let ifScope = new IfScope(templateScopeManager);
 
-    (svelte as any).walk(ast, {
+    (walk as any)(ast, {
         enter: (node: Node, parent: Node, prop: string, index: number) => {
             try {
                 switch (node.type) {

--- a/packages/svelte2tsx/src/utils/htmlxparser.ts
+++ b/packages/svelte2tsx/src/utils/htmlxparser.ts
@@ -1,4 +1,4 @@
-import compiler from 'svelte/compiler';
+import { parse } from 'svelte/compiler';
 import { Node } from 'estree-walker';
 
 function parseAttributeValue(value: string): string {
@@ -106,7 +106,7 @@ export function parseHtmlx(htmlx: string, options?: { emitOnTemplateError?: bool
     const parsingCode = options?.emitOnTemplateError
         ? blankPossiblyErrorOperatorOrPropertyAccess(deconstructed)
         : deconstructed;
-    const svelteHtmlxAst = compiler.parse(parsingCode).html;
+    const svelteHtmlxAst = parse(parsingCode).html;
 
     //restore our script and style tags as nodes to maintain validity with HTMLx
     for (const s of verbatimElements) {


### PR DESCRIPTION
Technically, there is no default export, although Rollup did handle it.