### PR TITLE
(fix) Don't step out of if block on else if

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx/index.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/index.ts
@@ -188,7 +188,9 @@ export function convertHtmlxToJsx(
             try {
                 switch (node.type) {
                     case 'IfBlock':
-                        ifScope = ifScope.getParent();
+                        if (!node.elseif) {
+                            ifScope = ifScope.getParent();
+                        }
                         break;
                     case 'EachBlock':
                         templateScopeManager.eachLeave(node);

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/nested-if-else-if-and-each-block/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/nested-if-else-if-and-each-block/expected.jsx
@@ -1,0 +1,5 @@
+<>{(true) ? <>
+  {(true) ? <></> : (true) ? <></> : <></> }
+</> : <>
+  {__sveltets_each([], (_) => /*Ωignore_startΩ*/(!(true)) && /*Ωignore_endΩ*/<></>)}
+</> }</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/nested-if-else-if-and-each-block/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/nested-if-else-if-and-each-block/input.svelte
@@ -1,0 +1,5 @@
+{#if true}
+  {#if true}{:else if true}{/if}
+{:else}
+  {#each [] as _}{/each}
+{/if}


### PR DESCRIPTION
`else if`s are represented with an if block node inside them, which is correctly handled when entering, but when leaving it would previously incorrectly step out of the if block leading to an internal error.