### PR TITLE
(feat) resolve svelte.d.ts files first

### DIFF
--- a/packages/language-server/test/plugins/typescript/module-loader.test.ts
+++ b/packages/language-server/test/plugins/typescript/module-loader.test.ts
@@ -5,7 +5,7 @@ import * as svS from '../../../src/plugins/typescript/svelte-sys';
 import { DocumentSnapshot } from '../../../src/plugins/typescript/DocumentSnapshot';
 import { createSvelteModuleLoader } from '../../../src/plugins/typescript/module-loader';
 
-describe.only('createSvelteModuleLoader', () => {
+describe('createSvelteModuleLoader', () => {
     afterEach(() => {
         sinon.restore();
     });

--- a/packages/language-server/test/plugins/typescript/module-loader.test.ts
+++ b/packages/language-server/test/plugins/typescript/module-loader.test.ts
@@ -5,7 +5,7 @@ import * as svS from '../../../src/plugins/typescript/svelte-sys';
 import { DocumentSnapshot } from '../../../src/plugins/typescript/DocumentSnapshot';
 import { createSvelteModuleLoader } from '../../../src/plugins/typescript/module-loader';
 
-describe('createSvelteModuleLoader', () => {
+describe.only('createSvelteModuleLoader', () => {
     afterEach(() => {
         sinon.restore();
     });
@@ -35,6 +35,10 @@ describe('createSvelteModuleLoader', () => {
         };
     }
 
+    function lastCall(stub: sinon.SinonStub<any[], any>) {
+        return stub.getCall(stub.getCalls().length - 1);
+    }
+
     it('uses tsSys for normal files', async () => {
         const resolvedModule: ts.ResolvedModuleFull = {
             extension: ts.Extension.Ts,
@@ -47,7 +51,7 @@ describe('createSvelteModuleLoader', () => {
         );
 
         assert.deepStrictEqual(result, [resolvedModule]);
-        assert.deepStrictEqual(resolveStub.getCall(0).args, [
+        assert.deepStrictEqual(lastCall(resolveStub).args, [
             './normal.ts',
             'C:/somerepo/somefile.svelte',
             compilerOptions,
@@ -67,8 +71,28 @@ describe('createSvelteModuleLoader', () => {
         );
 
         assert.deepStrictEqual(result, [resolvedModule]);
-        assert.deepStrictEqual(resolveStub.getCall(0).args, [
+        assert.deepStrictEqual(lastCall(resolveStub).args, [
             '/@/normal',
+            'C:/somerepo/somefile.svelte',
+            compilerOptions,
+            ts.sys
+        ]);
+    });
+
+    it('uses tsSys for svelte.d.ts files', async () => {
+        const resolvedModule: ts.ResolvedModuleFull = {
+            extension: ts.Extension.Dts,
+            resolvedFileName: 'filename.d.ts'
+        };
+        const { resolveStub, moduleResolver, compilerOptions } = setup(resolvedModule);
+        const result = moduleResolver.resolveModuleNames(
+            ['./normal.ts'],
+            'C:/somerepo/somefile.svelte'
+        );
+
+        assert.deepStrictEqual(result, [resolvedModule]);
+        assert.deepStrictEqual(lastCall(resolveStub).args, [
+            './normal.ts',
             'C:/somerepo/somefile.svelte',
             compilerOptions,
             ts.sys
@@ -98,13 +122,13 @@ describe('createSvelteModuleLoader', () => {
                 resolvedFileName: 'filename.svelte'
             }
         ]);
-        assert.deepStrictEqual(resolveStub.getCall(0).args, [
+        assert.deepStrictEqual(lastCall(resolveStub).args, [
             './svelte.svelte',
             'C:/somerepo/somefile.svelte',
             compilerOptions,
             svelteSys
         ]);
-        assert.deepStrictEqual(getSvelteSnapshotStub.getCall(0).args, ['filename.svelte']);
+        assert.deepStrictEqual(lastCall(getSvelteSnapshotStub).args, ['filename.svelte']);
     });
 
     it('uses svelte module loader for virtual svelte files with TS path aliases', async () => {
@@ -130,13 +154,13 @@ describe('createSvelteModuleLoader', () => {
                 resolvedFileName: 'filename.svelte'
             }
         ]);
-        assert.deepStrictEqual(resolveStub.getCall(0).args, [
+        assert.deepStrictEqual(lastCall(resolveStub).args, [
             '/@/svelte.svelte',
             'C:/somerepo/somefile.svelte',
             compilerOptions,
             svelteSys
         ]);
-        assert.deepStrictEqual(getSvelteSnapshotStub.getCall(0).args, ['filename.svelte']);
+        assert.deepStrictEqual(lastCall(getSvelteSnapshotStub).args, ['filename.svelte']);
     });
 
     it('uses cache if module was already resolved before', async () => {


### PR DESCRIPTION
Files ending with .svelte.d.ts are now resolved prior to a same file ending with .svelte . This enables library authors to ship type definitions of Svelte files next to their implementation.

In some folder:
```
component.svelte
component.svelte.d.ts
```
In some importing file:
```
<script>
  import Component from './component.svelte'; // <- reads type definitions from d.ts
</script>
```

#878

Nice side effect: Was able to get rid of some custom path alias logic that way.

Before merging this: @tomblachut is this something possible to implement on your side, too? Doesn't have to be right away, just want to make sure I'm not doing something impossible to do on your end.