### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
-          cache: npm
+          cache: yarn
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
-          cache: npm
+          cache: yarn
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,9 +7,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
+          cache: npm
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -38,9 +39,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
+          cache: npm
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,18 +12,6 @@ jobs:
           node-version: "12.x"
           cache: yarn
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       # Get projects set up
       - run: yarn install
       - run: yarn bootstrap

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -14,10 +14,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       # Ensure everything is compiling
       - run: "yarn install"

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
-          cache: npm
+          cache: yarn
 
       # Ensure everything is compiling
       - run: "yarn install"

--- a/.github/workflows/DeployExtensionsProd.yml
+++ b/.github/workflows/DeployExtensionsProd.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
-          cache: npm
+          cache: yarn
 
       # Ensure everything is compiling
       - run: "yarn install"

--- a/.github/workflows/DeployExtensionsProd.yml
+++ b/.github/workflows/DeployExtensionsProd.yml
@@ -11,10 +11,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       # Ensure everything is compiling
       - run: "yarn install"
@@ -28,18 +29,18 @@ jobs:
 
       # To deploy we need isolated node_modules folders which yarn won't do because it is a workspace
       # So, remove the workspace
-      - run: "rm package.json yarn.lock"  # Re-run the  yarn install outside of the workspace
+      - run: "rm package.json yarn.lock" # Re-run the  yarn install outside of the workspace
 
       - run: |
-         cd packages/svelte-vscode
-         yarn install
+          cd packages/svelte-vscode
+          yarn install
 
-         # Just a hard constraint from the vscode marketplace's usage of azure tokens
-         echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"
+          # Just a hard constraint from the vscode marketplace's usage of azure tokens
+          echo "Once a year this expires, tell Orta to access https://dev.azure.com/ortatherox0608/_usersSettings/tokens to get a new one"
 
-         # Ship it
-         npx vsce publish --yarn -p $VSCE_TOKEN
-         npx ovsx publish --yarn -p $OVSX_TOKEN
+          # Ship it
+          npx vsce publish --yarn -p $VSCE_TOKEN
+          npx ovsx publish --yarn -p $OVSX_TOKEN
 
         env:
           VSCE_TOKEN: ${{ secrets.AZURE_PAN_TOKEN }}

--- a/.github/workflows/DeploySvelte2tsxProd.yml
+++ b/.github/workflows/DeploySvelte2tsxProd.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
-          cache: npm
+          cache: yarn
 
       # Ensure everything is compiling
       - run: "yarn install"

--- a/.github/workflows/DeploySvelte2tsxProd.yml
+++ b/.github/workflows/DeploySvelte2tsxProd.yml
@@ -11,10 +11,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       # Ensure everything is compiling
       - run: "yarn install"
@@ -28,9 +29,9 @@ jobs:
 
       # Ship it
       - run: |
-         cd packages/svelte2tsx
-         npm install
-         npm publish
+          cd packages/svelte2tsx
+          npm install
+          npm publish
 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/DeploySvelteCheckProd.yml
+++ b/.github/workflows/DeploySvelteCheckProd.yml
@@ -11,10 +11,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       # Ensure everything is compiling
       - run: "yarn install"
@@ -28,9 +29,9 @@ jobs:
 
       # Ship it
       - run: |
-         cd packages/svelte-check
-         npm install
-         npm publish
+          cd packages/svelte-check
+          npm install
+          npm publish
 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/DeploySvelteCheckProd.yml
+++ b/.github/workflows/DeploySvelteCheckProd.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
-          cache: npm
+          cache: yarn
 
       # Ensure everything is compiling
       - run: "yarn install"

--- a/.github/workflows/DeploySvelteLanguageServerProd.yml
+++ b/.github/workflows/DeploySvelteLanguageServerProd.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
-          cache: npm
+          cache: yarn
 
       # Ensure everything is compiling
       - run: "yarn install"

--- a/.github/workflows/DeploySvelteLanguageServerProd.yml
+++ b/.github/workflows/DeploySvelteLanguageServerProd.yml
@@ -11,10 +11,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       # Ensure everything is compiling
       - run: "yarn install"
@@ -28,9 +29,9 @@ jobs:
 
       # Ship it
       - run: |
-         cd packages/language-server
-         npm install
-         npm publish
+          cd packages/language-server
+          npm install
+          npm publish
 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/DeployTypescriptPluginProd.yaml
+++ b/.github/workflows/DeployTypescriptPluginProd.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
-          cache: npm
+          cache: yarn
 
       # Ensure everything is compiling
       - run: "yarn install"

--- a/.github/workflows/DeployTypescriptPluginProd.yaml
+++ b/.github/workflows/DeployTypescriptPluginProd.yaml
@@ -11,10 +11,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       # Ensure everything is compiling
       - run: "yarn install"
@@ -28,9 +29,9 @@ jobs:
 
       # Ship it
       - run: |
-         cd packages/typescript-plugin
-         npm install
-         npm publish
+          cd packages/typescript-plugin
+          npm install
+          npm publish
 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
