### PR TITLE
bumps typescript to 4.3 and support semantic tokens on js

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "prettier --check . && eslint \"packages/**/*.{ts,js}\""
     },
     "dependencies": {
-        "typescript": "^4.2.2"
+        "typescript": "^4.3.2"
     },
     "devDependencies": {
         "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.2.0",

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -145,7 +145,7 @@ Enable signature help (parameter hints) for JS/TS. _Default_: `true`
 
 ##### `svelte.plugin.typescript.semanticTokens.enable`
 
-Enable semantic tokens (semantic highlight) for TypeScript. Doesn't apply to JavaScript. _Default_: `true`
+Enable semantic tokens (semantic highlight) for TypeScript. _Default_: `true`
 
 ##### `svelte.plugin.css.enable`
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -352,7 +352,8 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             comp.name,
             {},
             comp.source,
-            userPreferences
+            userPreferences,
+            comp.data
         );
 
         if (detail) {
@@ -390,11 +391,11 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
     }
 
     private getCompletionDocument(compDetail: ts.CompletionEntryDetails) {
-        const { source, documentation: tsDocumentation, displayParts, tags } = compDetail;
+        const { sourceDisplay, documentation: tsDocumentation, displayParts, tags } = compDetail;
         let detail: string = this.changeSvelteComponentName(ts.displayPartsToString(displayParts));
 
-        if (source) {
-            const importPath = ts.displayPartsToString(source);
+        if (sourceDisplay) {
+            const importPath = ts.displayPartsToString(sourceDisplay);
             detail = `Auto import from ${importPath}\n${detail}`;
         }
 

--- a/packages/language-server/src/plugins/typescript/previewer.ts
+++ b/packages/language-server/src/plugins/typescript/previewer.ts
@@ -73,19 +73,19 @@ function getTagBodyText(tag: ts.JSDocTagInfo): string | undefined {
 
     switch (tag.name) {
         case 'example':
-            return makeExampleTag(tag.text);
+            return makeExampleTag(ts.displayPartsToString(tag.text));
         case 'author':
-            return makeEmailTag(tag.text);
+            return makeEmailTag(ts.displayPartsToString(tag.text));
         case 'default':
-            return makeCodeblock(tag.text);
+            return makeCodeblock(ts.displayPartsToString(tag.text));
     }
 
-    return processInlineTags(tag.text);
+    return processInlineTags(ts.displayPartsToString(tag.text));
 }
 
 export function getTagDocumentation(tag: ts.JSDocTagInfo): string | undefined {
     function getWithType() {
-        const body = (tag.text || '').split(/^(\S+)\s*-?\s*/);
+        const body = (ts.displayPartsToString(tag.text) || '').split(/^(\S+)\s*-?\s*/);
         if (body?.length === 3) {
             const param = body[1];
             const doc = body[2];

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -269,10 +269,13 @@ describe('CompletionProviderImpl', () => {
         const { data } = completions!.items[0];
 
         assert.deepStrictEqual(data, {
+            data: undefined,
             hasAction: undefined,
             insertText: undefined,
             isPackageJsonImport: undefined,
+            isImportStatementCompletion: undefined,
             isRecommended: undefined,
+            isSnippet: undefined,
             kind: 'method',
             kindModifiers: '',
             name: 'b',
@@ -283,6 +286,7 @@ describe('CompletionProviderImpl', () => {
             replacementSpan: undefined,
             sortText: '1',
             source: undefined,
+            sourceDisplay: undefined,
             uri: fileNameToAbsoluteUri(filename)
         } as CompletionEntryWithIdentifer);
     });

--- a/packages/language-server/test/plugins/typescript/features/SemanticTokensProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/SemanticTokensProvider.test.ts
@@ -47,7 +47,6 @@ describe('SemanticTokensProvider', () => {
         assertResult(data, getTsExpected(/* isFull */ true));
     });
 
-
     it('provides partial semantic token', async () => {
         const { provider, document } = setup(tsFile);
 
@@ -64,28 +63,29 @@ describe('SemanticTokensProvider', () => {
     it('provides semantic token for js', async () => {
         const { provider, document } = setup('jsToken.svelte');
 
-        const { data } = (await provider.getSemanticTokens(
-            document
-        )) ?? {
+        const { data } = (await provider.getSemanticTokens(document)) ?? {
             data: []
         };
 
-        assertResult(data, buildExpected([
-            {
-                character: 4,
-                line: 1,
-                length: 'console'.length,
-                modifiers: [TokenModifier.defaultLibrary],
-                type: TokenType.variable
-            },
-            {
-                character: 12,
-                line: 1,
-                length: 'log'.length,
-                modifiers: [TokenModifier.defaultLibrary],
-                type: TokenType.member
-            }
-        ]));
+        assertResult(
+            data,
+            buildExpected([
+                {
+                    character: 4,
+                    line: 1,
+                    length: 'console'.length,
+                    modifiers: [TokenModifier.defaultLibrary],
+                    type: TokenType.variable
+                },
+                {
+                    character: 12,
+                    line: 1,
+                    length: 'log'.length,
+                    modifiers: [TokenModifier.defaultLibrary],
+                    type: TokenType.member
+                }
+            ])
+        );
     });
 
     it('can cancel semantic token before promise resolved', async () => {

--- a/packages/language-server/test/plugins/typescript/testfiles/semantic-tokens/jsToken.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/semantic-tokens/jsToken.svelte
@@ -1,0 +1,3 @@
+<script>
+    console.log();
+</script>

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -158,7 +158,7 @@
                     "type": "boolean",
                     "default": true,
                     "title": "TypeScript: Semantic Tokens",
-                    "description": "Enable semantic tokens (semantic highlight) for TypeScript. Doesn't apply to JavaScript"
+                    "description": "Enable semantic tokens (semantic highlight) for TypeScript."
                 },
                 "svelte.plugin.css.enable": {
                     "type": "boolean",

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -37,7 +37,7 @@
         "svelte": "~3.38.2",
         "tiny-glob": "^0.2.6",
         "tslib": "^1.10.0",
-        "typescript": "^4.2.2"
+        "typescript": "^4.3.2"
     },
     "peerDependencies": {
         "svelte": "^3.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,10 +2556,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@*, typescript@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
-  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+typescript@*, typescript@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
+  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
typescript allows semantic tokens to run on js in 4.3. Remove the doesn't-applied note.
The [import statement completion](https://devblogs.microsoft.com/typescript/announcing-typescript-4-3/#import-statement-completions) added in typescript 4.3 is a bit more complex. I'll add the support in another PR.