### PR TITLE
(fix) more robust mapping for Svelte diagnostics

### DIFF
--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -45,6 +45,29 @@ export function isInRange(range: Range, positionToTest: Position): boolean {
     );
 }
 
+export function isRangeStartAfterEnd(range: Range): boolean {
+    return (
+        range.end.line < range.start.line ||
+        (range.end.line === range.start.line && range.end.character < range.start.character)
+    );
+}
+
+export function swapRangeStartEndIfNecessary(range: Range): Range {
+    if (isRangeStartAfterEnd(range)) {
+        const start = range.start;
+        range.start = range.end;
+        range.end = start;
+    }
+    return range;
+}
+
+export function moveRangeStartToEndIfNecessary(range: Range): Range {
+    if (isRangeStartAfterEnd(range)) {
+        range.start = range.end;
+    }
+    return range;
+}
+
 export function isBeforeOrEqualToPosition(position: Position, positionToTest: Position): boolean {
     return (
         positionToTest.line < position.line ||


### PR DESCRIPTION
Try to catch some cases of invalid ranges which may cause the LSP to get confused and not update diagnostics anymore
#1019

I couldn't reproduce and there also wasn't able to add a test for this, but I just hope this fixes some of the problems in that issue