### PR TITLE
(fix) more robust preprocess source maps

### DIFF
--- a/packages/language-server/src/importPackage.ts
+++ b/packages/language-server/src/importPackage.ts
@@ -26,9 +26,9 @@ export function getPackageInfo(packageName: string, fromPath: string) {
         path: dirname(packageJSONPath),
         version: {
             full: version,
-            major,
-            minor,
-            patch
+            major: Number(major),
+            minor: Number(minor),
+            patch: Number(patch)
         }
     };
 }

--- a/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
@@ -258,6 +258,162 @@ describe('SveltePlugin#getCodeAction', () => {
         });
     });
 
+    describe('It should provide svelte ignore code actions (TypeScript)', () => {
+        const svelteIgnoreCodeAction = 'svelte-ignore-code-action-ts.svelte';
+
+        it('should provide ignore comment', async () => {
+            (
+                await expectCodeActionFor(svelteIgnoreCodeAction, {
+                    diagnostics: [
+                        {
+                            severity: DiagnosticSeverity.Warning,
+                            code: 'a11y-missing-attribute',
+                            range: Range.create(
+                                { line: 7, character: 0 },
+                                { line: 7, character: 6 }
+                            ),
+                            message: '',
+                            source: 'svelte'
+                        }
+                    ]
+                })
+            ).toEqual([
+                {
+                    edit: {
+                        documentChanges: [
+                            {
+                                edits: [
+                                    {
+                                        // eslint-disable-next-line max-len
+                                        newText: `<!-- svelte-ignore a11y-missing-attribute -->${EOL}`,
+                                        range: {
+                                            end: {
+                                                character: 0,
+                                                line: 7
+                                            },
+                                            start: {
+                                                character: 0,
+                                                line: 7
+                                            }
+                                        }
+                                    }
+                                ],
+                                textDocument: {
+                                    uri: getUri(svelteIgnoreCodeAction),
+                                    version: null
+                                }
+                            }
+                        ]
+                    },
+                    title: '(svelte) Disable a11y-missing-attribute for this line',
+                    kind: 'quickfix'
+                }
+            ]);
+        });
+
+        it('should provide ignore comment with indent', async () => {
+            (
+                await expectCodeActionFor(svelteIgnoreCodeAction, {
+                    diagnostics: [
+                        {
+                            severity: DiagnosticSeverity.Warning,
+                            code: 'a11y-missing-attribute',
+                            range: Range.create(
+                                { line: 10, character: 4 },
+                                { line: 10, character: 11 }
+                            ),
+                            message: '',
+                            source: 'svelte'
+                        }
+                    ]
+                })
+            ).toEqual([
+                {
+                    edit: {
+                        documentChanges: [
+                            {
+                                edits: [
+                                    {
+                                        newText: `${' '.repeat(
+                                            4
+                                        )}<!-- svelte-ignore a11y-missing-attribute -->${EOL}`,
+                                        range: {
+                                            end: {
+                                                character: 0,
+                                                line: 10
+                                            },
+                                            start: {
+                                                character: 0,
+                                                line: 10
+                                            }
+                                        }
+                                    }
+                                ],
+                                textDocument: {
+                                    uri: getUri(svelteIgnoreCodeAction),
+                                    version: null
+                                }
+                            }
+                        ]
+                    },
+                    title: '(svelte) Disable a11y-missing-attribute for this line',
+                    kind: 'quickfix'
+                }
+            ]);
+        });
+
+        it('should provide ignore comment with indent of parent tag', async () => {
+            (
+                await expectCodeActionFor(svelteIgnoreCodeAction, {
+                    diagnostics: [
+                        {
+                            severity: DiagnosticSeverity.Warning,
+                            code: 'a11y-invalid-attribute',
+                            range: Range.create(
+                                { line: 13, character: 8 },
+                                { line: 13, character: 15 }
+                            ),
+                            message: '',
+                            source: 'svelte'
+                        }
+                    ]
+                })
+            ).toEqual([
+                {
+                    edit: {
+                        documentChanges: [
+                            {
+                                edits: [
+                                    {
+                                        newText: `${' '.repeat(
+                                            4
+                                        )}<!-- svelte-ignore a11y-invalid-attribute -->${EOL}`,
+                                        range: {
+                                            end: {
+                                                character: 0,
+                                                line: 12
+                                            },
+                                            start: {
+                                                character: 0,
+                                                line: 12
+                                            }
+                                        }
+                                    }
+                                ],
+                                textDocument: {
+                                    uri: getUri(svelteIgnoreCodeAction),
+                                    version: null
+                                }
+                            }
+                        ]
+                    },
+                    title: '(svelte) Disable a11y-invalid-attribute for this line',
+                    kind: 'quickfix'
+                }
+            ]);
+        });
+    });
+
     describe('#extractComponent', async () => {
         const scriptContent = `<script>
         const bla = true;

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -425,13 +425,13 @@ describe('SveltePlugin#getDiagnostics', () => {
                 message:
                     "Component has unused export property 'unused1'. If it is for external reference only, please consider using `export const unused1`",
                 range: {
-                    end: {
-                        line: 4,
-                        character: 18
-                    },
                     start: {
-                        line: 4,
-                        character: 18
+                        line: 5,
+                        character: 13
+                    },
+                    end: {
+                        line: 5,
+                        character: 27
                     }
                 },
                 severity: 2,
@@ -442,13 +442,13 @@ describe('SveltePlugin#getDiagnostics', () => {
                 message:
                     "Component has unused export property 'unused2'. If it is for external reference only, please consider using `export const unused2`",
                 range: {
-                    end: {
-                        line: 6,
-                        character: 28
-                    },
                     start: {
                         line: 6,
-                        character: 8
+                        character: 13
+                    },
+                    end: {
+                        line: 6,
+                        character: 27
                     }
                 },
                 severity: 2,

--- a/packages/language-server/test/plugins/svelte/testfiles/svelte-ignore-code-action-ts.svelte
+++ b/packages/language-server/test/plugins/svelte/testfiles/svelte-ignore-code-action-ts.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    interface A {
+        b: boolean;
+    }
+    const a: A = { b: true };
+</script>
+
+<img>
+
+{#if true}
+    <a></a>
+
+    <a
+        href=""
+    >about</a>
+{/if}


### PR DESCRIPTION
In recent Svelte versions, preprocessing also returns a source map. If the user's version is high enough, use that instead of our own (now deprecated) logic. This provides more robust source mapping.
#934