### PR TITLE
Svelte2tsx Fix SourceMapping range endings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,8 +17,9 @@ module.exports = {
         'import/no-cycle': 'off',
         'import/no-unused-modules': 'off',
         'import/no-deprecated': 'off',
+		// handled by prettier
+        'max-len': 'off',
         // project-specific settings
-        'max-len': ['error', { code: 100, ignoreComments: true, ignoreStrings: true }],
         'no-trailing-spaces': 'error',
         'one-var': ['error', 'never'],
         '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
         'import/no-cycle': 'off',
         'import/no-unused-modules': 'off',
         'import/no-deprecated': 'off',
-		// handled by prettier
+        // handled by prettier
         'max-len': 'off',
         // project-specific settings
         'no-trailing-spaces': 'error',

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/action-directive.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/action-directive.ts
@@ -18,7 +18,7 @@ export function handleActionDirective(
         subset.edit`{...__sveltets_ensureAction(${action}(__sveltets_mapElementTag('${parent.name}')))}`;
     } else {
         // prettier-ignore
-        const [action, expression] = subset.deconstruct`use:${attr.name}=["']?{${attr.expression}}["']"?`;
+        const [action, expression] = subset.deconstruct`use:${attr.name}=["']?{${attr.expression}}["']?`;
         subset.edit`{...__sveltets_ensureAction(${action}(__sveltets_mapElementTag('${parent.name}'),(${expression})))}`;
     }
 }

--- a/packages/svelte2tsx/src/htmlxtojsx/utils/node-utils.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/utils/node-utils.ts
@@ -288,9 +288,7 @@ export function handle_subset(str: MagicString, fullnode: BaseNode) {
         }
         const tail = strings[nodes.length];
         if (tail) {
-            //if (start !== fullnode.end || tail !== str.slice(start, fullnode.end)) {
-            const offset = start === fullnode.end - 1 ? 2 : 1;
-            str.overwrite(start, fullnode.end + offset, tail + str.original.charAt(fullnode.end));
+            str.overwrite(start, fullnode.end + 1, tail + str.original.charAt(fullnode.end));
         }
     }
     return { deconstruct, edit };

--- a/packages/svelte2tsx/src/htmlxtojsx/utils/node-utils.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/utils/node-utils.ts
@@ -246,7 +246,7 @@ export function handle_subset(str: MagicString, fullnode: BaseNode) {
         return `\n  ${pre}${post}` + `\n  ${pre.replace(/./g, ' ')}^`;
     }
 
-    function* deconstruct(patterns: TemplateStringsArray, ...nodes: (Range | string)[]) {
+    function* deconstruct(patterns: TemplateStringsArray, ...nodes: Array<Range | string>) {
         let start = fullnode.start;
         for (let i = 0; i < patterns.length; i++) {
             const pattern = patterns.raw[i];
@@ -264,7 +264,7 @@ export function handle_subset(str: MagicString, fullnode: BaseNode) {
         }
     }
 
-    function edit(strings: TemplateStringsArray, ...nodes: (Range | string)[]) {
+    function edit(strings: TemplateStringsArray, ...nodes: Array<Range | string>) {
         let start = fullnode.start;
         strings = { ...strings };
         for (let i = 0; i < nodes.length; i++) {


### PR DESCRIPTION
_As requested by @dummdidumm, this PR is currently only a draft "POC" demonstration of the fix on a subset of the codebase (actions)._ 

### Issue

For what I suppose is an unintuitive yet implicit rule of SourceMapping, it appears that looking up the origin of a range (such as an identifier) implies looking up the first character and the character _after_ the last one in the range.

In other words svelte2tsx's sourcemap is wrong whenever the character following a range in tsx does not exactly map to the character following that same range in svelte.

### Example

Input
```svelte
<input use:foo />
```
Output
```tsx
<input•{...__sveltets_ensureAction(foo(__sveltets_mapElementTag('input')))}•/>↲
```
Mapped characters
```tsx
<input•                            foo                                     •/>↲
```
Issue : looking up `foo` returns `fo`
To lookup the original position of `foo`, the vscode language server queries the positions of `f` and `(`
`(` is not mapped, its position falls back to the last mapped character in that line, `o`
In the end, looking up the position of the identifier `foo` resolves into `fo`

### Current workaround

The Svelte language server currently hacks around that issue by monkey patching positions after the fact

https://github.com/sveltejs/language-tools/blob/0ac9826befb647e6f0fafad706efa3752a768979/packages/language-server/src/lib/documents/DocumentMapper.ts#L220-L228

It works but the output is still wrong, meaning that other tools relying on svelte2tsx must monkey patch too. 
Unfortunately the Svelte Typescript Plugin #842 cannot access internal typescript ranges, only individual positions.


### Solution

This issue occurs in many parts of the codebase. MagicString does not provide a solution, and [it's not evident that it would](https://github.com/sveltejs/language-tools/pull/763#issuecomment-766912738), perhaps because that library is focused on strings, and this would require it to process AST Nodes.

This PR introduces tagged template string helpers, kind of similar to `Rich-Harris/code-red`

```ts
const node = handle_subsets(magic_string, svelte_node);

/**
 * New API to deconstruct Svelte AST Nodes
 * 
 * Svelte sometimes only returns snippets as raw strings
 * Those must be first normalized into real Nodes
 */
const [action] = node.deconstruct`use:${attr.name}`;

/** 
 * Note that the strings in between nodes are regular expressions
 * Handy for Svelte quirks such as quoted expressions
 */
const [action, expression] = node.deconstruct`use:${attr.name}=["']?{${attr.expression}}["']?`;

/**
 * New API to edit snippets
 * 
 * Abstract layer above MagicString that handles AST Nodes differently
 * Edits the whole subset, and automatically handles mappings for every ${Node}
 */
node.edit`{...__sveltets_ensureAction(${action}(__sveltets_mapElementTag('${parent.name}')))}`;

/**
 * This PR has the side effect of making svelte2tsx much more concise and readable
 * This 6-line codeblock is nearly all it takes to handle actions now!
 */
node.edit`{...__sveltets_ensureAction(${action}(__sveltets_mapElementTag('${parent.name}'),(${expression})))}`;
```


Here is the output for the above example, notice the character after `foo` in tsx being mapped to the character after `foo` in the original code

<img width="960" alt="Code_2021-04-28_07-10-43" src="https://user-images.githubusercontent.com/30108880/116357574-e6295e00-a7fc-11eb-9cc5-affe36676d1f.png">