### PR TITLE
(fix) normalize paths, deduplicate snapshots

### DIFF
--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -2,6 +2,72 @@ import ts from 'typescript';
 import { DocumentSnapshot, JSOrTSDocumentSnapshot } from './DocumentSnapshot';
 import { Logger } from '../../logger';
 import { TextDocumentContentChangeEvent } from 'vscode-languageserver';
+import { normalizePath } from '../../utils';
+import { EventEmitter } from 'events';
+
+/**
+ * Every snapshot corresponds to a unique file on disk.
+ * A snapshot can be part of multiple projects, but for a given file path
+ * there can be only one snapshot.
+ */
+export class GlobalSnapshotsManager {
+    private emitter = new EventEmitter();
+    private documents = new Map<string, DocumentSnapshot>();
+
+    get(fileName: string) {
+        fileName = normalizePath(fileName);
+        return this.documents.get(fileName);
+    }
+
+    set(fileName: string, document: DocumentSnapshot) {
+        fileName = normalizePath(fileName);
+        const prev = this.get(fileName);
+        if (prev) {
+            prev.destroyFragment();
+        }
+
+        this.documents.set(fileName, document);
+        this.emitter.emit('change', fileName, document);
+    }
+
+    delete(fileName: string) {
+        fileName = normalizePath(fileName);
+        this.documents.delete(fileName);
+        this.emitter.emit('change', fileName, undefined);
+    }
+
+    updateTsOrJsFile(
+        fileName: string,
+        changes?: TextDocumentContentChangeEvent[]
+    ): JSOrTSDocumentSnapshot | undefined {
+        fileName = normalizePath(fileName);
+        const previousSnapshot = this.get(fileName);
+
+        if (changes) {
+            if (!(previousSnapshot instanceof JSOrTSDocumentSnapshot)) {
+                return;
+            }
+            previousSnapshot.update(changes);
+            return previousSnapshot;
+        } else {
+            const newSnapshot = DocumentSnapshot.fromNonSvelteFilePath(fileName);
+
+            if (previousSnapshot) {
+                newSnapshot.version = previousSnapshot.version + 1;
+            } else {
+                // ensure it's greater than initial version
+                // so that ts server picks up the change
+                newSnapshot.version += 1;
+            }
+            this.set(fileName, newSnapshot);
+            return newSnapshot;
+        }
+    }
+
+    onChange(listener: (fileName: string, newDocument: DocumentSnapshot | undefined) => void) {
+        this.emitter.on('change', listener);
+    }
+}
 
 export interface TsFilesSpec {
     include?: readonly string[];
@@ -12,7 +78,7 @@ export interface TsFilesSpec {
  * Should only be used by `service.ts`
  */
 export class SnapshotManager {
-    private documents: Map<string, DocumentSnapshot> = new Map();
+    private documents = new Map<string, DocumentSnapshot>();
     private lastLogged = new Date(new Date().getTime() - 60_001);
 
     private readonly watchExtensions = [
@@ -25,12 +91,26 @@ export class SnapshotManager {
     ];
 
     constructor(
+        private globalSnapshotsManager: GlobalSnapshotsManager,
         private projectFiles: string[],
         private fileSpec: TsFilesSpec,
         private workspaceRoot: string
-    ) {}
+    ) {
+        this.globalSnapshotsManager.onChange((fileName, document) => {
+            // Only delete/update snapshots, don't add new ones,
+            // as they could be from another TS service and this
+            // snapshot manager can't reach this file.
+            // For these, instead wait on a `get` method invocation
+            // and set them "manually" in the set/update methods.
+            if (!document) {
+                this.documents.delete(fileName);
+            } else if (this.documents.has(fileName)) {
+                this.documents.set(fileName, document);
+            }
+        });
+    }
 
-    updateProjectFiles() {
+    updateProjectFiles(): void {
         const { include, exclude } = this.fileSpec;
 
         // Since we default to not include anything,
@@ -39,67 +119,58 @@ export class SnapshotManager {
             return;
         }
 
-        const projectFiles = ts.sys.readDirectory(
-            this.workspaceRoot,
-            this.watchExtensions,
-            exclude,
-            include
-        );
+        const projectFiles = ts.sys
+            .readDirectory(this.workspaceRoot, this.watchExtensions, exclude, include)
+            .map(normalizePath);
 
         this.projectFiles = Array.from(new Set([...this.projectFiles, ...projectFiles]));
     }
 
     updateTsOrJsFile(fileName: string, changes?: TextDocumentContentChangeEvent[]): void {
-        const previousSnapshot = this.get(fileName);
-
-        if (changes) {
-            if (!(previousSnapshot instanceof JSOrTSDocumentSnapshot)) {
-                return;
-            }
-            previousSnapshot.update(changes);
-        } else {
-            const newSnapshot = DocumentSnapshot.fromNonSvelteFilePath(fileName);
-
-            if (previousSnapshot) {
-                newSnapshot.version = previousSnapshot.version + 1;
-            } else {
-                // ensure it's greater than initial version
-                // so that ts server picks up the change
-                newSnapshot.version += 1;
-            }
-            this.set(fileName, newSnapshot);
+        const snapshot = this.globalSnapshotsManager.updateTsOrJsFile(fileName, changes);
+        // This isn't duplicated logic to the listener, because this could
+        // be a new snapshot which the listener wouldn't add.
+        if (snapshot) {
+            this.documents.set(normalizePath(fileName), snapshot);
         }
     }
 
-    has(fileName: string) {
+    has(fileName: string): boolean {
+        fileName = normalizePath(fileName);
         return this.projectFiles.includes(fileName) || this.getFileNames().includes(fileName);
     }
 
-    set(fileName: string, snapshot: DocumentSnapshot) {
-        const prev = this.get(fileName);
-        if (prev) {
-            prev.destroyFragment();
-        }
-
+    set(fileName: string, snapshot: DocumentSnapshot): void {
+        this.globalSnapshotsManager.set(fileName, snapshot);
+        // This isn't duplicated logic to the listener, because this could
+        // be a new snapshot which the listener wouldn't add.
+        this.documents.set(normalizePath(fileName), snapshot);
         this.logStatistics();
-
-        return this.documents.set(fileName, snapshot);
     }
 
-    get(fileName: string) {
-        return this.documents.get(fileName);
+    get(fileName: string): DocumentSnapshot | undefined {
+        fileName = normalizePath(fileName);
+        let snapshot = this.documents.get(fileName);
+        if (!snapshot) {
+            snapshot = this.globalSnapshotsManager.get(fileName);
+            if (snapshot) {
+                this.documents.set(fileName, snapshot);
+            }
+        }
+        return snapshot;
     }
 
-    delete(fileName: string) {
+    delete(fileName: string): void {
+        fileName = normalizePath(fileName);
         this.projectFiles = this.projectFiles.filter((s) => s !== fileName);
-        return this.documents.delete(fileName);
+        this.globalSnapshotsManager.delete(fileName);
     }
 
-    getFileNames() {
+    getFileNames(): string[] {
         return Array.from(this.documents.keys());
     }
 
-    getProjectFileNames() {
+    getProjectFileNames(): string[] {
         return [...this.projectFiles];
     }
 

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -18,6 +18,14 @@ export function pathToUrl(path: string) {
 }
 
 /**
+ * Some paths (on windows) start with a upper case driver letter, some don't.
+ * This is normalized here.
+ */
+export function normalizePath(path: string): string {
+    return urlToPath(pathToUrl(path)) ?? '';
+}
+
+/**
  * URIs coming from the client could be encoded in a different
  * way than expected / than the internal services create them.
  * This normalizes them to be the same as the internally generated ones.

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -1,14 +1,14 @@
 import * as assert from 'assert';
+import fs from 'fs';
 import * as path from 'path';
 import ts from 'typescript';
-import fs from 'fs';
 import { CancellationTokenSource, FileChangeType, Position, Range } from 'vscode-languageserver';
 import { Document, DocumentManager } from '../../../src/lib/documents';
 import { LSConfigManager } from '../../../src/ls-config';
 import { LSAndTSDocResolver, TypeScriptPlugin } from '../../../src/plugins';
 import { INITIAL_VERSION } from '../../../src/plugins/typescript/DocumentSnapshot';
-import { pathToUrl, urlToPath } from '../../../src/utils';
 import { ignoredBuildDirectories } from '../../../src/plugins/typescript/SnapshotManager';
+import { pathToUrl } from '../../../src/utils';
 
 describe('TypescriptPlugin', () => {
     function getUri(filename: string) {
@@ -372,20 +372,10 @@ describe('TypescriptPlugin', () => {
         };
     };
 
-    /**
-     *  make it the same style of path delimiter as vscode's request
-     */
-    const normalizeWatchFilePath = (path: string) => {
-        return urlToPath(pathToUrl(path)) ?? '';
-    };
-
     const setupForOnWatchedFileUpdateOrDelete = async () => {
         const { plugin, snapshotManager, targetSvelteFile } = await setupForOnWatchedFileChanges();
 
-        const projectJsFile = normalizeWatchFilePath(
-            path.join(path.dirname(targetSvelteFile), 'documentation.ts')
-        );
-
+        const projectJsFile = path.join(path.dirname(targetSvelteFile), 'documentation.ts');
         await plugin.onWatchFileChanges([
             {
                 fileName: projectJsFile,
@@ -441,7 +431,6 @@ describe('TypescriptPlugin', () => {
     const testForOnWatchedFileAdd = async (filePath: string, shouldExist: boolean) => {
         const { snapshotManager, plugin, targetSvelteFile } = await setupForOnWatchedFileChanges();
         const addFile = path.join(path.dirname(targetSvelteFile), filePath);
-        const normalizedAddFilePath = normalizeWatchFilePath(addFile);
 
         const dir = path.dirname(addFile);
         if (!fs.existsSync(dir)) {
@@ -451,25 +440,25 @@ describe('TypescriptPlugin', () => {
         assert.ok(fs.existsSync(addFile));
 
         try {
-            assert.equal(snapshotManager.has(normalizedAddFilePath), false);
+            assert.equal(snapshotManager.has(addFile), false);
 
             await plugin.onWatchFileChanges([
                 {
-                    fileName: normalizedAddFilePath,
+                    fileName: addFile,
                     changeType: FileChangeType.Created
                 }
             ]);
 
-            assert.equal(snapshotManager.has(normalizedAddFilePath), shouldExist);
+            assert.equal(snapshotManager.has(addFile), shouldExist);
 
             await plugin.onWatchFileChanges([
                 {
-                    fileName: normalizedAddFilePath,
+                    fileName: addFile,
                     changeType: FileChangeType.Changed
                 }
             ]);
 
-            assert.equal(snapshotManager.has(normalizedAddFilePath), shouldExist);
+            assert.equal(snapshotManager.has(addFile), shouldExist);
         } finally {
             fs.unlinkSync(addFile);
         }

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/different-ts-service.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/different-ts-service.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    import { foo } from './shared-comp.svelte';
+    import { bar } from './shared-ts-file';
+    foo;bar;
+</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/different-ts-service/different-ts-service.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/different-ts-service/different-ts-service.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    import { foo } from '../shared-comp.svelte';
+    import { bar } from '../shared-ts-file';
+    foo;bar;
+</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/different-ts-service/tsconfig.json
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/different-ts-service/tsconfig.json
@@ -1,11 +1,9 @@
 {
     "compilerOptions": {
-        "strict": true,
         /**
           This is actually not needed, but makes the tests faster
           because TS does not look up other types.
         */
         "types": ["svelte"]
-    },
-    "exclude": ["different-ts-service/**"]
+    }
 }

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/shared-comp.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/shared-comp.svelte
@@ -1,0 +1,3 @@
+<script context="module">
+    export const fo;
+</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/shared-ts-file.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/shared-ts-file.ts
@@ -1,0 +1,1 @@
+export function ba() {}


### PR DESCRIPTION
- normalize paths, as it's not guaranteed that they are in the same format coming from different sources
- deduplicate snapshots by introducing a global snapshot manager. A snapshot is unique across all services. If a snapshot is updated, that update should be reflected in all services

#1037