### PR TITLE
Add mappings generation to svelte2tsx repl

### DIFF
--- a/packages/svelte2tsx/repl/index.svelte
+++ b/packages/svelte2tsx/repl/index.svelte
@@ -1,0 +1,7 @@
+<script>
+    export let value;
+</script>
+
+{#if value}
+    <input bind:value on:change />
+{/if}

--- a/packages/svelte2tsx/rollup.config.js
+++ b/packages/svelte2tsx/rollup.config.js
@@ -72,8 +72,17 @@ export default [
     {
         input: 'src/index.ts',
         output: [
-            { exports: 'auto', file: 'index.js', format: 'commonjs', sourcemap: true },
-            { exports: 'auto', file: 'index.mjs', format: 'esm' }
+            {
+                exports: 'auto',
+                sourcemap: true,
+                format: 'commonjs',
+                file: 'index.js'
+            },
+            {
+                exports: 'auto',
+                file: 'index.mjs',
+                format: 'esm'
+            }
         ],
         plugins: [
             resolve({ browser: false, preferBuiltins: true }),


### PR DESCRIPTION
<img width="112" alt="Code_2021-04-27_22-53-19" src="https://user-images.githubusercontent.com/30108880/116311751-e2b9b680-a7ab-11eb-85b7-6fda7c09fcc3.png">

+ Added `output/mappings.jsx`, it uses the same process as `test/sourcemaps`
+ Added `output/code.tsx.map`, it can be uploaded in conjunction with `code.tsx` to [visualization tools](https://evanw.github.io/source-map-visualization/)
+ Added try catch to print error in output instead of exiting process
+ Added some default to `repl/index.svelte`
+ Added `exports: 'auto'` to options so rollup stops complaining each rebuild