### PR TITLE
(fix) fall back to any for untyped slot

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -1753,4 +1753,10 @@ describe('DiagnosticsProvider', () => {
             }
         ]);
     });
+
+    it('falls back to any for untyped props and slots in js', async () => {
+        const { plugin, document } = setup('using-untyped-js.svelte');
+        const diagnostics = await plugin.getDiagnostics(document);
+        assert.deepStrictEqual(diagnostics, []);
+    });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/untyped-js.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/untyped-js.svelte
@@ -1,0 +1,5 @@
+<script>
+    export let untyped;
+</script>
+
+<slot {untyped} />

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/using-untyped-js.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/using-untyped-js.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    import Untyped from './untyped-js.svelte';
+</script>
+
+<Untyped untyped={true} let:untyped>{untyped.worksBecauseAny}</Untyped>

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -99,6 +99,7 @@ type SvelteAnimationReturnType = {
 type SvelteWithOptionalProps<Props, Keys extends keyof Props> = Omit<Props, Keys> & Partial<Pick<Props, Keys>>;
 type SvelteAllProps = { [index: string]: any }
 type SveltePropsAnyFallback<Props> = {[K in keyof Props]: Props[K] extends undefined ? any : Props[K]}
+type SvelteSlotsAnyFallback<Slots> = {[K in keyof Slots]: {[S in keyof Slots[K]]: Slots[K][S] extends undefined ? any : Slots[K][S]}}
 type SvelteRestProps = { [index: string]: any }
 type SvelteSlots = { [index: string]: any }
 type SvelteStore<T> = { subscribe: (run: (value: T) => any, invalidate?: any) => any }
@@ -134,19 +135,19 @@ declare function __sveltets_1_slotsType<Slots, Key extends keyof Slots>(slots: S
 
 declare function __sveltets_1_partial<Props = {}, Events = {}, Slots = {}>(
     render: {props: Props, events: Events, slots: Slots }
-): {props: Expand<SveltePropsAnyFallback<Props>>, events: Events, slots: Slots }
+): {props: Expand<SveltePropsAnyFallback<Props>>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>> }
 declare function __sveltets_1_partial<Props = {}, Events = {}, Slots = {}, OptionalProps extends keyof Props = any>(
     optionalProps: OptionalProps[],
     render: {props: Props, events: Events, slots: Slots }
-): {props: Expand<SvelteWithOptionalProps<SveltePropsAnyFallback<Props>, OptionalProps>>, events: Events, slots: Slots }
+): {props: Expand<SvelteWithOptionalProps<SveltePropsAnyFallback<Props>, OptionalProps>>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>> }
 
 declare function __sveltets_1_partial_with_any<Props = {}, Events = {}, Slots = {}>(
     render: {props: Props, events: Events, slots: Slots }
-): {props: Expand<SveltePropsAnyFallback<Props> & SvelteAllProps>, events: Events, slots: Slots }
+): {props: Expand<SveltePropsAnyFallback<Props> & SvelteAllProps>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>> }
 declare function __sveltets_1_partial_with_any<Props = {}, Events = {}, Slots = {}, OptionalProps extends keyof Props = any>(
     optionalProps: OptionalProps[],
     render: {props: Props, events: Events, slots: Slots }
-): {props: Expand<SvelteWithOptionalProps<SveltePropsAnyFallback<Props>, OptionalProps> & SvelteAllProps>, events: Events, slots: Slots }
+): {props: Expand<SvelteWithOptionalProps<SveltePropsAnyFallback<Props>, OptionalProps> & SvelteAllProps>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>> }
 
 
 declare function __sveltets_1_with_any<Props = {}, Events = {}, Slots = {}>(


### PR DESCRIPTION
When using JS and having an untyped slot, its type is undefined. Fall back to any in that case (same as in #698)