### PR TITLE
Don't watch node_modules when using the FallbackWatcher

### DIFF
--- a/packages/language-server/src/lib/FallbackWatcher.ts
+++ b/packages/language-server/src/lib/FallbackWatcher.ts
@@ -10,7 +10,14 @@ export class FallbackWatcher {
     private readonly callbacks: DidChangeHandler[] = [];
 
     constructor(glob: string, workspacePaths: string[]) {
-        this.watcher = watch(workspacePaths.map((workspacePath) => join(workspacePath, glob)));
+        const gitOrNodeModules = /\.git|node_modules/;
+        this.watcher = watch(
+            workspacePaths.map((workspacePath) => join(workspacePath, glob)),
+            {
+                ignored: (path: string) =>
+                    gitOrNodeModules.test(path) && !path.includes('src/node_modules')
+            }
+        );
 
         this.watcher
             .on('add', (path) => this.callback(path, FileChangeType.Created))

--- a/packages/language-server/src/lib/FallbackWatcher.ts
+++ b/packages/language-server/src/lib/FallbackWatcher.ts
@@ -15,7 +15,9 @@ export class FallbackWatcher {
             workspacePaths.map((workspacePath) => join(workspacePath, glob)),
             {
                 ignored: (path: string) =>
-                    gitOrNodeModules.test(path) && !path.includes('src/node_modules')
+                    gitOrNodeModules.test(path) &&
+                    !path.includes('src/node_modules') &&
+                    !path.includes('src\\node_modules')
             }
         );
 

--- a/packages/language-server/src/lib/FallbackWatcher.ts
+++ b/packages/language-server/src/lib/FallbackWatcher.ts
@@ -16,6 +16,7 @@ export class FallbackWatcher {
             {
                 ignored: (path: string) =>
                     gitOrNodeModules.test(path) &&
+                    // Handle Sapper's alias mapping
                     !path.includes('src/node_modules') &&
                     !path.includes('src\\node_modules')
             }


### PR DESCRIPTION
`FallbackWatcher` used in the language server was watching files in the `node_modules` and `.git` directories, which resulted in a V8 heap out of memory and unbearable performance when using the language server standalone, without VSCode (e.g. using neovim LSP).

## Investigation

When using [the svelte language server in neovim LSP](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#svelte) I have noticed very poor performance (when asking for a hover message, I got it after a minute, with the language server crashing right after that).

I checked in `~/.cache/nvim/lsp.log` that the language server was initializing a new TS server for each `tsconfig.json` it found in `node_modules`:

<details>
<summary>Logs with a V8 crash at the end</summary>

```
[ START ] 2021-04-18T13:18:21+0200 ] LSP logging initiated
[ ERROR ] 2021-04-18T13:18:22+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize language server at  file:///home/voreny/projects/personal/supreme-trobot\n"
[ ERROR ] 2021-04-18T13:18:22+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:18:22+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot\n"
[ ERROR ] 2021-04-18T13:18:22+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Loaded config at  /home/voreny/projects/personal/supreme-trobot/svelte.config.js\n"
[ ERROR ] 2021-04-18T13:18:22+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 26\nSvelte files: 0\nFrom node_modules: 0\nTotal: 26\n"
[ ERROR ] 2021-04-18T13:18:23+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Using Svelte v3.37.0 from /home/voreny/projects/personal/supreme-trobot/node_modules/svelte/compiler\n"
[ ERROR ] 2021-04-18T13:18:26+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Using Svelte v3.37.0 from /home/voreny/projects/personal/supreme-trobot/node_modules/svelte/compiler\n"
[ ERROR ] 2021-04-18T13:18:26+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/node_modules/big-integer/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:18:26+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot/node_modules/big-integer\n"
[ ERROR ] 2021-04-18T13:18:26+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 7\nSvelte files: 0\nFrom node_modules: 7\nTotal: 7\n"
[ ERROR ] 2021-04-18T13:18:26+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/node_modules/chrome-launcher/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:18:26+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot/node_modules/chrome-launcher\n"
[ ERROR ] 2021-04-18T13:18:26+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 0\nSvelte files: 0\nFrom node_modules: 0\nTotal: 0\n"
[ ERROR ] 2021-04-18T13:18:29+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/node_modules/dotenv/types/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:18:29+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot/node_modules/dotenv/types\n"
[ ERROR ] 2021-04-18T13:18:29+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 4\nSvelte files: 0\nFrom node_modules: 4\nTotal: 4\n"
[ ERROR ] 2021-04-18T13:18:29+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/node_modules/fastq/test/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:18:29+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot/node_modules/fastq/test\n"
[ ERROR ] 2021-04-18T13:18:29+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 4\nSvelte files: 0\nFrom node_modules: 4\nTotal: 4\n"
[ ERROR ] 2021-04-18T13:18:29+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/node_modules/rxjs/src/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:18:29+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot/node_modules/rxjs/src\n"
[ ERROR ] 2021-04-18T13:18:30+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 681\nSvelte files: 0\nFrom node_modules: 681\nTotal: 681\n"
[ ERROR ] 2021-04-18T13:18:31+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/node_modules/@nodelib/fs.scandir/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:18:31+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot/node_modules/@nodelib/fs.scandir\n"
[ ERROR ] 2021-04-18T13:18:31+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 26\nSvelte files: 0\nFrom node_modules: 0\nTotal: 26\n"
[ ERROR ] 2021-04-18T13:18:31+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/node_modules/@nodelib/fs.stat/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:18:31+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot/node_modules/@nodelib/fs.stat\n"
[ ERROR ] 2021-04-18T13:18:31+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 26\nSvelte files: 0\nFrom node_modules: 0\nTotal: 26\n"
[ ERROR ] 2021-04-18T13:18:31+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/node_modules/@nodelib/fs.walk/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:18:31+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot/node_modules/@nodelib/fs.walk\n"
[ ERROR ] 2021-04-18T13:18:31+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 26\nSvelte files: 0\nFrom node_modules: 0\nTotal: 26\n"
[ ERROR ] 2021-04-18T13:19:15+0200 ] ...nt_nvimq7tYKQ/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "stylelint-lsp" "stderr"        "internal/modules/cjs/loader.js:883\n  throw err;\n  ^\n\nError: Cannot find module 'tslib'\nRequire stack:\n- /home/voreny/.nvm/versions/node/v14.15.0/lib/node_modules/stylelint-lsp/dist/index.js\n    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)\n    at Function.Module._load (internal/modules/cjs/loader.js:725:27)\n    at Module.require (internal/modules/cjs/loader.js:952:19)\n    at require (internal/modules/cjs/helpers.js:88:18)\n    at Object.<anonymous> (/home/voreny/.nvm/versions/node/v14.15.0/lib/node_modules/stylelint-lsp/dist/index.js:4:17)\n    at Module._compile (internal/modules/cjs/loader.js:1063:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)\n    at Module.load (internal/modules/cjs/loader.js:928:32)\n    at Function.Module._load (internal/modules/cjs/loader.js:769:14)\n    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12) {\n  code: 'MODULE_NOT_FOUND',\n  requireStack: [\n    '/home/voreny/.nvm/versions/node/v14.15.0/lib/node_modules/stylelint-lsp/dist/index.js'\n  ]\n}\n"
[ ERROR ] 2021-04-18T13:19:28+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "\n<--- Last few GCs --->\n\n[303014:0x4fd39d0]    63589 ms: Mark-sweep (reduce) 2044.5 (2054.3) -> 2043.8 (2054.8) MB, 879.4 / 0.1 ms  (average mu = 0.104, current mu = 0.009) allocation failure scavenge might not succeed\n[303014:0x4fd39d0]    64830 ms: Mark-sweep (reduce) 2044.9 (2051.8) -> 2044.0 (2052.8) MB, 1234.1 / 0.1 ms  (average mu = 0.049, current mu = 0.006) allocation failure scavenge might not succeed\n\n\n<--- JS stacktrace --->\n\nFATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory\n"
[ ERROR ] 2021-04-18T13:19:28+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        " 1: 0xa03530 node::Abort() [node]\n"
[ ERROR ] 2021-04-18T13:19:28+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        " 2: 0x94e471 node::FatalError(char const*, char const*) [node]\n"
[ ERROR ] 2021-04-18T13:19:28+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        " 3: 0xb7773e v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [node]\n"
[ ERROR ] 2021-04-18T13:19:28+0200 ] ...nt_nvimzcvtFx/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        " 4: 0xb77ab7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [node]\n"
```

</details>

Some debugging later, I found out that I was using the `FallbackWatcher`:

https://github.com/Gelio/language-tools/blob/597cafeaebb30348b787b52bdac61e17ae34f674/packages/language-server/src/server.ts#L103-L105

which in turn used `chokidar` to watch the whole workspace. AFAIK chokidar does not ignore any directories by default, so it rightfully went over all of `node_modules`, which ended up initializing multiple unnecessary TS servers

https://github.com/Gelio/language-tools/blob/597cafeaebb30348b787b52bdac61e17ae34f674/packages/language-server/src/plugins/typescript/service.ts#L55

With this change, the logs are more reasonable and I am able to use the language server, with the only TS server being initialized for my own project.

<details>
<summary>Logs</summary>

```
[ START ] 2021-04-18T13:51:37+0200 ] LSP logging initiated
[ ERROR ] 2021-04-18T13:51:38+0200 ] ...nt_nvim3XcrQN/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize language server at  file:///home/voreny/projects/personal/supreme-trobot\n"
[ ERROR ] 2021-04-18T13:51:38+0200 ] ...nt_nvim3XcrQN/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Initialize new ts service at  /home/voreny/projects/personal/supreme-trobot/tsconfig.json\n"
[ ERROR ] 2021-04-18T13:51:38+0200 ] ...nt_nvim3XcrQN/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Trying to load configs for /home/voreny/projects/personal/supreme-trobot\n"
[ ERROR ] 2021-04-18T13:51:38+0200 ] ...nt_nvim3XcrQN/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Loaded config at  /home/voreny/projects/personal/supreme-trobot/svelte.config.js\n"
[ ERROR ] 2021-04-18T13:51:38+0200 ] ...nt_nvim3XcrQN/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "SnapshotManager File Statistics:\nProject files: 26\nSvelte files: 0\nFrom node_modules: 0\nTotal: 26\n"
[ ERROR ] 2021-04-18T13:51:39+0200 ] ...nt_nvim3XcrQN/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Using Svelte v3.37.0 from /home/voreny/projects/personal/supreme-trobot/node_modules/svelte/compiler\n"
[ ERROR ] 2021-04-18T13:51:42+0200 ] ...nt_nvim3XcrQN/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:457 ]  "rpc"   "svelteserver"  "stderr"        "Using Svelte v3.37.0 from /home/voreny/projects/personal/supreme-trobot/node_modules/svelte/compiler\n"
```

</details>

I assume the problem was not found before since the `FallbackWatcher` was not used extensively, as I assume when using the language server from within VSCode, it leverages VSCode's watcher, which ignored directories such as `node_modules`, `.git`, etc.