### PR TITLE
fix excluded file got added to snapshot manager

### DIFF
--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -382,10 +382,9 @@ export class TypeScriptPlugin
                 }
             } else if (changeType === FileChangeType.Deleted) {
                 snapshotManager.delete(fileName);
-                return;
+            } else {
+                snapshotManager.updateTsOrJsFile(fileName);
             }
-
-            snapshotManager.updateTsOrJsFile(fileName);
         }
     }
 

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -431,9 +431,9 @@ describe('TypescriptPlugin', () => {
         assert.equal(secondSnapshot, undefined);
     });
 
-    it('should add snapshot when project file added', async () => {
+    const testForOnWatchedFileAdd = async (fileName: string, shouldExist: boolean) => {
         const { snapshotManager, plugin, targetSvelteFile } = await setupForOnWatchedFileChanges();
-        const addFile = path.join(path.dirname(targetSvelteFile), 'foo.ts');
+        const addFile = path.join(path.dirname(targetSvelteFile), fileName);
         const normalizedAddFilePath = normalizeWatchFilePath(addFile);
 
         try {
@@ -447,10 +447,18 @@ describe('TypescriptPlugin', () => {
                 }
             ]);
 
-            assert.equal(snapshotManager.has(normalizedAddFilePath), true);
+            assert.equal(snapshotManager.has(normalizedAddFilePath), shouldExist);
         } finally {
             fs.unlinkSync(addFile);
         }
+    };
+
+    it('should add snapshot when a project file is added', async () => {
+        testForOnWatchedFileAdd('foo.ts', true);
+    });
+
+    it('should not add snapshot when an excluded file is added', async () => {
+        testForOnWatchedFileAdd('dist/index.js', false);
     });
 
     it('should update ts/js file after document change', async () => {

--- a/packages/language-server/test/plugins/typescript/testfiles/tsconfig.json
+++ b/packages/language-server/test/plugins/typescript/testfiles/tsconfig.json
@@ -6,5 +6,9 @@
           because TS does not look up other types.
         */
         "types": ["svelte"]
-    }
+    },
+    "exclude": [
+        /**For testing exclude */
+        "./dist"
+    ]
 }


### PR DESCRIPTION
This fixes the underlying problem for #950 and https://github.com/sublimelsp/LSP-svelte/issues/44. The files are added into snapshot manager no matter if it's updated or added. This caused memory to blow up alongside the problem of the fallback watcher. The fallback watcher is not the actual problem. 