### PR TITLE
Make on:sveltekit:xy events optional

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -714,9 +714,9 @@ declare namespace svelte.JSX {
       readonly online?: Window['navigator']['onLine'];
 
       // Transformed from on:sveltekit:xy
-      'onsveltekit:start': EventHandler<CustomEvent, Window>;
-      'onsveltekit:navigation-start': EventHandler<CustomEvent, Window>;
-      'onsveltekit:navigation-end': EventHandler<CustomEvent, Window>;
+      'onsveltekit:start'?: EventHandler<CustomEvent, Window>;
+      'onsveltekit:navigation-start'?: EventHandler<CustomEvent, Window>;
+      'onsveltekit:navigation-end'?: EventHandler<CustomEvent, Window>;
 
       ondevicelight?: EventHandler<Event, Window>;
       onbeforeinstallprompt?: EventHandler<Event, Window>;


### PR DESCRIPTION
Latest version of svelte2tsx requires `on:sveltekit:xy` events which breaks applications that use `<svelte:window>` without on:sveltekit:xy events.

I have made those events optional.