### PR TITLE
Use AST types from `svelte` instead of `estree` in `htmlxtojsx`

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx/index.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/index.ts
@@ -1,6 +1,7 @@
-import { Node } from 'estree-walker';
 import MagicString from 'magic-string';
 import { walk } from 'svelte/compiler';
+import { TemplateNode, Text } from 'svelte/types/compiler/interfaces';
+import { Attribute, BaseDirective, BaseNode } from '../interfaces';
 import { parseHtmlx } from '../utils/htmlxparser';
 import { getSlotName } from '../utils/svelteAst';
 import { handleActionDirective } from './nodes/action-directive';
@@ -26,7 +27,7 @@ import { handleText } from './nodes/text';
 import { handleTransitionDirective } from './nodes/transition-directive';
 import { usesLet } from './utils/node-utils';
 
-type Walker = (node: Node, parent: Node, prop: string, index: number) => void;
+type Walker = (node: TemplateNode, parent: BaseNode, prop: string, index: number) => void;
 
 function stripDoctype(str: MagicString): void {
     const regex = /<!doctype(.+?)>(\n)?/i;
@@ -42,7 +43,7 @@ function stripDoctype(str: MagicString): void {
  */
 export function convertHtmlxToJsx(
     str: MagicString,
-    ast: Node,
+    ast: TemplateNode,
     onWalk: Walker = null,
     onLeave: Walker = null
 ): void {
@@ -56,7 +57,7 @@ export function convertHtmlxToJsx(
     let ifScope = new IfScope(templateScopeManager);
 
     walk(ast, {
-        enter: (node: Node, parent: Node, prop: string, index: number) => {
+        enter: (node: TemplateNode, parent: BaseNode, prop: string, index: number) => {
             try {
                 switch (node.type) {
                     case 'IfBlock':
@@ -123,25 +124,25 @@ export function convertHtmlxToJsx(
                         handleComment(str, node);
                         break;
                     case 'Binding':
-                        handleBinding(htmlx, str, node, parent);
+                        handleBinding(htmlx, str, node as BaseDirective, parent);
                         break;
                     case 'Class':
-                        handleClassDirective(str, node);
+                        handleClassDirective(str, node as BaseDirective);
                         break;
                     case 'Action':
-                        handleActionDirective(htmlx, str, node, parent);
+                        handleActionDirective(htmlx, str, node as BaseDirective, parent);
                         break;
                     case 'Transition':
-                        handleTransitionDirective(htmlx, str, node, parent);
+                        handleTransitionDirective(htmlx, str, node as BaseDirective, parent);
                         break;
                     case 'Animation':
-                        handleAnimateDirective(htmlx, str, node, parent);
+                        handleAnimateDirective(htmlx, str, node as BaseDirective, parent);
                         break;
                     case 'Attribute':
-                        handleAttribute(htmlx, str, node, parent);
+                        handleAttribute(htmlx, str, node as Attribute, parent);
                         break;
                     case 'EventHandler':
-                        handleEventHandler(htmlx, str, node, parent);
+                        handleEventHandler(htmlx, str, node as BaseDirective, parent);
                         break;
                     case 'Options':
                         handleSvelteTag(htmlx, str, node);
@@ -171,7 +172,7 @@ export function convertHtmlxToJsx(
                         }
                         break;
                     case 'Text':
-                        handleText(str, node);
+                        handleText(str, node as Text);
                         break;
                 }
                 if (onWalk) {
@@ -183,7 +184,7 @@ export function convertHtmlxToJsx(
             }
         },
 
-        leave: (node: Node, parent: Node, prop: string, index: number) => {
+        leave: (node: TemplateNode, parent: BaseNode, prop: string, index: number) => {
             try {
                 switch (node.type) {
                     case 'IfBlock':

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/action-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/action-directive.ts
@@ -1,6 +1,6 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { isQuote } from '../utils/node-utils';
+import { BaseDirective, BaseNode } from '../../interfaces';
 
 /**
  * use:xxx={params}   --->    {...__sveltets_ensureAction(xxx(__sveltets_mapElementTag('ParentNodeName'),(params)))}
@@ -8,8 +8,8 @@ import { isQuote } from '../utils/node-utils';
 export function handleActionDirective(
     htmlx: string,
     str: MagicString,
-    attr: Node,
-    parent: Node
+    attr: BaseDirective,
+    parent: BaseNode
 ): void {
     str.overwrite(attr.start, attr.start + 'use:'.length, '{...__sveltets_ensureAction(');
 

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/animation-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/animation-directive.ts
@@ -1,6 +1,6 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { isQuote } from '../utils/node-utils';
+import { BaseDirective, BaseNode } from '../../interfaces';
 
 /**
  * animate:xxx(yyy)   --->   {...__sveltets_ensureAnimation(xxx(__sveltets_mapElementTag('..'),__sveltets_AnimationMove,(yyy)))}
@@ -8,8 +8,8 @@ import { isQuote } from '../utils/node-utils';
 export function handleAnimateDirective(
     htmlx: string,
     str: MagicString,
-    attr: Node,
-    parent: Node
+    attr: BaseDirective,
+    parent: BaseNode
 ): void {
     str.overwrite(
         attr.start,

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/attribute.ts
@@ -1,7 +1,7 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import svgAttributes from '../svgattributes';
 import { isQuote } from '../utils/node-utils';
+import { Attribute, BaseNode } from '../../interfaces';
 
 /**
  * List taken from `svelte-jsx.d.ts` by searching for all attributes of type number
@@ -35,14 +35,19 @@ const numberOnlyAttributes = new Set([
  * - lowercase DOM attributes
  * - multi-value handling
  */
-export function handleAttribute(htmlx: string, str: MagicString, attr: Node, parent: Node): void {
+export function handleAttribute(
+    htmlx: string,
+    str: MagicString,
+    attr: Attribute,
+    parent: BaseNode
+): void {
     let transformedFromDirectiveOrNamespace = false;
 
     //if we are on an "element" we are case insensitive, lowercase to match our JSX
     if (parent.type == 'Element') {
         const sapperLinkActions = ['sapper:prefetch', 'sapper:noscroll'];
         const sveltekitLinkActions = ['sveltekit:prefetch', 'sveltekit:noscroll'];
-        //skip Attribute shorthand, that is handled below
+        // skip Attribute shorthand, that is handled below
         if (
             (attr.value !== true &&
                 !(

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/await.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/await.ts
@@ -1,8 +1,8 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { IfScope } from './if-scope';
 import { TemplateScopeManager } from './template-scope';
 import { surroundWithIgnoreComments } from '../../utils/ignore';
+import { BaseNode } from '../../interfaces';
 
 /**
  * Transform {#await ...} into something JSX understands
@@ -10,7 +10,7 @@ import { surroundWithIgnoreComments } from '../../utils/ignore';
 export function handleAwait(
     htmlx: string,
     str: MagicString,
-    awaitBlock: Node,
+    awaitBlock: BaseNode,
     ifScope: IfScope,
     templateScopeManager: TemplateScopeManager
 ): void {
@@ -33,7 +33,7 @@ export function handleAwait(
 }
 
 export function handleAwaitPending(
-    awaitBlock: Node,
+    awaitBlock: BaseNode,
     htmlx: string,
     str: MagicString,
     ifScope: IfScope
@@ -61,7 +61,7 @@ export function handleAwaitPending(
 }
 
 export function handleAwaitThen(
-    awaitBlock: Node,
+    awaitBlock: BaseNode,
     htmlx: string,
     str: MagicString,
     ifScope: IfScope
@@ -106,7 +106,7 @@ export function handleAwaitThen(
 }
 
 export function handleAwaitCatch(
-    awaitBlock: Node,
+    awaitBlock: BaseNode,
     htmlx: string,
     str: MagicString,
     ifScope: IfScope

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/binding.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/binding.ts
@@ -1,6 +1,6 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { isShortHandAttribute, getThisType, isQuote } from '../utils/node-utils';
+import { BaseDirective, BaseNode } from '../../interfaces';
 
 const oneWayBindingAttributes: Map<string, string> = new Map(
     ['clientWidth', 'clientHeight', 'offsetWidth', 'offsetHeight']
@@ -16,7 +16,12 @@ const oneWayBindingAttributes: Map<string, string> = new Map(
 /**
  * Transform bind:xxx into something that conforms to JSX
  */
-export function handleBinding(htmlx: string, str: MagicString, attr: Node, el: Node): void {
+export function handleBinding(
+    htmlx: string,
+    str: MagicString,
+    attr: BaseDirective,
+    el: BaseNode
+): void {
     //bind group on input
     if (attr.name == 'group' && el.name == 'input') {
         str.remove(attr.start, attr.expression.start);

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/class-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/class-directive.ts
@@ -1,10 +1,10 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
+import { BaseDirective } from '../../interfaces';
 
 /**
  * class:xx={yyy}   --->   {...__sveltets_ensureType(Boolean, !!(yyy))}
  */
-export function handleClassDirective(str: MagicString, attr: Node): void {
+export function handleClassDirective(str: MagicString, attr: BaseDirective): void {
     str.overwrite(attr.start, attr.expression.start, '{...__sveltets_ensureType(Boolean, !!(');
     const endBrackets = '))}';
     if (attr.end !== attr.expression.end) {

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/comment.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/comment.ts
@@ -1,9 +1,9 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
+import { BaseNode } from '../../interfaces';
 
 /**
  * Removes comment
  */
-export function handleComment(str: MagicString, node: Node): void {
+export function handleComment(str: MagicString, node: BaseNode): void {
     str.remove(node.start, node.end);
 }

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/component.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/component.ts
@@ -1,9 +1,9 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { getSlotName } from '../../utils/svelteAst';
 import { handleSlot } from './slot';
 import { IfScope } from './if-scope';
 import { TemplateScope } from '../nodes/template-scope';
+import { BaseNode } from '../../interfaces';
 
 /**
  * Handle `<svelte:self>` and slot-specific transformations.
@@ -11,8 +11,8 @@ import { TemplateScope } from '../nodes/template-scope';
 export function handleComponent(
     htmlx: string,
     str: MagicString,
-    el: Node,
-    parent: Node,
+    el: BaseNode,
+    parent: BaseNode,
     ifScope: IfScope,
     templateScope: TemplateScope
 ): void {

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/debug.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/debug.ts
@@ -1,14 +1,14 @@
-import { Node } from 'estree-walker';
 import MagicString from 'magic-string';
+import { BaseNode } from '../../interfaces';
 
 /**
  * {@debug a}		--->   {a}
  * {@debug a, b}	--->   {a}{b}
  * tsx won't accept commas, must split
  */
-export function handleDebug(_htmlx: string, str: MagicString, debugBlock: Node): void {
+export function handleDebug(_htmlx: string, str: MagicString, debugBlock: BaseNode): void {
     let cursor = debugBlock.start;
-    for (const identifier of debugBlock.identifiers as Node[]) {
+    for (const identifier of debugBlock.identifiers as BaseNode[]) {
         str.remove(cursor, identifier.start);
         str.prependLeft(identifier.start, '{');
         str.prependLeft(identifier.end, '}');

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/element.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/element.ts
@@ -1,9 +1,9 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { getSlotName } from '../../utils/svelteAst';
 import { handleSlot } from './slot';
 import { IfScope } from './if-scope';
 import { TemplateScope } from '../nodes/template-scope';
+import { BaseNode } from '../../interfaces';
 
 /**
  * Special treatment for self-closing / void tags to make them conform to JSX.
@@ -11,8 +11,8 @@ import { TemplateScope } from '../nodes/template-scope';
 export function handleElement(
     htmlx: string,
     str: MagicString,
-    node: Node,
-    parent: Node,
+    node: BaseNode,
+    parent: BaseNode,
     ifScope: IfScope,
     templateScope: TemplateScope
 ): void {

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/event-handler.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/event-handler.ts
@@ -1,6 +1,6 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { getTypeForComponent, isQuote } from '../utils/node-utils';
+import { BaseDirective, BaseNode } from '../../interfaces';
 
 /**
  * Transform on:xxx={yyy}
@@ -10,8 +10,8 @@ import { getTypeForComponent, isQuote } from '../utils/node-utils';
 export function handleEventHandler(
     htmlx: string,
     str: MagicString,
-    attr: Node,
-    parent: Node
+    attr: BaseDirective,
+    parent: BaseNode
 ): void {
     const jsxEventName = attr.name;
 

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/if-else.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/if-else.ts
@@ -1,11 +1,16 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { IfScope } from './if-scope';
+import { BaseNode } from '../../interfaces';
 
 /**
  * {# if ...}...{/if}   --->   {() => {if(...){<>...</>}}}
  */
-export function handleIf(htmlx: string, str: MagicString, ifBlock: Node, ifScope: IfScope): void {
+export function handleIf(
+    htmlx: string,
+    str: MagicString,
+    ifBlock: BaseNode,
+    ifScope: IfScope
+): void {
     const endIf = htmlx.lastIndexOf('{', ifBlock.end - 1);
 
     if (ifBlock.elseif) {
@@ -45,8 +50,8 @@ export function handleIf(htmlx: string, str: MagicString, ifBlock: Node, ifScope
 export function handleElse(
     htmlx: string,
     str: MagicString,
-    elseBlock: Node,
-    parent: Node,
+    elseBlock: BaseNode,
+    parent: BaseNode,
     ifScope: IfScope
 ): void {
     if (

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/key.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/key.ts
@@ -1,10 +1,10 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
+import { BaseNode } from '../../interfaces';
 
 /**
  * {#key expr}content{/key}   --->   {expr} content
  */
-export function handleKey(htmlx: string, str: MagicString, keyBlock: Node): void {
+export function handleKey(htmlx: string, str: MagicString, keyBlock: BaseNode): void {
     // {#key expr}   ->   {expr}
     str.overwrite(keyBlock.start, keyBlock.expression.start, '{');
     const end = htmlx.indexOf('}', keyBlock.expression.end);

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/raw-html.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/raw-html.ts
@@ -1,10 +1,10 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
+import { BaseNode } from '../../interfaces';
 
 /**
  * {@html ...}   --->   {...}
  */
-export function handleRawHtml(htmlx: string, str: MagicString, rawBlock: Node): void {
+export function handleRawHtml(htmlx: string, str: MagicString, rawBlock: BaseNode): void {
     const tokenStart = htmlx.indexOf('@html', rawBlock.start);
     str.remove(tokenStart, tokenStart + '@html'.length);
 }

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/slot.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/slot.ts
@@ -1,15 +1,15 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { beforeStart } from '../utils/node-utils';
 import { getSingleSlotDef } from '../../svelte2tsx/nodes/slot';
 import { IfScope } from './if-scope';
 import { TemplateScope } from '../nodes/template-scope';
+import { BaseNode } from '../../interfaces';
 
 export function handleSlot(
     htmlx: string,
     str: MagicString,
-    slotEl: Node,
-    component: Node,
+    slotEl: BaseNode,
+    component: BaseNode,
     slotName: string,
     ifScope: IfScope,
     templateScope: TemplateScope

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/svelte-tag.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/svelte-tag.ts
@@ -1,11 +1,11 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
+import { BaseNode } from '../../interfaces';
 
 /**
  * `<svelte:window>...</svelte:window>`   ---->    `<sveltewindow>...</sveltewindow>`
  * (same for :head, :body, :options, :fragment)
  */
-export function handleSvelteTag(htmlx: string, str: MagicString, node: Node): void {
+export function handleSvelteTag(htmlx: string, str: MagicString, node: BaseNode): void {
     const colon = htmlx.indexOf(':', node.start);
     str.remove(colon, colon + 1);
 

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/template-scope.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/template-scope.ts
@@ -1,6 +1,5 @@
-import { Node } from 'estree-walker';
 import { extract_identifiers } from 'periscopic';
-import { SvelteIdentifier } from '../../interfaces';
+import { BaseNode, SvelteIdentifier } from '../../interfaces';
 import { isDestructuringPatterns, isIdentifier } from '../../utils/svelteAst';
 import { usesLet } from '../utils/node-utils';
 
@@ -21,7 +20,7 @@ export class TemplateScope {
 export class TemplateScopeManager {
     value = new TemplateScope();
 
-    eachEnter(node: Node) {
+    eachEnter(node: BaseNode) {
         this.value = this.value.child();
         if (node.context) {
             this.handleScope(node.context);
@@ -31,13 +30,13 @@ export class TemplateScopeManager {
         }
     }
 
-    eachLeave(node: Node) {
+    eachLeave(node: BaseNode) {
         if (!node.else) {
             this.value = this.value.parent;
         }
     }
 
-    awaitEnter(node: Node) {
+    awaitEnter(node: BaseNode) {
         this.value = this.value.child();
         if (node.value) {
             this.handleScope(node.value);
@@ -47,7 +46,7 @@ export class TemplateScopeManager {
         }
     }
 
-    awaitPendingEnter(node: Node, parent: Node) {
+    awaitPendingEnter(node: BaseNode, parent: BaseNode) {
         if (node.skip || parent.type !== 'AwaitBlock') {
             return;
         }
@@ -55,7 +54,7 @@ export class TemplateScopeManager {
         this.value.inits.clear();
     }
 
-    awaitThenEnter(node: Node, parent: Node) {
+    awaitThenEnter(node: BaseNode, parent: BaseNode) {
         if (node.skip || parent.type !== 'AwaitBlock') {
             return;
         }
@@ -67,7 +66,7 @@ export class TemplateScopeManager {
         }
     }
 
-    awaitCatchEnter(node: Node, parent: Node) {
+    awaitCatchEnter(node: BaseNode, parent: BaseNode) {
         if (node.skip || parent.type !== 'AwaitBlock') {
             return;
         }
@@ -83,25 +82,25 @@ export class TemplateScopeManager {
         this.value = this.value.parent;
     }
 
-    elseEnter(parent: Node) {
+    elseEnter(parent: BaseNode) {
         if (parent.type === 'EachBlock') {
             this.value = this.value.parent;
         }
     }
 
-    componentOrSlotTemplateOrElementEnter(node: Node) {
+    componentOrSlotTemplateOrElementEnter(node: BaseNode) {
         if (usesLet(node)) {
             this.value = this.value.child();
         }
     }
 
-    componentOrSlotTemplateOrElementLeave(node: Node) {
+    componentOrSlotTemplateOrElementLeave(node: BaseNode) {
         if (usesLet(node)) {
             this.value = this.value.parent;
         }
     }
 
-    private handleScope(identifierDef: Node) {
+    private handleScope(identifierDef: BaseNode) {
         if (isIdentifier(identifierDef)) {
             this.value.inits.add(identifierDef.name);
         }

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/text.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/text.ts
@@ -1,7 +1,6 @@
-import { Node } from 'estree-walker';
 import MagicString from 'magic-string';
-
-export function handleText(str: MagicString, node: Node) {
+import { Text } from 'svelte/types/compiler/interfaces';
+export function handleText(str: MagicString, node: Text) {
     if (!node.data) {
         return;
     }

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/text.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/text.ts
@@ -1,5 +1,6 @@
 import MagicString from 'magic-string';
 import { Text } from 'svelte/types/compiler/interfaces';
+
 export function handleText(str: MagicString, node: Text) {
     if (!node.data) {
         return;

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/transition-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/transition-directive.ts
@@ -1,6 +1,6 @@
 import MagicString from 'magic-string';
-import { Node } from 'estree-walker';
 import { isQuote } from '../utils/node-utils';
+import { BaseDirective, BaseNode } from '../../interfaces';
 
 /**
  * transition:xxx(yyy)   --->   {...__sveltets_ensureTransition(xxx(__sveltets_mapElementTag('..'),(yyy)))}
@@ -8,8 +8,8 @@ import { isQuote } from '../utils/node-utils';
 export function handleTransitionDirective(
     htmlx: string,
     str: MagicString,
-    attr: Node,
-    parent: Node
+    attr: BaseDirective,
+    parent: BaseNode
 ): void {
     str.overwrite(
         attr.start,

--- a/packages/svelte2tsx/src/htmlxtojsx/utils/node-utils.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/utils/node-utils.ts
@@ -1,4 +1,5 @@
 import { Node, walk } from 'estree-walker';
+import { BaseNode } from '../../interfaces';
 
 export function getTypeForComponent(node: Node): string {
     if (node.name === 'svelte:component' || node.name === 'svelte:self') {
@@ -64,6 +65,6 @@ export function getIdentifiersInIfExpression(
     return identifiers;
 }
 
-export function usesLet(node: Node): boolean {
+export function usesLet(node: BaseNode): boolean {
     return node.attributes?.some((attr) => attr.type === 'Let');
 }

--- a/packages/svelte2tsx/src/interfaces.ts
+++ b/packages/svelte2tsx/src/interfaces.ts
@@ -6,6 +6,7 @@ import {
     MustacheTag,
     Text
 } from 'svelte/types/compiler/interfaces';
+
 export interface NodeRange {
     start: number;
     end: number;

--- a/packages/svelte2tsx/src/interfaces.ts
+++ b/packages/svelte2tsx/src/interfaces.ts
@@ -1,6 +1,11 @@
-import { Node } from 'estree-walker';
 import { ArrayPattern, ObjectPattern, Identifier } from 'estree';
-
+import {
+    Directive,
+    TemplateNode,
+    Transition,
+    MustacheTag,
+    Text
+} from 'svelte/types/compiler/interfaces';
 export interface NodeRange {
     start: number;
     end: number;
@@ -17,19 +22,10 @@ export interface WithName {
     name: string;
 }
 
-export type DirectiveType =
-    | 'Action'
-    | 'Animation'
-    | 'Binding'
-    | 'Class'
-    | 'EventHandler'
-    | 'Let'
-    | 'Ref'
-    | 'Transition';
+export type BaseNode = Exclude<TemplateNode, Text | MustacheTag | Directive | Transition>;
 
-export interface BaseDirective extends Node {
-    type: DirectiveType;
-    expression: null | Node;
-    name: string;
-    modifiers: string[];
+export type BaseDirective = Exclude<Directive, Transition>;
+
+export interface Attribute extends BaseNode {
+    value: BaseNode[] | true;
 }

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/handleScopeAndResolveForSlot.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/handleScopeAndResolveForSlot.ts
@@ -1,9 +1,10 @@
 import { Node } from 'estree-walker';
-import { BaseDirective, SvelteIdentifier } from '../../interfaces';
+import { SvelteIdentifier } from '../../interfaces';
 import TemplateScope from './TemplateScope';
 import { SlotHandler } from './slot';
 import { isIdentifier, isDestructuringPatterns } from '../../utils/svelteAst';
 import { extract_identifiers as extractIdentifiers } from 'periscopic';
+import { Directive } from 'svelte/types/compiler/interfaces';
 
 export function handleScopeAndResolveForSlot({
     identifierDef,
@@ -44,7 +45,7 @@ export function handleScopeAndResolveLetVarForSlot({
     templateScope,
     slotHandler
 }: {
-    letNode: BaseDirective;
+    letNode: Directive;
     slotName: string;
     component: Node;
     templateScope: TemplateScope;

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/slot.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/slot.ts
@@ -9,8 +9,9 @@ import {
     getSlotName
 } from '../../utils/svelteAst';
 import TemplateScope from './TemplateScope';
-import { SvelteIdentifier, WithName, BaseDirective } from '../../interfaces';
+import { SvelteIdentifier, WithName } from '../../interfaces';
 import { getTypeForComponent } from '../../htmlxtojsx/utils/node-utils';
+import { Directive } from 'svelte/types/compiler/interfaces';
 
 function attributeStrValueAsJsExpression(attr: Node): string {
     if (attr.value.length == 0) return "''"; //wut?
@@ -98,7 +99,7 @@ export class SlotHandler {
     resolveDestructuringAssignmentForLet(
         destructuringNode: Node,
         identifiers: SvelteIdentifier[],
-        letNode: BaseDirective,
+        letNode: Directive,
         component: Node,
         slotName: string
     ) {
@@ -112,15 +113,11 @@ export class SlotHandler {
         });
     }
 
-    private getResolveExpressionStrForLet(
-        letNode: BaseDirective,
-        component: Node,
-        slotName: string
-    ) {
+    private getResolveExpressionStrForLet(letNode: Directive, component: Node, slotName: string) {
         return `${getSingleSlotDef(component, slotName)}.${letNode.name}`;
     }
 
-    resolveLet(letNode: BaseDirective, identifierDef: WithName, component: Node, slotName: string) {
+    resolveLet(letNode: Directive, identifierDef: WithName, component: Node, slotName: string) {
         let resolved = this.resolved.get(identifierDef);
         if (resolved) {
             return resolved;
@@ -153,7 +150,7 @@ export class SlotHandler {
     private getLetNodes(child: Node, slotName: string) {
         const letNodes = ((child?.attributes as Node[]) ?? []).filter(
             (attr) => attr.type === 'Let'
-        ) as BaseDirective[];
+        ) as Directive[];
 
         return letNodes?.map((letNode) => ({
             letNode,

--- a/packages/svelte2tsx/src/utils/htmlxparser.ts
+++ b/packages/svelte2tsx/src/utils/htmlxparser.ts
@@ -96,7 +96,7 @@ function blankVerbatimContent(htmlx: string, verbatimElements: Node[]) {
     return output;
 }
 
-export function parseHtmlx(htmlx: string, options?: { emitOnTemplateError?: boolean }): Node {
+export function parseHtmlx(htmlx: string, options?: { emitOnTemplateError?: boolean }) {
     //Svelte tries to parse style and script tags which doesn't play well with typescript, so we blank them out.
     //HTMLx spec says they should just be retained after processing as is, so this is fine
     const verbatimElements = findVerbatimElements(htmlx);

--- a/packages/svelte2tsx/src/utils/svelteAst.ts
+++ b/packages/svelte2tsx/src/utils/svelteAst.ts
@@ -1,5 +1,5 @@
 import { Node } from 'estree-walker';
-import { SvelteIdentifier, SvelteArrayPattern, SvelteObjectPattern } from '../interfaces';
+import { SvelteIdentifier, SvelteArrayPattern, SvelteObjectPattern, BaseNode } from '../interfaces';
 
 export function isMember(parent: Node, prop: string) {
     return parent.type == 'MemberExpression' && prop == 'property';
@@ -36,8 +36,8 @@ export function isIdentifier(node: Node): node is SvelteIdentifier {
     return node.type === 'Identifier';
 }
 
-export function getSlotName(child: Node): string | undefined {
-    const slot = (child.attributes as Node[])?.find((a) => a.name == 'slot');
+export function getSlotName(child: BaseNode): string | undefined {
+    const slot = (child.attributes as BaseNode[])?.find((a) => a.name == 'slot');
 
     return slot?.value?.[0].raw;
 }


### PR DESCRIPTION
Replaced declaration of `BaseDirective` with the one from `svelte` at `packages\svelte2tsx\src\interfaces.ts`

Replaced most `Node` types from `estree` to types from `svelte`
- if directive, by `BaseDirective`
- if attribute, by `Attribute extends BaseNode` ( adds `value` property ) 
- if text, by `Text`
- else by `BaseNode`
