### PR TITLE
(fix) don't provide version for edits

### DIFF
--- a/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
@@ -6,10 +6,10 @@ import {
     CodeActionKind,
     Diagnostic,
     DiagnosticSeverity,
+    OptionalVersionedTextDocumentIdentifier,
     Position,
     TextDocumentEdit,
-    TextEdit,
-    VersionedTextDocumentIdentifier
+    TextEdit
 } from 'vscode-languageserver';
 import { mapObjWithRangeToOriginal, offsetAt, positionAt } from '../../../../lib/documents';
 import { pathToUrl } from '../../../../utils';
@@ -40,9 +40,9 @@ async function createQuickfixAction(
     svelteDoc: SvelteDocument,
     ast: Ast
 ): Promise<CodeAction> {
-    const textDocument = VersionedTextDocumentIdentifier.create(
+    const textDocument = OptionalVersionedTextDocumentIdentifier.create(
         pathToUrl(svelteDoc.getFilePath()),
-        svelteDoc.version
+        null
     );
 
     return CodeAction.create(

--- a/packages/language-server/src/plugins/svelte/features/getCodeActions/getRefactorings.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCodeActions/getRefactorings.ts
@@ -1,11 +1,11 @@
 import * as path from 'path';
 import {
     CreateFile,
+    OptionalVersionedTextDocumentIdentifier,
     Position,
     Range,
     TextDocumentEdit,
     TextEdit,
-    VersionedTextDocumentIdentifier,
     WorkspaceEdit
 } from 'vscode-languageserver';
 import { isRangeInTag, TagInformation, updateRelativeImport } from '../../../../lib/documents';
@@ -54,10 +54,13 @@ async function executeExtractComponentCommand(
 
     return <WorkspaceEdit>{
         documentChanges: [
-            TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(svelteDoc.uri, 0), [
-                TextEdit.replace(range, `<${componentName}></${componentName}>`),
-                createComponentImportTextEdit()
-            ]),
+            TextDocumentEdit.create(
+                OptionalVersionedTextDocumentIdentifier.create(svelteDoc.uri, null),
+                [
+                    TextEdit.replace(range, `<${componentName}></${componentName}>`),
+                    createComponentImportTextEdit()
+                ]
+            ),
             CreateFile.create(newFileUri, { overwrite: true }),
             createNewFileEdit()
         ]
@@ -91,9 +94,10 @@ async function executeExtractComponentCommand(
             .map((tag) => tag.text)
             .join('');
 
-        return TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(newFileUri, 0), [
-            TextEdit.insert(Position.create(0, 0), newText)
-        ]);
+        return TextDocumentEdit.create(
+            OptionalVersionedTextDocumentIdentifier.create(newFileUri, null),
+            [TextEdit.insert(Position.create(0, 0), newText)]
+        );
 
         function getTemplate() {
             const startOffset = svelteDoc.offsetAt(range.start);

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -2,10 +2,10 @@ import {
     CodeAction,
     CodeActionContext,
     CodeActionKind,
+    OptionalVersionedTextDocumentIdentifier,
     Range,
     TextDocumentEdit,
     TextEdit,
-    VersionedTextDocumentIdentifier,
     WorkspaceEdit
 } from 'vscode-languageserver';
 import {
@@ -82,7 +82,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
             changes.map(async (change) => {
                 // Organize Imports will only affect the current file, so no need to check the file path
                 return TextDocumentEdit.create(
-                    VersionedTextDocumentIdentifier.create(document.url, 0),
+                    OptionalVersionedTextDocumentIdentifier.create(document.url, null),
                     change.textChanges.map((edit) => {
                         const range = this.checkRemoveImportCodeActionRange(
                             edit,
@@ -169,7 +169,10 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                     fix.changes.map(async (change) => {
                         const { snapshot, fragment } = await docs.retrieve(change.fileName);
                         return TextDocumentEdit.create(
-                            VersionedTextDocumentIdentifier.create(pathToUrl(change.fileName), 0),
+                            OptionalVersionedTextDocumentIdentifier.create(
+                                pathToUrl(change.fileName),
+                                null
+                            ),
                             change.textChanges
                                 .map((edit) => {
                                     if (
@@ -362,7 +365,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
 
         const documentChanges = edits?.edits.map((edit) =>
             TextDocumentEdit.create(
-                VersionedTextDocumentIdentifier.create(document.uri, 0),
+                OptionalVersionedTextDocumentIdentifier.create(document.uri, null),
                 edit.textChanges.map((edit) => {
                     const range = mapRangeToOriginal(fragment, convertRange(fragment, edit.span));
 

--- a/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
@@ -1,7 +1,7 @@
 import {
+    OptionalVersionedTextDocumentIdentifier,
     TextDocumentEdit,
     TextEdit,
-    VersionedTextDocumentIdentifier,
     WorkspaceEdit
 } from 'vscode-languageserver';
 import { mapRangeToOriginal } from '../../../lib/documents';
@@ -43,7 +43,7 @@ export class UpdateImportsProviderImpl implements UpdateImportsProvider {
                 const fragment = await docs.retrieveFragment(change.fileName);
 
                 return TextDocumentEdit.create(
-                    VersionedTextDocumentIdentifier.create(fragment.getURL(), 0),
+                    OptionalVersionedTextDocumentIdentifier.create(fragment.getURL(), null),
                     change.textChanges.map((edit) => {
                         const range = mapRangeToOriginal(
                             fragment,

--- a/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
@@ -11,7 +11,7 @@ import {
     Range,
     TextDocumentEdit,
     TextEdit,
-    VersionedTextDocumentIdentifier,
+    OptionalVersionedTextDocumentIdentifier,
     WorkspaceEdit
 } from 'vscode-languageserver';
 import { Document } from '../../../../src/lib/documents';
@@ -144,7 +144,7 @@ describe('SveltePlugin#getCodeAction', () => {
                                 ],
                                 textDocument: {
                                     uri: getUri(svelteIgnoreCodeAction),
-                                    version: 0
+                                    version: null
                                 }
                             }
                         ]
@@ -195,7 +195,7 @@ describe('SveltePlugin#getCodeAction', () => {
                                 ],
                                 textDocument: {
                                     uri: getUri(svelteIgnoreCodeAction),
-                                    version: 0
+                                    version: null
                                 }
                             }
                         ]
@@ -246,7 +246,7 @@ describe('SveltePlugin#getCodeAction', () => {
                                 ],
                                 textDocument: {
                                     uri: getUri(svelteIgnoreCodeAction),
-                                    version: 0
+                                    version: null
                                 }
                             }
                         ]
@@ -289,16 +289,22 @@ describe('SveltePlugin#getCodeAction', () => {
             const result = await extractComponent(path, range);
             assert.deepStrictEqual(result, <WorkspaceEdit>{
                 documentChanges: [
-                    TextDocumentEdit.create(VersionedTextDocumentIdentifier.create('someUrl', 0), [
-                        TextEdit.replace(range, '<NewComp></NewComp>'),
-                        TextEdit.insert(
-                            doc.script?.startPos || Position.create(0, 0),
-                            "\n  import NewComp from './NewComp.svelte';\n"
-                        )
-                    ]),
+                    TextDocumentEdit.create(
+                        OptionalVersionedTextDocumentIdentifier.create('someUrl', null),
+                        [
+                            TextEdit.replace(range, '<NewComp></NewComp>'),
+                            TextEdit.insert(
+                                doc.script?.startPos || Position.create(0, 0),
+                                "\n  import NewComp from './NewComp.svelte';\n"
+                            )
+                        ]
+                    ),
                     CreateFile.create('file:///NewComp.svelte', { overwrite: true }),
                     TextDocumentEdit.create(
-                        VersionedTextDocumentIdentifier.create('file:///NewComp.svelte', 0),
+                        OptionalVersionedTextDocumentIdentifier.create(
+                            'file:///NewComp.svelte',
+                            null
+                        ),
                         [
                             TextEdit.insert(
                                 Position.create(0, 0),
@@ -357,7 +363,7 @@ describe('SveltePlugin#getCodeAction', () => {
             assert.deepStrictEqual(result, <WorkspaceEdit>{
                 documentChanges: [
                     TextDocumentEdit.create(
-                        VersionedTextDocumentIdentifier.create(existingFileUri, 0),
+                        OptionalVersionedTextDocumentIdentifier.create(existingFileUri, null),
                         [
                             TextEdit.replace(range, '<NewComp></NewComp>'),
                             TextEdit.insert(
@@ -367,17 +373,20 @@ describe('SveltePlugin#getCodeAction', () => {
                         ]
                     ),
                     CreateFile.create(newFileUri, { overwrite: true }),
-                    TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(newFileUri, 0), [
-                        TextEdit.insert(
-                            Position.create(0, 0),
-                            `<script>
+                    TextDocumentEdit.create(
+                        OptionalVersionedTextDocumentIdentifier.create(newFileUri, null),
+                        [
+                            TextEdit.insert(
+                                Position.create(0, 0),
+                                `<script>
             import OtherComponent from './path/OtherComponent.svelte';
             import {test} from './test';
             </script>\n\ntoExtract\n\n<style>
             @import './path/style.css';
             </style>\n\n`
-                        )
-                    ])
+                            )
+                        ]
+                    )
                 ]
             });
         });

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -84,7 +84,7 @@ describe('CodeActionsProvider', () => {
                             ],
                             textDocument: {
                                 uri: getUri('codeactions.svelte'),
-                                version: 0
+                                version: null
                             }
                         }
                     ]
@@ -141,7 +141,7 @@ describe('CodeActionsProvider', () => {
                             ],
                             textDocument: {
                                 uri: getUri('codeactions.svelte'),
-                                version: 0
+                                version: null
                             }
                         }
                     ]
@@ -230,7 +230,7 @@ describe('CodeActionsProvider', () => {
                             ],
                             textDocument: {
                                 uri: getUri('codeactions.svelte'),
-                                version: 0
+                                version: null
                             }
                         }
                     ]
@@ -305,7 +305,7 @@ describe('CodeActionsProvider', () => {
                             ],
                             textDocument: {
                                 uri: getUri('organize-imports-with-module.svelte'),
-                                version: 0
+                                version: null
                             }
                         }
                     ]
@@ -393,7 +393,7 @@ describe('CodeActionsProvider', () => {
                             ],
                             textDocument: {
                                 uri: getUri('organize-imports-module-store.svelte'),
-                                version: 0
+                                version: null
                             }
                         }
                     ]
@@ -487,7 +487,7 @@ describe('CodeActionsProvider', () => {
                     ],
                     textDocument: {
                         uri: getUri('codeactions.svelte'),
-                        version: 0
+                        version: null
                     }
                 }
             ]
@@ -584,7 +584,7 @@ describe('CodeActionsProvider', () => {
                     ],
                     textDocument: {
                         uri: getUri('codeactions.svelte'),
-                        version: 0
+                        version: null
                     }
                 }
             ]

--- a/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
@@ -3,11 +3,11 @@ import { join } from 'path';
 import sinon from 'sinon';
 import ts from 'typescript';
 import {
+    OptionalVersionedTextDocumentIdentifier,
     Position,
     Range,
     TextDocumentEdit,
-    TextEdit,
-    VersionedTextDocumentIdentifier
+    TextEdit
 } from 'vscode-languageserver';
 import { Document, DocumentManager } from '../../../../src/lib/documents';
 import { LSConfigManager } from '../../../../src/ls-config';
@@ -51,7 +51,7 @@ describe('UpdateImportsProviderImpl', () => {
         });
 
         assert.deepStrictEqual(workspaceEdit?.documentChanges, [
-            TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(fileUri, 0), [
+            TextDocumentEdit.create(OptionalVersionedTextDocumentIdentifier.create(fileUri, null), [
                 TextEdit.replace(
                     Range.create(Position.create(1, 17), Position.create(1, 49)),
                     './documentation.svelte'


### PR DESCRIPTION
Setting it to 0 is against the spec since clients may reject the edits then. Set it to null instead.
#851