### PR TITLE
(fix) update document logic

### DIFF
--- a/packages/language-server/src/lib/documents/Document.ts
+++ b/packages/language-server/src/lib/documents/Document.ts
@@ -51,7 +51,6 @@ export class Document extends WritableDocument {
         if (config && !config.loadConfigError) {
             update(config);
         } else {
-            this.configPromise = configLoader.awaitConfig(this.getFilePath() || '');
             update(undefined);
             this.configPromise.then((c) => update(c));
         }

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -86,7 +86,7 @@ export class LSAndTSDocResolver {
     async getSnapshot(pathOrDoc: string | Document) {
         const filePath = typeof pathOrDoc === 'string' ? pathOrDoc : pathOrDoc.getFilePath() || '';
         const tsService = await this.getTSService(filePath);
-        return tsService.updateDocument(pathOrDoc);
+        return tsService.updateSnapshot(pathOrDoc);
     }
 
     async updateSnapshotPath(oldPath: string, newPath: string): Promise<DocumentSnapshot> {
@@ -95,7 +95,7 @@ export class LSAndTSDocResolver {
     }
 
     async deleteSnapshot(filePath: string) {
-        (await this.getTSService(filePath)).deleteDocument(filePath);
+        (await this.getTSService(filePath)).deleteSnapshot(filePath);
         this.docManager.releaseDocument(pathToUrl(filePath));
     }
 


### PR DESCRIPTION
Due to the refactoring in #917, documents were reread from disk every time when getting a snapshot. This resulted in worse performance and introduced inconsistencies because "openDocument" of the DocumentManager was called over and over again with potentially outdated content, resulting in buggy, seemingly random behavior.
This fix reverts that part of #917 which was accidentally introduced and only loads documents from disk if a snapshot doesn't already exist.

#970