### PR TITLE
(feat) load all Svelte files on startup

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -228,7 +228,16 @@ async function createLanguageService(
             forcedCompilerOptions,
             tsconfigPath,
             undefined,
-            [{ extension: 'svelte', isMixedContent: false, scriptKind: ts.ScriptKind.TSX }]
+            [
+                {
+                    extension: 'svelte',
+                    isMixedContent: true,
+                    // Deferred was added in a later TS version, fall back to tsx
+                    // If Deferred exists, this means that all Svelte files are included
+                    // in parsedConfig.fileNames
+                    scriptKind: ts.ScriptKind.Deferred ?? ts.ScriptKind.TSX
+                }
+            ]
         );
 
         const compilerOptions: ts.CompilerOptions = {

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -606,12 +606,12 @@ describe.only('CompletionProviderImpl', () => {
             item!
         );
 
-        assert.strictEqual(detail, 'Auto import from ./imported-file.svelte\nclass ImportedFile');
+        assert.strictEqual(detail, 'Auto import from ../imported-file.svelte\nclass ImportedFile');
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),
             // " instead of ' because VSCode uses " by default when there are no other imports indicating otherwise
-            `${newLine}import ImportedFile from "./imported-file.svelte";${newLine}`
+            `${newLine}import ImportedFile from "../imported-file.svelte";${newLine}`
         );
 
         assert.deepEqual(
@@ -641,12 +641,12 @@ describe.only('CompletionProviderImpl', () => {
             item!
         );
 
-        assert.strictEqual(detail, 'Auto import from ./imported-file.svelte\nclass ImportedFile');
+        assert.strictEqual(detail, 'Auto import from ../imported-file.svelte\nclass ImportedFile');
 
         assert.strictEqual(
             harmonizeNewLines(additionalTextEdits![0]?.newText),
             // " instead of ' because VSCode uses " by default when there are no other imports indicating otherwise
-            `<script>${newLine}import ImportedFile from "./imported-file.svelte";` +
+            `<script>${newLine}import ImportedFile from "../imported-file.svelte";` +
                 `${newLine}${newLine}</script>${newLine}`
         );
 


### PR DESCRIPTION
Change the ScriptKind to Deferred which means that the tsconfig loader is able to also determine all Svelte files that are part of the tsconfig. This should ensure slightly better startup times and also make it possible to import Svelte files which are referenced nowhere else yet.