### PR TITLE
(perf) improve svelte-check performance

### DIFF
--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -26,12 +26,12 @@ export class LSAndTSDocResolver {
         docManager.on(
             'documentChange',
             isEditor
-                ? handleDocumentChange
-                : debounceSameArg(
+                ? debounceSameArg(
                       handleDocumentChange,
                       (newDoc, prevDoc) => newDoc.uri === prevDoc?.uri,
                       1000
                   )
+                : handleDocumentChange
         );
     }
 


### PR DESCRIPTION
Because of the `setTimeout` in the `debounceSameArg`. The document update in `LSAndTSDocResolver` is actually done after all the diagnostic is done. Because of that, the typescript language service has to rebuild its type checker multiple times due to a new document being loaded in.

Remove the denounce make svelte-check run a lot faster on my machine. It went down from 1:30 to 15s for one of my projects.