### PR TITLE
(perf) also cache unresolved modules

### DIFF
--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -105,6 +105,9 @@ export class LSAndTSDocResolver {
         this.docManager.releaseDocument(pathToUrl(filePath));
     }
 
+    /**
+     * @internal Public for tests only
+     */
     async getSnapshotManager(filePath: string): Promise<SnapshotManager> {
         return (await this.getTSService(filePath)).snapshotManager;
     }

--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -8,6 +8,9 @@ export interface TsFilesSpec {
     exclude?: readonly string[];
 }
 
+/**
+ * Should only be used by `service.ts`
+ */
 export class SnapshotManager {
     private documents: Map<string, DocumentSnapshot> = new Map();
     private lastLogged = new Date(new Date().getTime() - 60_001);

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -11,22 +11,27 @@ import { createSvelteSys } from './svelte-sys';
  * Caches resolved modules.
  */
 class ModuleResolutionCache {
-    private cache = new Map<string, ts.ResolvedModule>();
+    private cache = new Map<string, ts.ResolvedModule | undefined>();
 
     /**
      * Tries to get a cached module.
+     * Careful: `undefined` can mean either there's no match found, or that the result resolved to `undefined`.
      */
     get(moduleName: string, containingFile: string): ts.ResolvedModule | undefined {
         return this.cache.get(this.getKey(moduleName, containingFile));
     }
 
     /**
-     * Caches resolved module, if it is not undefined.
+     * Checks if has cached module.
+     */
+    has(moduleName: string, containingFile: string): boolean {
+        return this.cache.has(this.getKey(moduleName, containingFile));
+    }
+
+    /**
+     * Caches resolved module (or undefined).
      */
     set(moduleName: string, containingFile: string, resolvedModule: ts.ResolvedModule | undefined) {
-        if (!resolvedModule) {
-            return;
-        }
         this.cache.set(this.getKey(moduleName, containingFile), resolvedModule);
     }
 
@@ -36,7 +41,18 @@ class ModuleResolutionCache {
      */
     delete(resolvedModuleName: string): void {
         this.cache.forEach((val, key) => {
-            if (val.resolvedFileName === resolvedModuleName) {
+            if (val?.resolvedFileName === resolvedModuleName) {
+                this.cache.delete(key);
+            }
+        });
+    }
+
+    /**
+     * Deletes everything from cache that resolved to `undefined`
+     */
+    deleteUnresolvedResolutionsFromCache(): void {
+        this.cache.forEach((val, key) => {
+            if (!val) {
                 this.cache.delete(key);
             }
         });
@@ -71,6 +87,8 @@ export function createSvelteModuleLoader(
         readFile: svelteSys.readFile,
         readDirectory: svelteSys.readDirectory,
         deleteFromModuleCache: (path: string) => moduleCache.delete(path),
+        deleteUnresolvedResolutionsFromCache: () =>
+            moduleCache.deleteUnresolvedResolutionsFromCache(),
         resolveModuleNames
     };
 
@@ -79,9 +97,8 @@ export function createSvelteModuleLoader(
         containingFile: string
     ): Array<ts.ResolvedModule | undefined> {
         return moduleNames.map((moduleName) => {
-            const cachedModule = moduleCache.get(moduleName, containingFile);
-            if (cachedModule) {
-                return cachedModule;
+            if (moduleCache.has(moduleName, containingFile)) {
+                return moduleCache.get(moduleName, containingFile);
             }
 
             const resolvedModule = resolveModuleName(moduleName, containingFile);

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -168,7 +168,7 @@ async function createLanguageService(
         }
 
         if (!prevSnapshot) {
-            svelteModuleLoader.deleteUnresolvedResolutionsFromCache();
+            svelteModuleLoader.deleteUnresolvedResolutionsFromCache(filePath);
         }
 
         const newSnapshot = DocumentSnapshot.fromDocument(document, transformationConfig);
@@ -189,7 +189,7 @@ async function createLanguageService(
             return prevSnapshot;
         }
 
-        svelteModuleLoader.deleteUnresolvedResolutionsFromCache();
+        svelteModuleLoader.deleteUnresolvedResolutionsFromCache(filePath);
         const newSnapshot = DocumentSnapshot.fromFilePath(
             filePath,
             docContext.createDocument,
@@ -207,7 +207,7 @@ async function createLanguageService(
             return doc;
         }
 
-        svelteModuleLoader.deleteUnresolvedResolutionsFromCache();
+        svelteModuleLoader.deleteUnresolvedResolutionsFromCache(fileName);
         doc = DocumentSnapshot.fromFilePath(
             fileName,
             docContext.createDocument,
@@ -231,7 +231,7 @@ async function createLanguageService(
 
     function updateTsOrJsFile(fileName: string, changes?: TextDocumentContentChangeEvent[]): void {
         if (!snapshotManager.has(fileName)) {
-            svelteModuleLoader.deleteUnresolvedResolutionsFromCache();
+            svelteModuleLoader.deleteUnresolvedResolutionsFromCache(fileName);
         }
         snapshotManager.updateTsOrJsFile(fileName, changes);
     }

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -1,21 +1,32 @@
 import { dirname, resolve } from 'path';
 import ts from 'typescript';
-import { Document } from '../../lib/documents';
-import { Logger } from '../../logger';
+import { TextDocumentContentChangeEvent } from 'vscode-languageserver-protocol';
 import { getPackageInfo } from '../../importPackage';
+import { Document } from '../../lib/documents';
+import { configLoader } from '../../lib/documents/configLoader';
+import { Logger } from '../../logger';
 import { DocumentSnapshot } from './DocumentSnapshot';
 import { createSvelteModuleLoader } from './module-loader';
 import { ignoredBuildDirectories, SnapshotManager } from './SnapshotManager';
 import { ensureRealSvelteFilePath, findTsConfigPath } from './utils';
-import { configLoader } from '../../lib/documents/configLoader';
 
 export interface LanguageServiceContainer {
     readonly tsconfigPath: string;
     readonly compilerOptions: ts.CompilerOptions;
+    /**
+     * @internal Public for tests only
+     */
     readonly snapshotManager: SnapshotManager;
     getService(): ts.LanguageService;
     updateSnapshot(documentOrFilePath: Document | string): DocumentSnapshot;
     deleteSnapshot(filePath: string): void;
+    updateProjectFiles(): void;
+    updateTsOrJsFile(fileName: string, changes?: TextDocumentContentChangeEvent[]): void;
+    /**
+     * Checks if a file is present in the project.
+     * Unlike `fileBelongsToProject`, this doesn't run a file search on disk.
+     */
+    hasFile(filePath: string): boolean;
     /**
      * Careful, don't call often, or it will hurt performance.
      * Only works for TS versions that have ScriptKind.Deferred
@@ -131,6 +142,9 @@ async function createLanguageService(
         getService: () => languageService,
         updateSnapshot,
         deleteSnapshot,
+        updateProjectFiles,
+        updateTsOrJsFile,
+        hasFile,
         fileBelongsToProject,
         snapshotManager
     };
@@ -153,6 +167,10 @@ async function createLanguageService(
             return prevSnapshot;
         }
 
+        if (!prevSnapshot) {
+            svelteModuleLoader.deleteUnresolvedResolutionsFromCache();
+        }
+
         const newSnapshot = DocumentSnapshot.fromDocument(document, transformationConfig);
 
         snapshotManager.set(filePath, newSnapshot);
@@ -171,6 +189,7 @@ async function createLanguageService(
             return prevSnapshot;
         }
 
+        svelteModuleLoader.deleteUnresolvedResolutionsFromCache();
         const newSnapshot = DocumentSnapshot.fromFilePath(
             filePath,
             docContext.createDocument,
@@ -188,6 +207,7 @@ async function createLanguageService(
             return doc;
         }
 
+        svelteModuleLoader.deleteUnresolvedResolutionsFromCache();
         doc = DocumentSnapshot.fromFilePath(
             fileName,
             docContext.createDocument,
@@ -197,8 +217,23 @@ async function createLanguageService(
         return doc;
     }
 
+    function updateProjectFiles(): void {
+        snapshotManager.updateProjectFiles();
+    }
+
+    function hasFile(filePath: string): boolean {
+        return snapshotManager.has(filePath);
+    }
+
     function fileBelongsToProject(filePath: string): boolean {
-        return snapshotManager.has(filePath) || getParsedConfig().fileNames.includes(filePath);
+        return hasFile(filePath) || getParsedConfig().fileNames.includes(filePath);
+    }
+
+    function updateTsOrJsFile(fileName: string, changes?: TextDocumentContentChangeEvent[]): void {
+        if (!snapshotManager.has(fileName)) {
+            svelteModuleLoader.deleteUnresolvedResolutionsFromCache();
+        }
+        snapshotManager.updateTsOrJsFile(fileName, changes);
     }
 
     function getParsedConfig() {

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -30,7 +30,7 @@ const fileNameToAbsoluteUri = (file: string) => {
     return pathToUrl(join(testFilesDir, file));
 };
 
-describe.only('CompletionProviderImpl', () => {
+describe('CompletionProviderImpl', () => {
     function setup(filename: string) {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text)

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/unresolvedimport.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/unresolvedimport.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+  import foo from './doesntexistyet';
+  foo;
+</script>


### PR DESCRIPTION
This change also makes resolveModuleNames return early if the module to be resolved was already tried to be resolved but without success. Now, `undefined` is returned immediately in this case without trying to resolve again. Such unresolved resolutions are deleted whenever a new file is created. This increases performance especially on projects with many unresolved modules.

During this I made sure that `SnapshotManager` is now only called through the service. This also fixes a small bug where a TS/JS file was not removed from the module resolution after it was deleted.