### PR TITLE
more attempt to fix memory issues in sapper workspace

### DIFF
--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -122,3 +122,5 @@ export class SnapshotManager {
         }
     }
 }
+
+export const ignoredBuildDirectories = ['__sapper__', '.svelte'];

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -368,7 +368,7 @@ export class TypeScriptPlugin
 
         for (const { fileName, changeType } of onWatchFileChangesParas) {
             const pathParts = fileName.split(/\/|\\/);
-            const dirPathParts = pathParts.slice(0, pathParts.length);
+            const dirPathParts = pathParts.slice(0, pathParts.length - 1);
             if (ignoredBuildDirectories.some((dir) => dirPathParts.includes(dir))) {
                 continue;
             }

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -5,7 +5,7 @@ import { Logger } from '../../logger';
 import { getPackageInfo } from '../../importPackage';
 import { DocumentSnapshot } from './DocumentSnapshot';
 import { createSvelteModuleLoader } from './module-loader';
-import { SnapshotManager } from './SnapshotManager';
+import { ignoredBuildDirectories, SnapshotManager } from './SnapshotManager';
 import { ensureRealSvelteFilePath, findTsConfigPath } from './utils';
 import { configLoader } from '../../lib/documents/configLoader';
 
@@ -269,6 +269,6 @@ async function createLanguageService(
     }
 
     function getDefaultExclude() {
-        return ['__sapper__', 'node_modules'];
+        return ['node_modules', ...ignoredBuildDirectories];
     }
 }


### PR DESCRIPTION
#965 
Haven't done the gitignore part. That can be done in another PR. 
#956 only fix files being added. But if the added files got updated they would still be loaded into snapshot manager. This fixes this issue. Also ignore `__sapper__` and `.svelte` directories completely in the `onWatchFileChanges`