### PR TITLE
(feat) add workspace trust

### DIFF
--- a/packages/language-server/src/importPackage.ts
+++ b/packages/language-server/src/importPackage.ts
@@ -5,6 +5,17 @@ import sveltePreprocess from 'svelte-preprocess';
 import { Logger } from './logger';
 
 /**
+ * Whether or not the current workspace can be trusted.
+ * TODO rework this to a class which depends on the LsConfigManager
+ * and inject that class into all places where it's needed (Document etc.)
+ */
+let isTrusted = true;
+
+export function setIsTrusted(_isTrusted: boolean) {
+    isTrusted = _isTrusted;
+}
+
+/**
  * This function encapsulates the require call in one place
  * so we can replace its content inside rollup builds
  * so it's not transformed.
@@ -15,8 +26,12 @@ function dynamicRequire(dynamicFileToRequire: string): any {
 }
 
 export function getPackageInfo(packageName: string, fromPath: string) {
+    const paths = [__dirname];
+    if (isTrusted) {
+        paths.unshift(fromPath);
+    }
     const packageJSONPath = require.resolve(`${packageName}/package.json`, {
-        paths: [fromPath, __dirname]
+        paths
     });
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { version } = dynamicRequire(packageJSONPath);

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -252,6 +252,7 @@ export class LSConfigManager {
     };
     private prettierConfig: any = {};
     private emmetConfig: VSCodeEmmetConfig = {};
+    private isTrusted = true;
 
     /**
      * Updates config.
@@ -322,6 +323,18 @@ export class LSConfigManager {
                 this._updateTsUserPreferences(lang, config[lang]);
             }
         });
+    }
+
+    /**
+     * Whether or not the current workspace can be trusted.
+     * If not, certain operations should be disabled.
+     */
+    getIsTrusted(): boolean {
+        return this.isTrusted;
+    }
+
+    updateIsTrusted(isTrusted: boolean): void {
+        this.isTrusted = isTrusted;
     }
 
     private _updateTsUserPreferences(lang: TsUserConfigLang, config: TSUserConfig) {

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -47,7 +47,7 @@ export class SveltePlugin
     constructor(private configManager: LSConfigManager) {}
 
     async getDiagnostics(document: Document): Promise<Diagnostic[]> {
-        if (!this.featureEnabled('diagnostics')) {
+        if (!this.featureEnabled('diagnostics') || !this.configManager.getIsTrusted()) {
             return [];
         }
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -105,7 +105,7 @@ export function startServer(options?: LSOptions) {
         }
 
         const isTrusted: boolean = evt.initializationOptions?.isTrusted ?? true;
-        configLoader.setDisabled(isTrusted);
+        configLoader.setDisabled(!isTrusted);
         setIsTrusted(isTrusted);
         configManager.updateIsTrusted(isTrusted);
         if (!isTrusted) {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -35,6 +35,8 @@ import {
 } from './plugins';
 import { debounceThrottle, isNotNullOrUndefined, normalizeUri, urlToPath } from './utils';
 import { FallbackWatcher } from './lib/FallbackWatcher';
+import { configLoader } from './lib/documents/configLoader';
+import { setIsTrusted } from './importPackage';
 
 namespace TagCloseRequest {
     export const type: RequestType<TextDocumentPositionParams, string | null, any> =
@@ -100,6 +102,14 @@ export function startServer(options?: LSOptions) {
             const workspacePaths = workspaceUris.map(urlToPath).filter(isNotNullOrUndefined);
             watcher = new FallbackWatcher('**/*.{ts,js}', workspacePaths);
             watcher.onDidChangeWatchedFiles(onDidChangeWatchedFiles);
+        }
+
+        const isTrusted: boolean = evt.initializationOptions?.isTrusted ?? true;
+        configLoader.setDisabled(isTrusted);
+        setIsTrusted(isTrusted);
+        configManager.updateIsTrusted(isTrusted);
+        if (!isTrusted) {
+            Logger.log('Workspace is not trusted, running with reduced capabilities.');
         }
 
         // Backwards-compatible way of setting initialization options (first `||` is the old style)

--- a/packages/language-server/test/lib/documents/configLoader.test.ts
+++ b/packages/language-server/test/lib/documents/configLoader.test.ts
@@ -2,6 +2,7 @@ import { ConfigLoader } from '../../../src/lib/documents/configLoader';
 import path from 'path';
 import { pathToFileURL, URL } from 'url';
 import assert from 'assert';
+import { spy } from 'sinon';
 
 describe('ConfigLoader', () => {
     function configFrom(path: string) {
@@ -162,5 +163,18 @@ describe('ConfigLoader', () => {
             await configLoader.awaitConfig(normalizePath('some/file.svelte')),
             configFrom(normalizePath('some/svelte.config.js'))
         );
+    });
+
+    it('should not load config when disabled', async () => {
+        const moduleLoader = spy();
+        const configLoader = new ConfigLoader(
+            () => [],
+            { existsSync: () => true },
+            path,
+            moduleLoader
+        );
+        configLoader.setDisabled(true);
+        await configLoader.awaitConfig(normalizePath('some/file.svelte')),
+            assert.deepStrictEqual(moduleLoader.notCalled, true);
     });
 });

--- a/packages/language-server/test/lib/documents/configLoader.test.ts
+++ b/packages/language-server/test/lib/documents/configLoader.test.ts
@@ -174,7 +174,7 @@ describe('ConfigLoader', () => {
             moduleLoader
         );
         configLoader.setDisabled(true);
-        await configLoader.awaitConfig(normalizePath('some/file.svelte')),
-            assert.deepStrictEqual(moduleLoader.notCalled, true);
+        await configLoader.awaitConfig(normalizePath('some/file.svelte'));
+        assert.deepStrictEqual(moduleLoader.notCalled, true);
     });
 });

--- a/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
+++ b/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
@@ -12,10 +12,11 @@ import * as importPackage from '../../../src/importPackage';
 import sinon from 'sinon';
 
 describe('Svelte Plugin', () => {
-    function setup(content: string, prettierConfig?: any) {
+    function setup(content: string, prettierConfig?: any, trusted = true) {
         const document = new Document('file:///hello.svelte', content);
         const docManager = new DocumentManager(() => document);
         const pluginManager = new LSConfigManager();
+        pluginManager.updateIsTrusted(trusted);
         pluginManager.updatePrettierConfig(prettierConfig);
         const plugin = new SveltePlugin(pluginManager);
         docManager.openDocument(<any>'some doc');
@@ -50,6 +51,14 @@ describe('Svelte Plugin', () => {
         );
 
         assert.deepStrictEqual(diagnostics, [diagnostic]);
+    });
+
+    it('provides no diagnostic errors when untrusted', async () => {
+        const { plugin, document } = setup('<div bind:whatever></div>', {}, false);
+
+        const diagnostics = await plugin.getDiagnostics(document);
+
+        assert.deepStrictEqual(diagnostics, []);
     });
 
     describe('#formatDocument', () => {

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -46,7 +46,7 @@
     "capabilities": {
         "untrustedWorkspaces": {
             "supported": "limited",
-            "description": "The extension requires workspace trust because it executes code specified by the workspace. Loading the user's node_modules and loading svelte config file is disabled when untrusted"
+            "description": "The extension requires workspace trust because it executes code specified by the workspace. Loading the user's node_modules and loading svelte config files is disabled when untrusted"
         }
     },
     "contributes": {

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -43,6 +43,15 @@
         "onLanguage:svelte",
         "onCommand:svelte.restartLanguageServer"
     ],
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": "limited",
+            "description": "The extension requires workspace trust because it executes code specified by the workspace. Setting a custom language-server runtime, loading the user's node_modules and loading the svelte config file is disabled when untrusted",
+            "restrictedConfigurations": [
+                "svelte.language-server.ls-path"
+            ]
+        }
+    },
     "contributes": {
         "typescriptServerPlugins-disabled": [
             {
@@ -67,7 +76,6 @@
                     "description": "- You normally don't need this - Path to the node executable to use to spawn the language server. This is useful when you depend on native modules such as node-sass as without this they will run in the context of vscode, meaning node version mismatch is likely. Minimum required node version is 12.17. This setting can only be changed in user settings for security reasons."
                 },
                 "svelte.language-server.ls-path": {
-                    "scope": "application",
                     "type": "string",
                     "title": "Language Server Path",
                     "description": "- You normally don't set this - Path to the language server executable. If you installed the \"svelte-language-server\" npm package, it's within there at \"bin/server.js\". Path can be either relative to your workspace root or absolute. Set this only if you want to use a custom version of the language server. This setting can only be changed in user settings for security reasons."

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -46,10 +46,7 @@
     "capabilities": {
         "untrustedWorkspaces": {
             "supported": "limited",
-            "description": "The extension requires workspace trust because it executes code specified by the workspace. Setting a custom language-server runtime, loading the user's node_modules and loading the svelte config file is disabled when untrusted",
-            "restrictedConfigurations": [
-                "svelte.language-server.ls-path"
-            ]
+            "description": "The extension requires workspace trust because it executes code specified by the workspace. Loading the user's node_modules and loading svelte config file is disabled when untrusted"
         }
     },
     "contributes": {
@@ -76,6 +73,7 @@
                     "description": "- You normally don't need this - Path to the node executable to use to spawn the language server. This is useful when you depend on native modules such as node-sass as without this they will run in the context of vscode, meaning node version mismatch is likely. Minimum required node version is 12.17. This setting can only be changed in user settings for security reasons."
                 },
                 "svelte.language-server.ls-path": {
+                    "scope": "application",
                     "type": "string",
                     "title": "Language Server Path",
                     "description": "- You normally don't set this - Path to the language server executable. If you installed the \"svelte-language-server\" npm package, it's within there at \"bin/server.js\". Path can be either relative to your workspace root or absolute. Set this only if you want to use a custom version of the language server. This setting can only be changed in user settings for security reasons."

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -100,7 +100,8 @@ export function activate(context: ExtensionContext) {
                 typescript: workspace.getConfiguration('typescript'),
                 javascript: workspace.getConfiguration('javascript')
             },
-            dontFilterIncompleteCompletions: true // VSCode filters client side and is smarter at it than us
+            dontFilterIncompleteCompletions: true, // VSCode filters client side and is smarter at it than us
+            isTrusted: (workspace as any).isTrusted
         }
     };
 


### PR DESCRIPTION
#1051

Marking as draft for now since I want to get [feedback from the VS Code team first about backwards compatibility](https://github.com/microsoft/vscode/issues/120251#issuecomment-874654461).
If there's no backwards compatibility we need to bump the minimum required VS Code version, which means I'd rather get some more bugfixes/enhancements in, first. Edit: Got the response, we need to bump the minimum required version for this. For me this means:
1. Add workspace trust in a backwards compatible way first, which means not lifting the `"scope": "application"` restriction
2. Wait a month or so, get other bug fixes/features etc in
3. lift restriction and bump minimum required VS Code version