### PR TITLE
(perf) add priority queue

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -262,9 +262,10 @@ export function startServer(options?: LSOptions) {
     });
 
     connection.onDidCloseTextDocument((evt) => docManager.closeDocument(evt.textDocument.uri));
-    connection.onDidChangeTextDocument((evt) =>
-        docManager.updateDocument(evt.textDocument, evt.contentChanges)
-    );
+    connection.onDidChangeTextDocument((evt) => {
+        docManager.updateDocument(evt.textDocument, evt.contentChanges);
+        pluginHost.didUpdateDocument();
+    });
     connection.onHover((evt) => pluginHost.doHover(evt.textDocument, evt.position));
     connection.onCompletion((evt, cancellationToken) =>
         pluginHost.getCompletions(evt.textDocument, evt.position, evt.context, cancellationToken)


### PR DESCRIPTION
Give certain requests priority.
If a request doesn't have priority, we first wait 1 second to
1. let higher priority requests get through first
2. wait for possible document changes, which make the request wait again

This hopefully makes perceived responsiveness of the language server better. It helped in my tests, especially because semantic tokens are computed less often.
#1098, #1130, #1139