### PR TITLE
(perf) Optimize fallback watcher

### DIFF
--- a/packages/language-server/src/lib/FallbackWatcher.ts
+++ b/packages/language-server/src/lib/FallbackWatcher.ts
@@ -18,7 +18,12 @@ export class FallbackWatcher {
                     gitOrNodeModules.test(path) &&
                     // Handle Sapper's alias mapping
                     !path.includes('src/node_modules') &&
-                    !path.includes('src\\node_modules')
+                    !path.includes('src\\node_modules'),
+
+                // typescript would scan the project files on init.
+                // We only need to know what got updated.
+                ignoreInitial: true,
+                ignorePermissionErrors: true
             }
         );
 

--- a/packages/language-server/src/lib/FallbackWatcher.ts
+++ b/packages/language-server/src/lib/FallbackWatcher.ts
@@ -1,7 +1,8 @@
 import { FSWatcher, watch } from 'chokidar';
+import { debounce } from 'lodash';
 import { join } from 'path';
 import { DidChangeWatchedFilesParams, FileChangeType, FileEvent } from 'vscode-languageserver';
-import { debounceSameArg, pathToUrl } from '../utils';
+import { pathToUrl } from '../utils';
 
 type DidChangeHandler = (para: DidChangeWatchedFilesParams) => void;
 
@@ -51,18 +52,14 @@ export class FallbackWatcher {
         this.scheduleTrigger();
     }
 
-    private readonly scheduleTrigger = debounceSameArg<void>(
-        () => {
-            const para: DidChangeWatchedFilesParams = {
-                changes: this.undeliveredFileEvents
-            };
-            this.undeliveredFileEvents = [];
+    private readonly scheduleTrigger = debounce(() => {
+        const para: DidChangeWatchedFilesParams = {
+            changes: this.undeliveredFileEvents
+        };
+        this.undeliveredFileEvents = [];
 
-            this.callbacks.forEach((callback) => callback(para));
-        },
-        () => true,
-        DELAY
-    );
+        this.callbacks.forEach((callback) => callback(para));
+    }, DELAY);
 
     onDidChangeWatchedFiles(callback: DidChangeHandler) {
         this.callbacks.push(callback);


### PR DESCRIPTION
One of the reasons for problem #950 and https://github.com/sublimelsp/LSP-svelte/issues/44 encountering is devastating is that the chokidar would trigger an initial event. That causes all the js/ts files to be scanned on startup. Rather than only in `npm i` as I originally thought. 

Even if we are excluding node_modules now. This behavior still needs to be disabled. So we can save all those IO operations on startup. And delay the language service creation when not needed. 

Another change is to denounce the watch file callback. Squashing multiple changes into one. This means fewer update project files call when switching branches or when generated files are written to the file system.