### PR TITLE
(fix) add esm flag to support node 12 < version < 12.17

### DIFF
--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -62,12 +62,14 @@ More docs and troubleshooting: [See here](/docs/README.md).
 ##### `svelte.language-server.runtime`
 
 Path to the node executable you would like to use to run the language server.
-This is useful when you depend on native modules such as node-sass as without
-this they will run in the context of vscode, meaning node version mismatch is likely.
+This is useful when you depend on native modules such as node-sass as without this they will run in the context of vscode, meaning node version mismatch is likely.
+Minimum required node version is `12.17`.
+This setting can only be changed in user settings for security reasons.
 
 ##### `svelte.language-server.ls-path`
 
-You normally don't set this. Path to the language server executable. If you installed the \"svelte-language-server\" npm package, it's within there at \"bin/server.js\". Path can be either relative to your workspace root or absolute. Set this only if you want to use a custom version of the language server.
+You normally don't set this. Path to the language server executable. If you installed the `svelte-language-server` npm package, it's within there at `bin/server.js`. Path can be either relative to your workspace root or absolute. Set this only if you want to use a custom version of the language server.
+This setting can only be changed in user settings for security reasons.
 
 ##### `svelte.language-server.port`
 

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -52,7 +52,7 @@
                     "scope": "application",
                     "type": "string",
                     "title": "Language Server Runtime",
-                    "description": "- You normally don't need this - Path to the node executable to use to spawn the language server. This is useful when you depend on native modules such as node-sass as without this they will run in the context of vscode, meaning node version mismatch is likely. This setting can only be changed in user settings for security reasons."
+                    "description": "- You normally don't need this - Path to the node executable to use to spawn the language server. This is useful when you depend on native modules such as node-sass as without this they will run in the context of vscode, meaning node version mismatch is likely. Minimum required node version is 12.17. This setting can only be changed in user settings for security reasons."
                 },
                 "svelte.language-server.ls-path": {
                     "scope": "application",

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -56,7 +56,9 @@ export function activate(context: ExtensionContext) {
     const serverModule = require.resolve(lsPath || 'svelte-language-server/bin/server.js');
     console.log('Loading server from ', serverModule);
 
-    const runExecArgv: string[] = [];
+    // Add --experimental-modules flag for people using node 12 < version < 12.17
+    // Remove this in mid 2022 and bump vs code minimum required version to 1.55
+    const runExecArgv: string[] = ['--experimental-modules'];
     let port = runtimeConfig.get<number>('port') ?? -1;
     if (port < 0) {
         port = 6009;
@@ -64,7 +66,7 @@ export function activate(context: ExtensionContext) {
         console.log('setting port to', port);
         runExecArgv.push(`--inspect=${port}`);
     }
-    const debugOptions = { execArgv: ['--nolazy', `--inspect=${port}`] };
+    const debugOptions = { execArgv: ['--nolazy', '--experimental-modules', `--inspect=${port}`] };
 
     const serverOptions: ServerOptions = {
         run: {
@@ -376,6 +378,7 @@ function addExtracComponentCommand(getLS: () => LanguageClient, context: Extensi
 }
 
 function createLanguageServer(serverOptions: ServerOptions, clientOptions: LanguageClientOptions) {
+    console.log('NEWWWWWWWWWWWWWWWW');
     return new LanguageClient('svelte', 'Svelte', serverOptions, clientOptions);
 }
 


### PR DESCRIPTION
Node versions prior to v12.17 need the `--experimental-modules` flag or the dynamic import introduced in #930 won't work. This node version is used in VS Code versions prior to 1.55 and could be used by users setting the node executable to a node version below 12.17.

Remove this in mid 2022 and bump vs code minimum required version to 1.55