### PR TITLE
(fix) more robust source mapper + definition fallback

### DIFF
--- a/packages/typescript-plugin/src/language-service/definition.ts
+++ b/packages/typescript-plugin/src/language-service/definition.ts
@@ -23,11 +23,13 @@ export function decorateGetDefinition(
                         return def;
                     }
 
-                    const textSpan = snapshotManager
+                    let textSpan = snapshotManager
                         .get(def.fileName)
                         ?.getOriginalTextSpan(def.textSpan);
                     if (!textSpan) {
-                        return undefined;
+                        // Unmapped positions are for example the default export.
+                        // Fall back to the start of the file to at least go to the correct file.
+                        textSpan = { start: 0, length: 1 };
                     }
                     return {
                         ...def,

--- a/packages/typescript-plugin/src/source-mapper.ts
+++ b/packages/typescript-plugin/src/source-mapper.ts
@@ -78,7 +78,12 @@ export class SourceMapper {
         }
 
         const closestMatch = binarySearch(lineMap, position.character, 0);
-        const { 2: line, 3: character } = lineMap[closestMatch];
+        const match = lineMap[closestMatch];
+        if (!match) {
+            return { line: -1, character: -1 };
+        }
+
+        const { 2: line, 3: character } = match;
         return { line, character };
     }
 
@@ -90,7 +95,12 @@ export class SourceMapper {
         }
 
         const closestMatch = binarySearch(lineMap, position.character, 0);
-        const { 1: line, 2: character } = lineMap[closestMatch];
+        const match = lineMap[closestMatch];
+        if (!match) {
+            return { line: -1, character: -1 };
+        }
+
+        const { 1: line, 2: character } = match;
         return { line, character };
     }
 


### PR DESCRIPTION
- Check for undefined in source mapper and return -1 if it can't find a match
- fall back to start of file for definitions that can't be mapped