### PR TITLE
(fix) ignore certain diagnostics for pug

### DIFF
--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -72,7 +72,11 @@ function blankIfBlocks(text: string): string {
  * @param source text content to extract tag from
  * @param tag the tag to extract
  */
-function extractTags(text: string, tag: 'script' | 'style', html?: HTMLDocument): TagInformation[] {
+function extractTags(
+    text: string,
+    tag: 'script' | 'style' | 'template',
+    html?: HTMLDocument
+): TagInformation[] {
     text = blankIfBlocks(text);
     const rootNodes = html?.roots || parseHtml(text).roots;
     const matchedNodes = rootNodes
@@ -171,6 +175,16 @@ export function extractStyleTag(source: string, html?: HTMLDocument): TagInforma
 
     // There can only be one style tag
     return styles[0];
+}
+
+export function extractTemplateTag(source: string, html?: HTMLDocument): TagInformation | null {
+    const templates = extractTags(source, 'template', html);
+    if (!templates.length) {
+        return null;
+    }
+
+    // There should only be one style tag
+    return templates[0];
 }
 
 /**

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -871,4 +871,63 @@ describe('DiagnosticsProvider', () => {
             }
         ]);
     });
+
+    it('Pug: Ignores errors in template and unused warnings in script', async () => {
+        const { plugin, document } = setup('diagnostics-pug.svelte');
+        const diagnostics = await plugin.getDiagnostics(document);
+
+        assert.deepStrictEqual(diagnostics, [
+            {
+                code: 2307,
+                message: "Cannot find module '.' or its corresponding type declarations.",
+                range: {
+                    end: {
+                        character: 22,
+                        line: 1
+                    },
+                    start: {
+                        character: 19,
+                        line: 1
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            },
+            {
+                code: 2307,
+                message: "Cannot find module '.' or its corresponding type declarations.",
+                range: {
+                    end: {
+                        character: 30,
+                        line: 2
+                    },
+                    start: {
+                        character: 27,
+                        line: 2
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            },
+            {
+                code: 2322,
+                message: "Type 'boolean' is not assignable to type 'string | number'.",
+                range: {
+                    end: {
+                        character: 10,
+                        line: 4
+                    },
+                    start: {
+                        character: 9,
+                        line: 4
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            }
+        ]);
+    });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/diagnostics-pug.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/diagnostics-pug.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+   import Foo from '.';
+   import { A, B, C } from '.';
+
+   const a: string | number = true;
+</script>
+
+<template lang="pug">
++if('typeof a === "number"')
+  A(a='{a.toFixed(2)}')
+</template>


### PR DESCRIPTION
Ignore all diagnostics inside the template and all unused import-diagnostics in the script
#958