### PR TITLE
(feat) add experimantal support for $$Slots

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -1406,4 +1406,180 @@ describe('DiagnosticsProvider', () => {
             }
         ]);
     });
+
+    it('checks $$Slots usage', async () => {
+        const { plugin, document } = setup('$$slots.svelte');
+        const diagnostics = await plugin.getDiagnostics(document);
+        assert.deepStrictEqual(diagnostics, [
+            {
+                code: 2345,
+                message:
+                    "Argument of type 'boolean' is not assignable to parameter of type 'string'.",
+                range: {
+                    start: {
+                        character: 41,
+                        line: 13
+                    },
+                    end: {
+                        character: 45,
+                        line: 13
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            },
+            {
+                code: 2345,
+                message:
+                    'Argument of type \'"invalidProp1"\' is not assignable to parameter of type \'"valid1" | "validPropWrongType1"\'.',
+                range: {
+                    start: {
+                        character: 60,
+                        line: 13
+                    },
+                    end: {
+                        character: 60,
+                        line: 13
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            },
+            {
+                code: 2345,
+                message:
+                    "Argument of type 'boolean' is not assignable to parameter of type 'string'.",
+                range: {
+                    start: {
+                        character: 52,
+                        line: 14
+                    },
+                    end: {
+                        character: 56,
+                        line: 14
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            },
+            {
+                code: 2345,
+                message:
+                    'Argument of type \'"invalidProp2"\' is not assignable to parameter of type \'"valid2" | "validPropWrongType2"\'.',
+                range: {
+                    start: {
+                        character: 71,
+                        line: 14
+                    },
+                    end: {
+                        character: 71,
+                        line: 14
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            },
+            {
+                code: 2345,
+                message:
+                    "Argument of type '\"invalid\"' is not assignable to parameter of type 'keyof $$Slots'.",
+                range: {
+                    start: {
+                        character: 26,
+                        line: 15
+                    },
+                    end: {
+                        character: 26,
+                        line: 15
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            }
+        ]);
+    });
+
+    it('checks $$Slots component usage', async () => {
+        const { plugin, document } = setup('using-$$slots.svelte');
+        const diagnostics = await plugin.getDiagnostics(document);
+        assert.deepStrictEqual(diagnostics, [
+            {
+                code: 2339,
+                message:
+                    "Property 'invalidProp1' does not exist on type '{ valid1: boolean; validPropWrongType1: string; }'.",
+                range: {
+                    start: {
+                        character: 46,
+                        line: 4
+                    },
+                    end: {
+                        character: 58,
+                        line: 4
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            },
+            {
+                code: 2367,
+                message:
+                    "This condition will always return 'false' since the types 'string' and 'boolean' have no overlap.",
+                range: {
+                    start: {
+                        character: 5,
+                        line: 6
+                    },
+                    end: {
+                        character: 33,
+                        line: 6
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            },
+            {
+                code: 2339,
+                message:
+                    "Property 'invalidProp2' does not exist on type '{ valid2: boolean; validPropWrongType2: string; }'.",
+                range: {
+                    start: {
+                        character: 59,
+                        line: 8
+                    },
+                    end: {
+                        character: 71,
+                        line: 8
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            },
+            {
+                code: 2367,
+                message:
+                    "This condition will always return 'false' since the types 'string' and 'boolean' have no overlap.",
+                range: {
+                    start: {
+                        character: 9,
+                        line: 10
+                    },
+                    end: {
+                        character: 37,
+                        line: 10
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                tags: []
+            }
+        ]);
+    });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/$$slots.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/$$slots.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    interface $$Slots {
+        default: {
+            valid1: boolean;
+            validPropWrongType1: string;
+        },
+        foo: {
+            valid2: boolean;
+            validPropWrongType2: string;
+        }
+    }
+</script>
+
+<slot valid1={true} validPropWrongType1={true} invalidProp1={true} />
+<slot name="foo" valid2={true} validPropWrongType2={true} invalidProp2={true} />
+<slot name="invalid" prop={true} />

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/using-$$slots.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/using-$$slots.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    import Slots from './$$slots.svelte';
+</script>
+
+<Slots let:valid1 let:validPropWrongType1 let:invalidProp1>
+    {valid1 === true}
+    {validPropWrongType1 === true}
+    {invalidProp1}
+    <div slot="foo" let:valid2 let:validPropWrongType2 let:invalidProp2>
+        {valid2 === true}
+        {validPropWrongType2 === true}
+        {invalidProp2}
+    </div>
+</Slots>

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/attribute.ts
@@ -42,6 +42,11 @@ export function handleAttribute(
     parent: BaseNode,
     preserveCase: boolean
 ): void {
+    const shouldApplySlotCheck = parent.type === 'Slot' && attr.name !== 'name';
+    const slotName = shouldApplySlotCheck
+        ? parent.attributes?.find((a: BaseNode) => a.name === 'name')?.value[0]?.data || 'default'
+        : undefined;
+    const ensureSlotStr = `__sveltets_ensureSlot("${slotName}","${attr.name}",`;
     let transformedFromDirectiveOrNamespace = false;
 
     const transformAttributeCase = (name: string) => {
@@ -118,6 +123,10 @@ export function handleAttribute(
             }
 
             str.appendRight(attr.start, `${attrName}=`);
+            if (shouldApplySlotCheck) {
+                str.prependRight(attr.start + 1, ensureSlotStr);
+                str.prependLeft(attr.end - 1, `)`);
+            }
             return;
         }
 
@@ -145,25 +154,37 @@ export function handleAttribute(
                 !isNaN(attrVal.data);
 
             if (needsNumberConversion) {
+                const begin = '{' + (shouldApplySlotCheck ? ensureSlotStr : '');
+                const end = shouldApplySlotCheck ? `)}` : '}';
                 if (needsQuotes) {
-                    str.prependRight(equals + 1, '{');
-                    str.appendLeft(attr.end, '}');
+                    str.prependRight(equals + 1, begin);
+                    str.appendLeft(attr.end, end);
                 } else {
-                    str.overwrite(equals + 1, equals + 2, '{');
-                    str.overwrite(attr.end - 1, attr.end, '}');
+                    str.overwrite(equals + 1, equals + 2, begin);
+                    str.overwrite(attr.end - 1, attr.end, end);
                 }
             } else if (needsQuotes) {
-                str.prependRight(equals + 1, '"');
-                str.appendLeft(attr.end, '"');
+                const begin = shouldApplySlotCheck ? `{${ensureSlotStr}"` : '"';
+                const end = shouldApplySlotCheck ? `")}` : '"';
+                str.prependRight(equals + 1, begin);
+                str.appendLeft(attr.end, end);
+            } else if (shouldApplySlotCheck) {
+                str.prependRight(equals + 1, `{${ensureSlotStr}`);
+                str.appendLeft(attr.end, ')}');
             }
             return;
         }
 
         if (attrVal.type == 'MustacheTag') {
+            const isInQuotes = attrVal.end != attr.end;
             //if the end doesn't line up, we are wrapped in quotes
-            if (attrVal.end != attr.end) {
+            if (isInQuotes) {
                 str.remove(attrVal.start - 1, attrVal.start);
                 str.remove(attr.end - 1, attr.end);
+            }
+            if (shouldApplySlotCheck) {
+                str.prependRight(attrVal.start + 1, ensureSlotStr);
+                str.appendLeft(attr.end - (isInQuotes ? 2 : 1), ')');
             }
             return;
         }
@@ -171,7 +192,13 @@ export function handleAttribute(
     }
 
     // We have multiple attribute values, so we build a template string out of them.
-    buildTemplateString(attr, str, htmlx, '={`', '`}');
+    buildTemplateString(
+        attr,
+        str,
+        htmlx,
+        shouldApplySlotCheck ? `={${ensureSlotStr}\`` : '={`',
+        shouldApplySlotCheck ? '`)}' : '`}'
+    );
 }
 
 function buildTemplateString(

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/attribute.ts
@@ -125,7 +125,7 @@ export function handleAttribute(
             str.appendRight(attr.start, `${attrName}=`);
             if (shouldApplySlotCheck) {
                 str.prependRight(attr.start + 1, ensureSlotStr);
-                str.prependLeft(attr.end - 1, `)`);
+                str.prependLeft(attr.end - 1, ')');
             }
             return;
         }
@@ -155,7 +155,7 @@ export function handleAttribute(
 
             if (needsNumberConversion) {
                 const begin = '{' + (shouldApplySlotCheck ? ensureSlotStr : '');
-                const end = shouldApplySlotCheck ? `)}` : '}';
+                const end = shouldApplySlotCheck ? ')}' : '}';
                 if (needsQuotes) {
                     str.prependRight(equals + 1, begin);
                     str.appendLeft(attr.end, end);
@@ -165,7 +165,7 @@ export function handleAttribute(
                 }
             } else if (needsQuotes) {
                 const begin = shouldApplySlotCheck ? `{${ensureSlotStr}"` : '"';
-                const end = shouldApplySlotCheck ? `")}` : '"';
+                const end = shouldApplySlotCheck ? '")}' : '"';
                 str.prependRight(equals + 1, begin);
                 str.appendLeft(attr.end, end);
             } else if (shouldApplySlotCheck) {

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/slot.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/slot.ts
@@ -17,6 +17,9 @@ interface ComponentNode extends BaseNode {
     [shadowedPropsSymbol]?: PropsShadowedByLet[];
 }
 
+/**
+ * Transforms the usage of a slot (let:xx)
+ */
 export function handleSlot(
     htmlx: string,
     str: MagicString,

--- a/packages/svelte2tsx/src/svelte2tsx/createRenderFunction.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/createRenderFunction.ts
@@ -1,0 +1,112 @@
+import MagicString from 'magic-string';
+import { Node } from 'estree-walker';
+import { ComponentEvents } from './nodes/ComponentEvents';
+import { createRenderFunctionGetterStr } from './nodes/exportgetters';
+import { InstanceScriptProcessResult } from './processInstanceScriptContent';
+import { surroundWithIgnoreComments } from '../utils/ignore';
+
+export interface CreateRenderFunctionPara extends InstanceScriptProcessResult {
+    str: MagicString;
+    scriptTag: Node;
+    scriptDestination: number;
+    slots: Map<string, Map<string, string>>;
+    events: ComponentEvents;
+    isTsFile: boolean;
+    uses$$SlotsInterface: boolean;
+    mode?: 'tsx' | 'dts';
+}
+
+export function createRenderFunction({
+    str,
+    scriptTag,
+    scriptDestination,
+    slots,
+    getters,
+    events,
+    exportedNames,
+    isTsFile,
+    uses$$props,
+    uses$$restProps,
+    uses$$slots,
+    uses$$SlotsInterface,
+    generics,
+    mode
+}: CreateRenderFunctionPara) {
+    const htmlx = str.original;
+    let propsDecl = '';
+
+    if (uses$$props) {
+        propsDecl += ' let $$props = __sveltets_allPropsType();';
+    }
+    if (uses$$restProps) {
+        propsDecl += ' let $$restProps = __sveltets_restPropsType();';
+    }
+
+    if (uses$$slots) {
+        propsDecl +=
+            ' let $$slots = __sveltets_slotsType({' +
+            Array.from(slots.keys())
+                .map((name) => `'${name}': ''`)
+                .join(', ') +
+            '});';
+    }
+
+    const slotsDeclaration =
+        slots.size > 0 && mode !== 'dts'
+            ? '\n' +
+              surroundWithIgnoreComments(
+                  ';const __sveltets_ensureSlot = __sveltets_createEnsureSlot' +
+                      (uses$$SlotsInterface ? '<$$Slots>' : '') +
+                      '();'
+              )
+            : '';
+
+    if (scriptTag) {
+        //I couldn't get magicstring to let me put the script before the <> we prepend during conversion of the template to jsx, so we just close it instead
+        const scriptTagEnd = htmlx.lastIndexOf('>', scriptTag.content.start) + 1;
+        str.overwrite(scriptTag.start, scriptTag.start + 1, '</>;');
+        str.overwrite(
+            scriptTag.start + 1,
+            scriptTagEnd,
+            `function render${generics.toDefinitionString(true)}() {${propsDecl}\n`
+        );
+
+        const scriptEndTagStart = htmlx.lastIndexOf('<', scriptTag.end - 1);
+        // wrap template with callback
+        str.overwrite(scriptEndTagStart, scriptTag.end, `${slotsDeclaration};\n() => (<>`, {
+            contentOnly: true
+        });
+    } else {
+        str.prependRight(
+            scriptDestination,
+            `</>;function render${generics.toDefinitionString(true)}() {` +
+                `${propsDecl}${slotsDeclaration}\n<>`
+        );
+    }
+
+    const slotsAsDef = uses$$SlotsInterface
+        ? '{} as unknown as $$Slots'
+        : '{' +
+          Array.from(slots.entries())
+              .map(([name, attrs]) => {
+                  const attrsAsString = Array.from(attrs.entries())
+                      .map(([exportName, expr]) => `${exportName}:${expr}`)
+                      .join(', ');
+                  return `'${name}': {${attrsAsString}}`;
+              })
+              .join(', ') +
+          '}';
+
+    const returnString =
+        `\nreturn { props: ${exportedNames.createPropsStr(isTsFile)}` +
+        `, slots: ${slotsAsDef}` +
+        `, getters: ${createRenderFunctionGetterStr(getters)}` +
+        `, events: ${events.toDefString()} }}`;
+
+    // wrap template with callback
+    if (scriptTag) {
+        str.append(');');
+    }
+
+    str.append(returnString);
+}

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ComponentEvents.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ComponentEvents.ts
@@ -1,15 +1,16 @@
 import ts from 'typescript';
 import { EventHandler } from './event-handler';
-import { getVariableAtTopLevel, getLastLeadingDoc } from '../utils/tsAst';
+import {
+    getVariableAtTopLevel,
+    getLastLeadingDoc,
+    isInterfaceOrTypeDeclaration
+} from '../utils/tsAst';
 import MagicString from 'magic-string';
 
 export function is$$EventsDeclaration(
     node: ts.Node
 ): node is ts.TypeAliasDeclaration | ts.InterfaceDeclaration {
-    return (
-        (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node)) &&
-        node.name.text === '$$Events'
-    );
+    return isInterfaceOrTypeDeclaration(node) && node.name.text === '$$Events';
 }
 
 /**

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/Stores.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/Stores.ts
@@ -59,7 +59,7 @@ export function handleStore(node: Node, parent: Node, str: MagicString): void {
     // - in order to get ts errors if store is not assignable to SvelteStore
     // - use $store variable defined above to get ts flow control
     const dollar = str.original.indexOf('$', node.start);
-    str.overwrite(dollar, dollar + 1, '(__sveltets_store_get(');
+    str.overwrite(dollar, dollar + 1, '(__sveltets_store_get(', { contentOnly: true });
     str.prependLeft(node.end, `), $${storename})`);
 }
 

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/slot.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/slot.ts
@@ -12,6 +12,8 @@ import TemplateScope from './TemplateScope';
 import { SvelteIdentifier, WithName } from '../../interfaces';
 import { getTypeForComponent } from '../../htmlxtojsx/utils/node-utils';
 import { Directive } from 'svelte/types/compiler/interfaces';
+import ts from 'typescript';
+import { isInterfaceOrTypeDeclaration } from '../utils/tsAst';
 
 function attributeStrValueAsJsExpression(attr: Node): string {
     if (attr.value.length == 0) return "''"; //wut?
@@ -28,6 +30,12 @@ function attributeStrValueAsJsExpression(attr: Node): string {
     // we have multiple attribute values, so we know we are building a string out of them.
     // so return a dummy string, it will typecheck the same :)
     return '"__svelte_ts_string"';
+}
+
+export function is$$SlotsDeclaration(
+    node: ts.Node
+): node is ts.TypeAliasDeclaration | ts.InterfaceDeclaration {
+    return isInterfaceOrTypeDeclaration(node) && node.name.text === '$$Slots';
 }
 
 export class SlotHandler {

--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -14,6 +14,7 @@ import { Scope } from './utils/Scope';
 import { handleTypeAssertion } from './nodes/handleTypeAssertion';
 import { ImplicitStoreValues } from './nodes/ImplicitStoreValues';
 import { Generics } from './nodes/Generics';
+import { is$$SlotsDeclaration } from './nodes/slot';
 
 export interface InstanceScriptProcessResult {
     exportedNames: ExportedNames;
@@ -21,6 +22,7 @@ export interface InstanceScriptProcessResult {
     uses$$props: boolean;
     uses$$restProps: boolean;
     uses$$slots: boolean;
+    uses$$SlotsInterface: boolean;
     getters: Set<string>;
     generics: Generics;
 }
@@ -55,6 +57,7 @@ export function processInstanceScriptContent(
     let uses$$props = false;
     let uses$$restProps = false;
     let uses$$slots = false;
+    let uses$$SlotsInterface = false;
 
     //track if we are in a declaration scope
     let isDeclaration = false;
@@ -354,6 +357,9 @@ export function processInstanceScriptContent(
         if (is$$EventsDeclaration(node)) {
             events.setComponentEventsInterface(node, astOffset);
         }
+        if (is$$SlotsDeclaration(node)) {
+            uses$$SlotsInterface = true;
+        }
 
         if (ts.isVariableStatement(node)) {
             const exportModifier = findExportKeyword(node);
@@ -512,6 +518,7 @@ export function processInstanceScriptContent(
         uses$$props,
         uses$$restProps,
         uses$$slots,
+        uses$$SlotsInterface,
         getters,
         generics
     };

--- a/packages/svelte2tsx/src/svelte2tsx/processModuleScriptTag.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processModuleScriptTag.ts
@@ -6,6 +6,7 @@ import { handleTypeAssertion } from './nodes/handleTypeAssertion';
 import { Generics } from './nodes/Generics';
 import { is$$EventsDeclaration } from './nodes/ComponentEvents';
 import { throwError } from './utils/error';
+import { is$$SlotsDeclaration } from './nodes/slot';
 
 export function processModuleScriptTag(
     str: MagicString,
@@ -30,6 +31,7 @@ export function processModuleScriptTag(
 
         generics.throwIfIsGeneric(node);
         throwIfIs$$EventsDeclaration(node, str, astOffset);
+        throwIfIs$$SlotsDeclaration(node, str, astOffset);
 
         ts.forEachChild(node, (n) => walk(n));
     };
@@ -72,11 +74,21 @@ function resolveImplicitStoreValue(
 
 function throwIfIs$$EventsDeclaration(node: ts.Node, str: MagicString, astOffset: number) {
     if (is$$EventsDeclaration(node)) {
-        throwError(
-            node.getStart() + astOffset,
-            node.getEnd() + astOffset,
-            '$$Events can only be declared in the instance script',
-            str.original
-        );
+        throw$$Error(node, str, astOffset, '$$Events');
     }
+}
+
+function throwIfIs$$SlotsDeclaration(node: ts.Node, str: MagicString, astOffset: number) {
+    if (is$$SlotsDeclaration(node)) {
+        throw$$Error(node, str, astOffset, '$$Slots');
+    }
+}
+
+function throw$$Error(node: ts.Node, str: MagicString, astOffset: number, type: string) {
+    throwError(
+        node.getStart() + astOffset,
+        node.getEnd() + astOffset,
+        `${type} can only be declared in the instance script`,
+        str.original
+    );
 }

--- a/packages/svelte2tsx/src/svelte2tsx/svelteShims.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/svelteShims.ts
@@ -111,6 +111,7 @@ declare function __sveltets_ensureAction(actionCall: SvelteActionReturnType): {}
 declare function __sveltets_ensureTransition(transitionCall: SvelteTransitionReturnType): {};
 declare function __sveltets_ensureFunction(expression: (e: Event & { detail?: any }) => unknown ): {};
 declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): {};
+declare function __sveltets_createEnsureSlot<Slots = Record<string, Record<string, any>>>(): <K1 extends keyof Slots, K2 extends keyof Slots[K1]>(k1: K1, k2: K2, val: Slots[K1][K2]) => Slots[K1][K2];
 declare function __sveltets_cssProp(prop: Record<string, any>): {};
 declare function __sveltets_ctorOf<T>(type: T): AConstructorTypeOf<T>;
 declare function __sveltets_instanceOf<T = any>(type: AConstructorTypeOf<T>): T;

--- a/packages/svelte2tsx/src/svelte2tsx/utils/tsAst.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/utils/tsAst.ts
@@ -1,5 +1,11 @@
 import ts from 'typescript';
 
+export function isInterfaceOrTypeDeclaration(
+    node: ts.Node
+): node is ts.TypeAliasDeclaration | ts.InterfaceDeclaration {
+    return ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node);
+}
+
 export function findExportKeyword(node: ts.Node) {
     return node.modifiers?.find((x) => x.kind == ts.SyntaxKind.ExportKeyword);
 }

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -112,6 +112,7 @@ declare function __sveltets_ensureAction(actionCall: SvelteActionReturnType): {}
 declare function __sveltets_ensureTransition(transitionCall: SvelteTransitionReturnType): {};
 declare function __sveltets_ensureFunction(expression: (e: Event & { detail?: any }) => unknown ): {};
 declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): {};
+declare function __sveltets_createEnsureSlot<Slots = Record<string, Record<string, any>>>(): <K1 extends keyof Slots, K2 extends keyof Slots[K1]>(k1: K1, k2: K2, val: Slots[K1][K2]) => Slots[K1][K2];
 declare function __sveltets_cssProp(prop: Record<string, any>): {};
 declare function __sveltets_ctorOf<T>(type: T): AConstructorTypeOf<T>;
 declare function __sveltets_instanceOf<T = any>(type: AConstructorTypeOf<T>): T;

--- a/packages/svelte2tsx/test/sourcemaps/samples/slots/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/slots/mappings.jsx
@@ -1,9 +1,10 @@
 ///<reference types="svelte" />
-<></>;function render() {                                                                                                                             {/**
+<></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/                                                       {/**
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
 <><slot />                                                                                                                                            {/**
 =#             Originless mappings                                                                                                                    
-<><slot•/>↲    [generated] line 3                                                                                                                     
+<><slot•/>↲    [generated] line 4                                                                                                                     
   <slot•/>↲                                                                                                                                           
 <slot•/>↲      [original] line 1                                                                                                                      
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
@@ -11,24 +12,28 @@
 <slot name="foo">fallback</slot>
                                                                                                                                                       {/**
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-<slot foo={foo} name="bar" baz={baz} leet>fallback</slot>                                                                                             {/**
-<slot•foo={foo}•name="bar"•baz={baz}•leet>fallback</slot>↲    [generated] line 7                                                                      
-<slot•foo={foo}•name="bar"•    {baz}•leet>fallback</slot>↲                                                                                            
-<slot•foo={foo}•name="bar"•{baz}•leet>fallback</slot>↲        [original] line 5                                                                       
+<slot foo={__sveltets_ensureSlot("bar","foo",foo)} name="bar" baz={__sveltets_ensureSlot("bar","baz",baz)} leet>fallback</slot>                       {/**
+<slot•foo={__sveltets_ensureSlot("bar","foo",foo)}•name="bar"•baz={__sveltets_ensureSlot("bar","baz",baz)}•leet>fallback</slot>↲    [generated] line 8
+<slot•foo={                                  foo }•name="bar"•    {                                  baz }•leet>fallback</slot>↲                      
+<slot•foo={foo}•name="bar"•{baz}•leet>fallback</slot>↲                                                                              [original] line 5 
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
 
-<slot
-    foo={foo} name="bar"                                                                                                                              {/**
+<slot                                                                                                                                                 {/**
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-    baz={baz}                                                                                                                                         {/**
-   ╚baz={baz}•↲    [generated] line 11                                                                                                                
-   ╚    {baz}•↲                                                                                                                                       
-   ╚{baz}•↲        [original] line 9                                                                                                                  
+    foo={__sveltets_ensureSlot("bar","foo",foo)} name="bar"                                                                                           {/**
+   ╚foo={__sveltets_ensureSlot("bar","foo",foo)}•name="bar"↲    [generated] line 11                                                                   
+   ╚foo={                                  foo }•name="bar"↲                                                                                          
+   ╚foo={foo}•name="bar"↲                                       [original] line 8                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------ */}
+    baz={__sveltets_ensureSlot("bar","baz",baz)}                                                                                                      {/**
+   ╚baz={__sveltets_ensureSlot("bar","baz",baz)}•↲    [generated] line 12                                                                             
+   ╚    {                                  baz }•↲                                                                                                    
+   ╚{baz}•↲                                           [original] line 9                                                                               
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
     leet>fallback                                                                                                                                     {/**
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
 </slot></>                                                                                                                                            {/**
-</slot></>↲    [generated] line 13                                                                                                                    
+</slot></>↲    [generated] line 14                                                                                                                    
 </slot>        [original] line 11                                                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
 return { props: {}, slots: {'default': {}, 'foo': {}, 'bar': {foo:foo, baz:baz}}, getters: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
@@ -2,10 +2,11 @@
 <></>;function render() {
 
     let b = 7;
-;
+
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/;
 () => (<>
 <div>
-    <slot a={b}>Hello</slot>
+    <slot a={__sveltets_ensureSlot("default","a",b)}>Hello</slot>
 </div></>);
 return { props: {}, slots: {'default': {a:b}}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
@@ -4,11 +4,12 @@
     let b = 7;
     let d = 5;
     let e = 5;
-;
+
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/;
 () => (<>
 <div>
-    <slot a={b}>Hello</slot>
-    <slot name="test" c={d} e={e}></slot>
+    <slot a={__sveltets_ensureSlot("default","a",b)}>Hello</slot>
+    <slot name="test" c={__sveltets_ensureSlot("test","c",d)} e={__sveltets_ensureSlot("test","e",e)}></slot>
     <slot name="abc-cde.113"></slot>
 </div></>);
 return { props: {}, slots: {'default': {a:b}, 'test': {c:d, e:e}, 'abc-cde.113': {}}, getters: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-interface/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-interface/expected.tsx
@@ -1,0 +1,24 @@
+///<reference types="svelte" />
+<></>;function render() {
+
+    interface $$Slots {
+        default: {
+            a: number;
+        },
+        foo: {
+            b: number
+        }
+    }
+    let b = 7;
+
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot<$$Slots>();/*Ωignore_endΩ*/;
+() => (<>
+
+<div>
+    <slot a={__sveltets_ensureSlot("default","a",b)} />
+    <slot name="foo" b={__sveltets_ensureSlot("foo","b",b)} />
+</div></>);
+return { props: {}, slots: {} as unknown as $$Slots, getters: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-interface/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-interface/input.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    interface $$Slots {
+        default: {
+            a: number;
+        },
+        foo: {
+            b: number
+        }
+    }
+    let b = 7;
+</script>
+
+<div>
+    <slot a={b} />
+    <slot name="foo" {b} />
+</div>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-type/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-type/expected.tsx
@@ -1,0 +1,24 @@
+///<reference types="svelte" />
+<></>;function render() {
+
+    type $$Slots = {
+        default: {
+            a: number;
+        },
+        foo: {
+            b: number
+        }
+    }
+    let b = 7;
+
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot<$$Slots>();/*Ωignore_endΩ*/;
+() => (<>
+
+<div>
+    <slot a={__sveltets_ensureSlot("default","a",b)} />
+    <slot name="foo" b={__sveltets_ensureSlot("foo","b",b)} />
+</div></>);
+return { props: {}, slots: {} as unknown as $$Slots, getters: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-type/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-type/input.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    type $$Slots = {
+        default: {
+            a: number;
+        },
+        foo: {
+            b: number
+        }
+    }
+    let b = 7;
+</script>
+
+<div>
+    <slot a={b} />
+    <slot name="foo" {b} />
+</div>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
@@ -2,10 +2,11 @@
 <></>;function render() {
 
     let b = 7;
-;
+
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/;
 () => (<>
 <div>
-    <slot a={b} b={b} c="b" d={`a${b}`} e={b} >Hello</slot>
+    <slot a={__sveltets_ensureSlot("default","a",b)} b={__sveltets_ensureSlot("default","b",b)} c={__sveltets_ensureSlot("default","c","b")} d={__sveltets_ensureSlot("default","d",`a${b}`)} e={__sveltets_ensureSlot("default","e",b)} >Hello</slot>
 </div></>);
 return { props: {}, slots: {'default': {a:b, b:b, c:"b", d:"__svelte_ts_string", e:b}}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-forward-with-props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-forward-with-props/expected.tsx
@@ -1,7 +1,8 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <><Parent propA propB={propB} propC="val1" propD="val2" propE={`a${a}b${b}`} >{() => { let {foo} = /*Ωignore_startΩ*/new Parent({target: __sveltets_any(''), props: {'propA':true, 'propB':propB, 'propC':"", 'propD':"", 'propE':""}})/*Ωignore_endΩ*/.$$slot_def['default'];<>
-    <slot foo={foo} />
+    <slot foo={__sveltets_ensureSlot("default","foo",foo)} />
 </>}}</Parent></>
 return { props: {}, slots: {'default': {foo:__sveltets_instanceOf(Parent).$$slot_def['default'].foo}}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-await/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-await/expected.tsx
@@ -1,12 +1,13 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <>{() => {let _$$p = (promise); __sveltets_awaitThen(_$$p, (value) => {<>
-    <slot a={value}>Hello</slot>
+    <slot a={__sveltets_ensureSlot("default","a",value)}>Hello</slot>
 </>}, (err) => {<>
-    <slot name="err" err={err}>Hello</slot>
+    <slot name="err" err={__sveltets_ensureSlot("err","err",err)}>Hello</slot>
 </>})}}
 {() => {let _$$p = (promise2); __sveltets_awaitThen(_$$p, ({ b }) => {<>
-    <slot name="second" a={b}>Hello</slot>
+    <slot name="second" a={__sveltets_ensureSlot("second","a",b)}>Hello</slot>
 </>})}}</>
 return { props: {}, slots: {'default': {a:__sveltets_unwrapPromiseLike(promise)}, 'err': {err:__sveltets_any({})}, 'second': {a:(({ b }) => b)(__sveltets_unwrapPromiseLike(promise2))}}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-each/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-each/expected.tsx
@@ -1,10 +1,11 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <>{__sveltets_each(items, (item) => <>
-    <slot a={item}>Hello</slot>
+    <slot a={__sveltets_ensureSlot("default","a",item)}>Hello</slot>
 </>)}
 {__sveltets_each(items2, ({ a }) => <>
-    <slot name="second" a={a}>Hello</slot>
+    <slot name="second" a={__sveltets_ensureSlot("second","a",a)}>Hello</slot>
 </>)}</>
 return { props: {}, slots: {'default': {a:__sveltets_unwrapArr(items)}, 'second': {a:(({ a }) => a)(__sveltets_unwrapArr(items2))}}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward-named-slot/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward-named-slot/expected.tsx
@@ -1,8 +1,9 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <><Component>
     {() => { let {a} = /*Ωignore_startΩ*/new Component({target: __sveltets_any(''), props: {}})/*Ωignore_endΩ*/.$$slot_def['b'];<><div  >
-        <slot a={a}></slot>
+        <slot a={__sveltets_ensureSlot("default","a",a)}></slot>
     </div></>}}
 </Component></>
 return { props: {}, slots: {'default': {a:__sveltets_instanceOf(Component).$$slot_def['b'].a}}, getters: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward/expected.tsx
@@ -1,7 +1,8 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <><Component   >{() => { let {name:n, thing, whatever:{ bla }} = /*Ωignore_startΩ*/new Component({target: __sveltets_any(''), props: {}})/*Ωignore_endΩ*/.$$slot_def['default'];<>
-    <slot n={n} thing={thing} bla={bla} />
+    <slot n={__sveltets_ensureSlot("default","n",n)} thing={__sveltets_ensureSlot("default","thing",thing)} bla={__sveltets_ensureSlot("default","bla",bla)} />
 </>}}</Component></>
 return { props: {}, slots: {'default': {n:__sveltets_instanceOf(Component).$$slot_def['default'].name, thing:__sveltets_instanceOf(Component).$$slot_def['default'].thing, bla:(({ bla }) => bla)(__sveltets_instanceOf(Component).$$slot_def['default'].whatever)}}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-nest-scope/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-nest-scope/expected.tsx
@@ -1,16 +1,17 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <>{__sveltets_each(items, (item) => <>
     {__sveltets_each(item, ({ a }) => <>
-        <slot a={a}>Hello</slot>
+        <slot a={__sveltets_ensureSlot("default","a",a)}>Hello</slot>
     </>)}
-    <slot name="second" a={ a }></slot>
+    <slot name="second" a={__sveltets_ensureSlot("second","a", a )}></slot>
 </>)}
 <Component >{() => { let {c} = /*Ωignore_startΩ*/new Component({target: __sveltets_any(''), props: {}})/*Ωignore_endΩ*/.$$slot_def['default'];<>{ c }</>}}</Component>
 {() => {let _$$p = (promise); __sveltets_awaitThen(_$$p, (d) => {<>
     {d}
 </>})}}
-<slot name="third" d={d} c={c}></slot></>
+<slot name="third" d={__sveltets_ensureSlot("third","d",d)} c={__sveltets_ensureSlot("third","c",c)}></slot></>
 return { props: {}, slots: {'default': {a:(({ a }) => a)(__sveltets_unwrapArr(__sveltets_unwrapArr(items)))}, 'second': {a:a}, 'third': {d:d, c:c}}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render()))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-object-key/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-object-key/expected.tsx
@@ -1,9 +1,10 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <>{__sveltets_each(items, (item) => <>
-    <slot a={item} b={{ item }} c={{ item: 'abc' }.item} d={{ item: item }}>Hello</slot>
+    <slot a={__sveltets_ensureSlot("default","a",item)} b={__sveltets_ensureSlot("default","b",{ item })} c={__sveltets_ensureSlot("default","c",{ item: 'abc' }.item)} d={__sveltets_ensureSlot("default","d",{ item: item })} e={__sveltets_ensureSlot("default","e",(__sveltets_store_get(item), $item))} f={__sveltets_ensureSlot("default","f",(__sveltets_store_get(item), $item))}>Hello</slot>
 </>)}</>
-return { props: {}, slots: {'default': {a:__sveltets_unwrapArr(items), b:{ item:__sveltets_unwrapArr(items) }, c:{ item: 'abc' }.item, d:{ item: __sveltets_unwrapArr(items) }}}, getters: {}, events: {} }}
+return { props: {}, slots: {'default': {a:__sveltets_unwrapArr(items), b:{ item:__sveltets_unwrapArr(items) }, c:{ item: 'abc' }.item, d:{ item: __sveltets_unwrapArr(items) }, e:$item, f:$item}}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_partial(__sveltets_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-object-key/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-object-key/input.svelte
@@ -1,3 +1,3 @@
 {#each items as item}
-    <slot a={item} b={{ item }} c={{ item: 'abc' }.item} d={{ item: item }}>Hello</slot>
+    <slot a={item} b={{ item }} c={{ item: 'abc' }.item} d={{ item: item }} e={$item} f="{$item}">Hello</slot>
 {/each}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-var-shadowing/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-var-shadowing/expected.tsx
@@ -1,7 +1,8 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <>{__sveltets_each(items, (items) => <>
-    <slot a={items}>Hello</slot>
+    <slot a={__sveltets_ensureSlot("default","a",items)}>Hello</slot>
 </>)}</>
 return { props: {}, slots: {'default': {a:__sveltets_unwrapArr(items)}}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/creates-dts/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/creates-dts/expected.tsx
@@ -109,6 +109,7 @@ declare function __sveltets_ensureAction(actionCall: SvelteActionReturnType): {}
 declare function __sveltets_ensureTransition(transitionCall: SvelteTransitionReturnType): {};
 declare function __sveltets_ensureFunction(expression: (e: Event & { detail?: any }) => unknown ): {};
 declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): {};
+declare function __sveltets_createEnsureSlot<Slots = Record<string, Record<string, any>>>(): <K1 extends keyof Slots, K2 extends keyof Slots[K1]>(k1: K1, k2: K2, val: Slots[K1][K2]) => Slots[K1][K2];
 declare function __sveltets_cssProp(prop: Record<string, any>): {};
 declare function __sveltets_ctorOf<T>(type: T): AConstructorTypeOf<T>;
 declare function __sveltets_instanceOf<T = any>(type: AConstructorTypeOf<T>): T;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/slot-bind-this/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/slot-bind-this/expected.tsx
@@ -1,5 +1,6 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <><slot name="s" {...__sveltets_ensureType(HTMLSlotElement, s)} /></>
 return { props: {}, slots: {'s': {}}, getters: {}, events: {} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-dts/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-dts/expected.tsx
@@ -109,6 +109,7 @@ declare function __sveltets_ensureAction(actionCall: SvelteActionReturnType): {}
 declare function __sveltets_ensureTransition(transitionCall: SvelteTransitionReturnType): {};
 declare function __sveltets_ensureFunction(expression: (e: Event & { detail?: any }) => unknown ): {};
 declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): {};
+declare function __sveltets_createEnsureSlot<Slots = Record<string, Record<string, any>>>(): <K1 extends keyof Slots, K2 extends keyof Slots[K1]>(k1: K1, k2: K2, val: Slots[K1][K2]) => Slots[K1][K2];
 declare function __sveltets_cssProp(prop: Record<string, any>): {};
 declare function __sveltets_ctorOf<T>(type: T): AConstructorTypeOf<T>;
 declare function __sveltets_instanceOf<T = any>(type: AConstructorTypeOf<T>): T;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics/expected.tsx
@@ -14,10 +14,11 @@ function render</*Ωignore_startΩ*/A,B extends keyof A,C extends boolean/*Ωign
      let c: C;
 
     const dispatch = createEventDispatcher<{a: A}>();
-;
+
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/;
 () => (<>
 
-<slot c={c} /></>);
+<slot c={__sveltets_ensureSlot("default","c",c)} /></>);
 return { props: {a: a , b: b , c: c} as {a: A, b: B, c: C}, slots: {'default': {c:c}}, getters: {}, events: {...__sveltets_toEventTypings<{a: A}>()} }}
 class __sveltets_Render<A,B extends keyof A,C extends boolean> {
     props() {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-creates-dts/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-creates-dts/expected.tsx
@@ -109,6 +109,7 @@ declare function __sveltets_ensureAction(actionCall: SvelteActionReturnType): {}
 declare function __sveltets_ensureTransition(transitionCall: SvelteTransitionReturnType): {};
 declare function __sveltets_ensureFunction(expression: (e: Event & { detail?: any }) => unknown ): {};
 declare function __sveltets_ensureType<T>(type: AConstructorTypeOf<T>, el: T): {};
+declare function __sveltets_createEnsureSlot<Slots = Record<string, Record<string, any>>>(): <K1 extends keyof Slots, K2 extends keyof Slots[K1]>(k1: K1, k2: K2, val: Slots[K1][K2]) => Slots[K1][K2];
 declare function __sveltets_cssProp(prop: Record<string, any>): {};
 declare function __sveltets_ctorOf<T>(type: T): AConstructorTypeOf<T>;
 declare function __sveltets_instanceOf<T = any>(type: AConstructorTypeOf<T>): T;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots-script/expected.tsx
@@ -3,7 +3,8 @@
 
     let name = $$slots.foo;
     let dashedName = $$slots['dashed-name'];
-;
+
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/;
 () => (<>
 
 <h1>{name}</h1>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots/expected.tsx
@@ -1,5 +1,6 @@
 ///<reference types="svelte" />
 <></>;function render() { let $$slots = __sveltets_slotsType({'foo': '', 'dashed-name': '', 'default': ''});
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <><h1>{$$slots.foo}</h1>
 <h1>{$$slots['dashed-name']}</h1>
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components-let-forward/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components-let-forward/expected.tsx
@@ -1,12 +1,13 @@
 ///<reference types="svelte" />
 <></>;function render() {
+/*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_createEnsureSlot();/*Ωignore_endΩ*/
 <>{(true) ? <>
 <svelteself >{() => { let {prop} = __sveltets_instanceOf(__sveltets_componentType()).$$slot_def['default'];/*Ωignore_startΩ*/((true)) && /*Ωignore_endΩ*/<>
-    <slot prop={prop} />
+    <slot prop={__sveltets_ensureSlot("default","prop",prop)} />
 </>}}</svelteself>
 </> : <></>}
 <sveltecomponent this={testComponent} >{() => { let {prop} = __sveltets_instanceOf(__sveltets_componentType()).$$slot_def['default'];<>
-    <slot prop={prop} />
+    <slot prop={__sveltets_ensureSlot("default","prop",prop)} />
 </>}}</sveltecomponent></>
 return { props: {}, slots: {'default': {prop:__sveltets_instanceOf(__sveltets_componentType()).$$slot_def['default'].prop}}, getters: {}, events: {} }}
 


### PR DESCRIPTION
This adds support for a new experimantel feature, the $$Slots interface. If it's defined, components using slots of that component are type-checked against that definition. It is also made sure that only slots that exist and their correct type are used within the component that defines the $$Slots interface.

#442
https://github.com/sveltejs/rfcs/pull/38