### PR TITLE
(fix) silence false positive warning for namespace

### DIFF
--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -266,7 +266,8 @@ function isNoFalsePositive(diag: Diagnostic, doc: Document): boolean {
         return true;
     }
 
-    // TypeScript transpiles `export enum A` to `export var A`, which the compiler will warn about.
+    // TypeScript transpiles `export enum A` and `export namespace A` to `export var A`,
+    // which the compiler will warn about.
     // Silence this edge case. We extract the property from the message and don't use the position
     // because that position could be wrong when source mapping trips up.
     const unusedExportName = diag.message.substring(
@@ -274,7 +275,7 @@ function isNoFalsePositive(diag: Diagnostic, doc: Document): boolean {
         diag.message.lastIndexOf("'")
     );
     const hasExportedEnumWithThatName = new RegExp(
-        `\\bexport\\s+?enum\\s+?${unusedExportName}\\b`
+        `\\bexport\\s+?(enum|namespace)\\s+?${unusedExportName}\\b`
     ).test(doc.getText());
     return !hasExportedEnumWithThatName;
 }

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -310,6 +310,35 @@ describe('SveltePlugin#getDiagnostics', () => {
         ).toEqual([]);
     });
 
+    it('filter out false positive warning (export namespace)', async () => {
+        (
+            await expectDiagnosticsFor({
+                docText:
+                    '<script context="module">export namespace foo { export function bar() {} }</script>',
+                getTranspiled: () => ({
+                    getOriginalPosition: (pos: Position) => {
+                        return pos;
+                    }
+                }),
+                getCompiled: () =>
+                    Promise.resolve({
+                        stats: {
+                            warnings: [
+                                {
+                                    start: { line: 1, column: 43 },
+                                    end: { line: 1, column: 46 },
+                                    message:
+                                        "Component has unused export property 'foo'. If it is for external reference only, please consider using `export const foo`",
+                                    code: 'unused-export-let'
+                                }
+                            ]
+                        }
+                    }),
+                config: {}
+            })
+        ).toEqual([]);
+    });
+
     it('filter out warnings', async () => {
         (
             await expectDiagnosticsFor({


### PR DESCRIPTION
TypeScript transpiles `export namespace A` to `export var A`, which the compiler will warn about. Silence this edge case.
#1095