### PR TITLE
(fix) more robust update-imports

### DIFF
--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -287,6 +287,14 @@ export function getLineAtPosition(position: Position, text: string) {
 }
 
 /**
+ * Assumption: Is called with a line. A line does only contain line break characters
+ * at its end.
+ */
+export function isAtEndOfLine(line: string, offset: number): boolean {
+    return [undefined, '\r', '\n'].includes(line[offset]);
+}
+
+/**
  * Updates a relative import
  *
  * @param oldPath Old absolute path

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -13,6 +13,7 @@ import {
 import {
     Document,
     getLineAtPosition,
+    isAtEndOfLine,
     isRangeInTag,
     mapRangeToOriginal
 } from '../../../lib/documents';
@@ -148,7 +149,10 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
             range.end.character += 1;
             if (
                 fragment instanceof SvelteSnapshotFragment &&
-                getLineAtPosition(range.end, fragment.originalText).length <= range.end.character
+                isAtEndOfLine(
+                    getLineAtPosition(range.end, fragment.originalText),
+                    range.end.character
+                )
             ) {
                 range.end.line += 1;
                 range.end.character = 0;


### PR DESCRIPTION
Previous check would fail in case of \r\n because then it's two EOL-characters instead of one. The new check fixes this.