### PR TITLE
(fix) apply type transformation to export binding

### DIFF
--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface/expected.tsx
@@ -14,10 +14,10 @@
      let exported1: string;
      let exported2: string = '';exported2 = __sveltets_any(exported2);;
 
-    let name1: string = "world"
+    let name1: string = "world";name1 = __sveltets_any(name1);
     let name2: string;
 
-    let rename1: string = '';
+    let rename1: string = '';rename1 = __sveltets_any(rename1);;
     let rename2: string;
 
     class Foo {}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-type/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-type/expected.tsx
@@ -14,10 +14,10 @@
      let exported1: string;
      let exported2: string = '';exported2 = __sveltets_any(exported2);;
 
-    let name1: string = "world"
+    let name1: string = "world";name1 = __sveltets_any(name1);
     let name2: string;
 
-    let rename1: string = '';
+    let rename1: string = '';rename1 = __sveltets_any(rename1);;
     let rename2: string;
 
     class Foo {}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-list/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-list/expected.tsx
@@ -1,10 +1,11 @@
 ///<reference types="svelte" />
 <></>;function render() {
 
-    let name1: string = "world"
+    let name1: string = "world";name1 = __sveltets_any(name1);
     let name2: string;
+    let name3: string = '';name3 = __sveltets_any(name3);;let  name4: string;
 
-    let rename1: string = '';
+    let rename1: string = '';rename1 = __sveltets_any(rename1);;
     let rename2: string;
 
     class Foo {}
@@ -18,7 +19,7 @@
     
 ;
 () => (<></>);
-return { props: {name1: name1 , name2: name2 , renamed1: rename1 , renamed2: rename2 , Foo: Foo , bar: bar , baz: baz , RenamedFoo: RenameFoo , renamedbar: renamebar , renamedbaz: renamebaz} as {name1?: string, name2: string, renamed1?: string, renamed2: string, Foo?: typeof Foo, bar?: typeof bar, baz?: string, RenamedFoo?: typeof RenameFoo, renamedbar?: typeof renamebar, renamedbaz?: string}, slots: {}, getters: {}, events: {} }}
+return { props: {name1: name1 , name2: name2 , name3: name3 , name4: name4 , renamed1: rename1 , renamed2: rename2 , Foo: Foo , bar: bar , baz: baz , RenamedFoo: RenameFoo , renamedbar: renamebar , renamedbaz: renamebaz} as {name1?: string, name2: string, name3?: string, name4: string, renamed1?: string, renamed2: string, Foo?: typeof Foo, bar?: typeof bar, baz?: string, RenamedFoo?: typeof RenameFoo, renamedbar?: typeof renamebar, renamedbaz?: string}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends createSvelte2TsxComponent(__sveltets_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-list/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-list/input.svelte
@@ -1,6 +1,7 @@
 <script>
     let name1: string = "world"
     let name2: string;
+    let name3: string = '', name4: string;
 
     let rename1: string = '';
     let rename2: string;
@@ -13,5 +14,5 @@
     function renamebar() {}
     const renamebaz: string = '';
 
-    export { name1, name2, rename1 as renamed1, rename2 as renamed2, Foo, bar, baz, RenameFoo as RenamedFoo, renamebar as renamedbar, renamebaz as renamedbaz };
+    export { name1, name2, name3, name4, rename1 as renamed1, rename2 as renamed2, Foo, bar, baz, RenameFoo as RenamedFoo, renamebar as renamedbar, renamebaz as renamedbaz };
 </script>


### PR DESCRIPTION
Apply the __sveltets_any transformation to variable declarations that are later exported through export { .. }
This tricks TS into widening their type, too.
#911