### PR TITLE
fix import completion in upper case directory

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -107,8 +107,7 @@ export function createLanguageService(
         resolveModuleNames: svelteModuleLoader.resolveModuleNames,
         readDirectory: svelteModuleLoader.readDirectory,
         getDirectories: ts.sys.getDirectories,
-        // vscode's uri is all lowercase
-        useCaseSensitiveFileNames: () => false,
+        useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
         getScriptKind: (fileName: string) => getSnapshot(fileName).scriptKind
     };
     let languageService = ts.createLanguageService(host);

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -340,6 +340,21 @@ describe('CompletionProviderImpl', () => {
         }
     });
 
+    it('provides import completions in file with uppercase directory', async () => {
+        const { completionProvider, document } = setup('UpperCase/dirCasing.svelte');
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            Position.create(1, 22),
+            {
+                triggerKind: CompletionTriggerKind.TriggerCharacter,
+                triggerCharacter: '/'
+            }
+        );
+
+        assert.equal(completions?.items[0].label, 'toImport.ts');
+    })
+
     it('provides import completions for supported files', async () => {
         const sourceFile = 'importcompletions.svelte';
         const { completionProvider, document } = setup(sourceFile);
@@ -584,7 +599,7 @@ describe('CompletionProviderImpl', () => {
             harmonizeNewLines(additionalTextEdits![0]?.newText),
             // " instead of ' because VSCode uses " by default when there are no other imports indicating otherwise
             `<script>${newLine}import ImportedFile from "./imported-file.svelte";` +
-                `${newLine}${newLine}</script>${newLine}`
+            `${newLine}${newLine}</script>${newLine}`
         );
 
         assert.deepEqual(

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -353,7 +353,7 @@ describe('CompletionProviderImpl', () => {
         );
 
         assert.equal(completions?.items[0].label, 'toImport.ts');
-    })
+    });
 
     it('provides import completions for supported files', async () => {
         const sourceFile = 'importcompletions.svelte';
@@ -599,7 +599,7 @@ describe('CompletionProviderImpl', () => {
             harmonizeNewLines(additionalTextEdits![0]?.newText),
             // " instead of ' because VSCode uses " by default when there are no other imports indicating otherwise
             `<script>${newLine}import ImportedFile from "./imported-file.svelte";` +
-            `${newLine}${newLine}</script>${newLine}`
+                `${newLine}${newLine}</script>${newLine}`
         );
 
         assert.deepEqual(

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/UpperCase/dirCasing.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/UpperCase/dirCasing.svelte
@@ -1,0 +1,3 @@
+<script>
+    import {} from './'
+</script>


### PR DESCRIPTION
The problem is with filename case sensitivity in different OS. Thanks to @bluwy for finding out the problem.

From the screenshot @Jake13f provides in #881 I see an Uppercase directory. So it probably is the same problem as @bluwy is encountering.
