### PR TITLE
fix: unsatisfied peer dependency

### DIFF
--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -20,7 +20,8 @@
     "devDependencies": {
         "@tsconfig/node12": "^1.0.0",
         "@types/node": "^13.9.0",
-        "typescript": "*"
+        "typescript": "*",
+        "svelte": "*"
     },
     "dependencies": {
         "svelte2tsx": "~0.4.0",


### PR DESCRIPTION
Adds svelte as a dev dependency because svelte2tsx [has a presently unsatisfied peer dependency on it](https://github.com/NickDarvey/language-tools/blob/d219ec4719b6d5b9425905f656c98df43136e879/packages/svelte2tsx/package.json#L43).

This means it can't be used with [pnpm](https://pnpm.io/)'s [strict-peer-dependencies](https://rushjs.io/pages/maintainer/recommended_settings#strictpeerdependencies).