### PR TITLE
(chore) tagged deployments for language server and svelte2tsx

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -44,5 +44,5 @@ jobs:
           OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
         with:
           sort: '["svelte2tsx", "svelte-language-server", "svelte-check", "svelte-vscode-nightly"]'
-          only: '["svelte2tsx", "svelte-language-server", "svelte-vscode-nightly"]'
+          only: '["svelte-vscode-nightly"]'
           install: "true"

--- a/.github/workflows/DeployExtensionsProd.yml
+++ b/.github/workflows/DeployExtensionsProd.yml
@@ -1,4 +1,4 @@
-name: Tagged Production Deploys
+name: Tagged Production Deploys for VS Code
 
 on:
   push:

--- a/.github/workflows/DeploySvelte2tsxProd.yml
+++ b/.github/workflows/DeploySvelte2tsxProd.yml
@@ -1,9 +1,9 @@
-name: Tagged Production Deploys for svelte-check
+name: Tagged Production Deploys for svelte2tsx
 
 on:
   push:
     tags:
-      - "svelte-check-*"
+      - "svelte2tsx-*"
 
 jobs:
   deploy:
@@ -24,11 +24,11 @@ jobs:
       - run: "npm install -g json"
 
       # Setup the environment
-      - run: 'json -I -f packages/svelte-check/package.json -e "this.version=\`${{ github.ref }}\`.split(\`-\`).pop()"'
+      - run: 'json -I -f packages/svelte2tsx/package.json -e "this.version=\`${{ github.ref }}\`.split(\`-\`).pop()"'
 
       # Ship it
       - run: |
-         cd packages/svelte-check
+         cd packages/svelte2tsx
          npm install
          npm publish
 

--- a/.github/workflows/DeploySvelteLanguageServerProd.yml
+++ b/.github/workflows/DeploySvelteLanguageServerProd.yml
@@ -1,9 +1,9 @@
-name: Tagged Production Deploys for svelte-check
+name: Tagged Production Deploys For svelte-language-server
 
 on:
   push:
     tags:
-      - "svelte-check-*"
+      - "language-server-*"
 
 jobs:
   deploy:
@@ -24,11 +24,11 @@ jobs:
       - run: "npm install -g json"
 
       # Setup the environment
-      - run: 'json -I -f packages/svelte-check/package.json -e "this.version=\`${{ github.ref }}\`.split(\`-\`).pop()"'
+      - run: 'json -I -f packages/language-server/package.json -e "this.version=\`${{ github.ref }}\`.split(\`-\`).pop()"'
 
       # Ship it
       - run: |
-         cd packages/svelte-check
+         cd packages/language-server
          npm install
          npm publish
 

--- a/packages/language-server/CHANGELOG.md
+++ b/packages/language-server/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+See https://github.com/sveltejs/language-tools/releases

--- a/packages/svelte-check/CHANGELOG.md
+++ b/packages/svelte-check/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+See https://github.com/sveltejs/language-tools/releases

--- a/packages/svelte2tsx/CHANGELOG.md
+++ b/packages/svelte2tsx/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+See https://github.com/sveltejs/language-tools/releases


### PR DESCRIPTION
I also disabled the daily deployments for now in the Github Actions menu. We can think about what to do with the nightly deploys of the extensions later. Either we remove the nightly versions completely, or we change the schedule so that it only proceeds if there was a new tag for `svelte2tsx` or `language-server` ([might be possible](https://stackoverflow.com/questions/63014786/how-to-schedule-a-github-actions-nightly-build-but-run-it-only-when-there-where)).

Closes #913