### PR TITLE
Include referrerpolicy in HTMLProps

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -532,6 +532,7 @@ declare namespace svelte.JSX {
       preload?: string;
       radiogroup?: string;
       readonly?: boolean;
+      referrerpolicy?: string;
       rel?: string;
       required?: boolean;
       reversed?: boolean;


### PR DESCRIPTION
This will allow using the referrerpolicy attribute without spurious errors from svelte-check.

Resolves sveltejs/language-tools#1102