### PR TITLE
normalize workspace uri

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -33,7 +33,7 @@ import {
     OnWatchFileChangesPara,
     LSAndTSDocResolver
 } from './plugins';
-import { debounceThrottle, isNotNullOrUndefined, urlToPath } from './utils';
+import { debounceThrottle, isNotNullOrUndefined, pathToUrl, urlToPath } from './utils';
 import { FallbackWatcher } from './lib/FallbackWatcher';
 
 namespace TagCloseRequest {
@@ -135,7 +135,11 @@ export function startServer(options?: LSOptions) {
         pluginHost.register(
             new TypeScriptPlugin(
                 configManager,
-                new LSAndTSDocResolver(docManager, workspaceUris, configManager)
+                new LSAndTSDocResolver(
+                    docManager,
+                    workspaceUris.map((uri) => pathToUrl(urlToPath(uri) ?? '')),
+                    configManager
+                )
             )
         );
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -33,7 +33,7 @@ import {
     OnWatchFileChangesPara,
     LSAndTSDocResolver
 } from './plugins';
-import { debounceThrottle, isNotNullOrUndefined, pathToUrl, urlToPath } from './utils';
+import { debounceThrottle, isNotNullOrUndefined, normalizeUri, urlToPath } from './utils';
 import { FallbackWatcher } from './lib/FallbackWatcher';
 
 namespace TagCloseRequest {
@@ -135,11 +135,7 @@ export function startServer(options?: LSOptions) {
         pluginHost.register(
             new TypeScriptPlugin(
                 configManager,
-                new LSAndTSDocResolver(
-                    docManager,
-                    workspaceUris.map((uri) => pathToUrl(urlToPath(uri) ?? '')),
-                    configManager
-                )
+                new LSAndTSDocResolver(docManager, workspaceUris.map(normalizeUri), configManager)
             )
         );
 


### PR DESCRIPTION
Notice some language server client has their rootUri in a different format with the workspace Uri of vs code. Specifically, the drive path in windows is not encoded. This causes the tsconfig to wrongly assumed to be not in the subpath of the workspace. Normalize it to fix this.

This is what's logged in sublime LSP, this also happens in visual studio 2019
> Initialize language server at  file:///C:/projects/...
Initialize new ts service at

And in vscode:
> Initialize language server at  file:///c%3A/projects/...
Initialize new ts service at  c:/projects/...