### PR TITLE
(feat) default slot let completion/hover info for Svelte components

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -216,13 +216,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         tsDoc: SvelteDocumentSnapshot,
         originalPosition: Position
     ): Promise<Array<AppCompletionItem<CompletionEntryWithIdentifer>>> {
-        const componentInfo = await getComponentAtPosition(
-            this.lsAndTsDocResolver,
-            lang,
-            doc,
-            tsDoc,
-            originalPosition
-        );
+        const componentInfo = await getComponentAtPosition(lang, doc, tsDoc, originalPosition);
         if (!componentInfo) {
             return [];
         }

--- a/packages/language-server/src/plugins/typescript/features/HoverProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/HoverProvider.ts
@@ -70,13 +70,7 @@ export class HoverProviderImpl implements HoverProvider {
             return null;
         }
 
-        const component = await getComponentAtPosition(
-            this.lsAndTsDocResolver,
-            lang,
-            doc,
-            tsDoc,
-            originalPosition
-        );
+        const component = await getComponentAtPosition(lang, doc, tsDoc, originalPosition);
         if (!component) {
             return null;
         }

--- a/packages/language-server/src/plugins/typescript/features/utils.ts
+++ b/packages/language-server/src/plugins/typescript/features/utils.ts
@@ -15,7 +15,6 @@ import { LSAndTSDocResolver } from '../LSAndTSDocResolver';
  * return the snapshot of that component.
  */
 export async function getComponentAtPosition(
-    lsAndTsDocResolver: LSAndTSDocResolver,
     lang: ts.LanguageService,
     doc: Document,
     tsDoc: SvelteDocumentSnapshot,
@@ -46,12 +45,6 @@ export async function getComponentAtPosition(
     )?.[0];
     if (!def) {
         return null;
-    }
-
-    const snapshot = await lsAndTsDocResolver.getSnapshot(def.fileName);
-
-    if (snapshot instanceof SvelteDocumentSnapshot) {
-        return snapshot;
     }
 
     return JsOrTsComponentInfoProvider.create(lang, def);

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -128,7 +128,7 @@ describe('CompletionProviderImpl', () => {
         assert.deepStrictEqual(eventCompletions, <CompletionItem[]>[
             {
                 detail: 'a: CustomEvent<boolean>',
-                documentation: undefined,
+                documentation: '',
                 label: 'on:a',
                 sortText: '-1',
                 textEdit: undefined
@@ -137,15 +137,15 @@ describe('CompletionProviderImpl', () => {
                 detail: 'b: MouseEvent',
                 documentation: {
                     kind: 'markdown',
-                    value: '\nTEST\n'
+                    value: 'TEST'
                 },
                 label: 'on:b',
                 sortText: '-1',
                 textEdit: undefined
             },
             {
-                detail: 'c: Event',
-                documentation: undefined,
+                detail: 'c: any',
+                documentation: '',
                 label: 'on:c',
                 sortText: '-1',
                 textEdit: undefined
@@ -176,7 +176,7 @@ describe('CompletionProviderImpl', () => {
         assert.deepStrictEqual(eventCompletions, <CompletionItem[]>[
             {
                 detail: 'a: CustomEvent<boolean>',
-                documentation: undefined,
+                documentation: '',
                 label: 'on:a',
                 sortText: '-1',
                 textEdit: {
@@ -197,7 +197,7 @@ describe('CompletionProviderImpl', () => {
                 detail: 'b: MouseEvent',
                 documentation: {
                     kind: 'markdown',
-                    value: '\nTEST\n'
+                    value: 'TEST'
                 },
                 label: 'on:b',
                 sortText: '-1',
@@ -216,8 +216,8 @@ describe('CompletionProviderImpl', () => {
                 }
             },
             {
-                detail: 'c: Event',
-                documentation: undefined,
+                detail: 'c: any',
+                documentation: '',
                 label: 'on:c',
                 sortText: '-1',
                 textEdit: {

--- a/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
@@ -79,7 +79,7 @@ describe('HoverProvider', () => {
 
         assert.deepStrictEqual(await provider.doHover(document, Position.create(12, 26)), <Hover>{
             contents:
-                '```typescript\nabc: MouseEvent\n```\n\nTEST\n```ts\nconst abc: boolean = true;\n```\n'
+                '```typescript\nabc: MouseEvent\n```\nTEST\n```ts\nconst abc: boolean = true;\n```'
         });
     });
 


### PR DESCRIPTION
Removing the custom getEvents/getSlotLets logic and instead consolidating on the type-checker approach.

@jasonlyu123 I think your approach is way better and more robust so I consolidated on it. The difference for the fallback (`any` instead of `Event` in the tsdoc) is okay for me. One could even argue it's more correct.