### PR TITLE
(fix) move store decl from import into render fn

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -316,6 +316,94 @@ describe('CodeActionsProvider', () => {
         ]);
     });
 
+    it('organizes imports with module script and store', async () => {
+        const { provider, document } = setup('organize-imports-module-store.svelte');
+
+        const codeActions = await provider.getCodeActions(
+            document,
+            Range.create(Position.create(1, 4), Position.create(1, 5)), // irrelevant
+            {
+                diagnostics: [],
+                only: [CodeActionKind.SourceOrganizeImports]
+            }
+        );
+        (<TextDocumentEdit>codeActions[0]?.edit?.documentChanges?.[0])?.edits.forEach(
+            (edit) => (edit.newText = harmonizeNewLines(edit.newText))
+        );
+
+        assert.deepStrictEqual(codeActions, [
+            {
+                edit: {
+                    documentChanges: [
+                        {
+                            edits: [
+                                {
+                                    newText:
+                                        "import { _,_d } from 'svelte-i18n';\nimport { _e } from 'svelte-i18n1';\n",
+                                    range: {
+                                        end: {
+                                            character: 0,
+                                            line: 2
+                                        },
+                                        start: {
+                                            character: 2,
+                                            line: 1
+                                        }
+                                    }
+                                },
+                                {
+                                    newText: '',
+                                    range: {
+                                        end: {
+                                            character: 2,
+                                            line: 6
+                                        },
+                                        start: {
+                                            character: 2,
+                                            line: 5
+                                        }
+                                    }
+                                },
+                                {
+                                    newText: '',
+                                    range: {
+                                        end: {
+                                            character: 2,
+                                            line: 7
+                                        },
+                                        start: {
+                                            character: 2,
+                                            line: 6
+                                        }
+                                    }
+                                },
+                                {
+                                    newText: '',
+                                    range: {
+                                        end: {
+                                            character: 37,
+                                            line: 7
+                                        },
+                                        start: {
+                                            character: 2,
+                                            line: 7
+                                        }
+                                    }
+                                }
+                            ],
+                            textDocument: {
+                                uri: getUri('organize-imports-module-store.svelte'),
+                                version: 0
+                            }
+                        }
+                    ]
+                },
+                kind: CodeActionKind.SourceOrganizeImports,
+                title: 'Organize Imports'
+            }
+        ]);
+    });
+
     it('should do extract into const refactor', async () => {
         const { provider, document } = setup('codeactions.svelte');
 

--- a/packages/language-server/test/plugins/typescript/testfiles/organize-imports-module-store.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/organize-imports-module-store.svelte
@@ -1,0 +1,13 @@
+<script context="module">
+  import { _ } from 'svelte-i18n';
+</script>
+
+<script>
+  import { _ } from 'svelte-i18n';
+  import { _d } from 'svelte-i18n';
+  import { _e } from 'svelte-i18n1';
+</script>
+
+<p>{$_('test')}</p>
+<p>{$_d('test')}</p>
+<p>{$_e('test')}</p>

--- a/packages/svelte2tsx/src/svelte2tsx/index.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/index.ts
@@ -455,7 +455,10 @@ export function svelte2tsx(
         }
     }
 
-    const implicitStoreValues = new ImplicitStoreValues(resolvedStores);
+    const renderFunctionStart = scriptTag
+        ? str.original.lastIndexOf('>', scriptTag.content.start) + 1
+        : instanceScriptTarget;
+    const implicitStoreValues = new ImplicitStoreValues(resolvedStores, renderFunctionStart);
     //move the instance script and process the content
     let exportedNames = new ExportedNames();
     let getters = new Set<string>();
@@ -492,7 +495,7 @@ export function svelte2tsx(
         processModuleScriptTag(
             str,
             moduleScriptTag,
-            new ImplicitStoreValues(implicitStoreValues.getAccessedStores())
+            new ImplicitStoreValues(implicitStoreValues.getAccessedStores(), renderFunctionStart)
         );
     }
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-from-module/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-from-module/expected.tsx
@@ -1,10 +1,10 @@
 ///<reference types="svelte" />
 <></>;
-    import {store1, store2} from './store';/*Ωignore_startΩ*/;let $store1 = __sveltets_store_get(store1);/*Ωignore_endΩ*//*Ωignore_startΩ*/;let $store2 = __sveltets_store_get(store2);/*Ωignore_endΩ*/
+    import {store1, store2} from './store';
     const store3 = writable('')/*Ωignore_startΩ*/;let $store3 = __sveltets_store_get(store3);/*Ωignore_endΩ*/;
     const store4 = writable('')/*Ωignore_startΩ*/;let $store4 = __sveltets_store_get(store4);/*Ωignore_endΩ*/;
 ;<></>;function render() {
-
+/*Ωignore_startΩ*/;let $store1 = __sveltets_store_get(store1);;let $store2 = __sveltets_store_get(store2);/*Ωignore_endΩ*/
     ;(__sveltets_store_get(store1), $store1);
     ;(__sveltets_store_get(store3), $store3);
 ;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-import/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-import/expected.tsx
@@ -4,10 +4,10 @@ import storeA from './store';
 import { storeB } from './store';
 import { storeB as storeC } from './store';
 function render() {
-
-    /*Ωignore_startΩ*/;let $storeA = __sveltets_store_get(storeA);/*Ωignore_endΩ*/
-    /*Ωignore_startΩ*/;let $storeB = __sveltets_store_get(storeB);/*Ωignore_endΩ*/
-    /*Ωignore_startΩ*/;let $storeC = __sveltets_store_get(storeC);/*Ωignore_endΩ*/
+/*Ωignore_startΩ*/;let $storeA = __sveltets_store_get(storeA);;let $storeB = __sveltets_store_get(storeB);;let $storeC = __sveltets_store_get(storeC);/*Ωignore_endΩ*/
+    
+    
+    
 ;
 () => (<>
 


### PR DESCRIPTION
Don't append the store declaration of imports that are stores right after the import. Instead, append it to the start of the render function. This way, imports are grouped without these declarations at the top, which makes "organize imports" behave correctly again and not put ignore-comments into the edits.
#879