### PR TITLE
Don't use `toString`, this could be a RawSourceMap

### DIFF
--- a/packages/language-server/src/plugins/svelte/SvelteDocument.ts
+++ b/packages/language-server/src/plugins/svelte/SvelteDocument.ts
@@ -1,4 +1,4 @@
-import { SourceMapConsumer } from 'source-map';
+import { RawSourceMap, SourceMapConsumer } from 'source-map';
 import { PreprocessorGroup, Processed } from 'svelte/types/compiler/preprocess/types';
 import type { compile } from 'svelte/compiler';
 import { CompileOptions } from 'svelte/types/compiler/interfaces';
@@ -250,7 +250,7 @@ export class SvelteFragmentMapper implements PositionMapper {
             async (parent, processedSingle) =>
                 processedSingle?.map
                     ? new SourceMapDocumentMapper(
-                          await new SourceMapConsumer(processedSingle.map.toString()),
+                          await new SourceMapConsumer(processedSingle.map as string | RawSourceMap),
                           originalDoc.uri,
                           await parent
                       )


### PR DESCRIPTION
This solves #981 - when `toString()` is used on an actual raw source map the receiving end will try to parse the string `[object Object]` as JSON, of course failing miserably.

By removing the `toString` and casting to `string | RawSourceMap` we handle both cases correctly, since the `SourceMapConsumer` is able to handle both the case where we are passing a JSON string and a raw source map object.