### PR TITLE
(fix) better css error diagnostics

### DIFF
--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -144,7 +144,7 @@ function getStyleErrorDiagnostics(error: any, document: Document): Diagnostic[] 
     // Error could be from another file that was mixed into the Svelte file as part of preprocessing.
     // Some preprocessors set the file property from which we can infer that
     const isErrorFromOtherFile =
-        typeof error.file === 'string' &&
+        typeof error?.file === 'string' &&
         getLastPartOfPath(error.file) !== getLastPartOfPath(document.getFilePath() || '');
 
     return [

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -26,6 +26,14 @@ export function normalizeUri(uri: string): string {
     return URI.parse(uri).toString();
 }
 
+/**
+ * Given a path like foo/bar or foo/bar.svelte , returns its last path
+ * (bar or bar.svelte in this example).
+ */
+export function getLastPartOfPath(path: string): string {
+    return path.replace(/\\/g, '/').split('/').pop() || '';
+}
+
 export function flatten<T>(arr: T[][]): T[] {
     return arr.reduce((all, item) => [...all, ...item], []);
 }


### PR DESCRIPTION
- Place error at start of script if coming from another file (#976)
- Add preprocessing wrapping for new TranspiledSvelteDocument for better error messages