### PR TITLE
(fix) more plugin startup checks

### DIFF
--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -66,7 +66,15 @@ function init(modules: { typescript: typeof ts }) {
             (!compilerOptions.jsxFactory || compilerOptions.jsxFactory.startsWith('svelte')) &&
             !compilerOptions.jsxFragmentFactory &&
             !compilerOptions.jsxImportSource;
-        return isNoJsxProject;
+        try {
+            const isSvelteProject =
+                typeof compilerOptions.configFilePath !== 'string' ||
+                require.resolve('svelte', { paths: [compilerOptions.configFilePath] });
+            return isNoJsxProject && isSvelteProject;
+        } catch (e) {
+            // If require.resolve fails, we end up here
+            return false;
+        }
     }
 
     return { create, getExternalFiles };


### PR DESCRIPTION
Check if the Svelte package can be resolved which hints at a Svelte project in order to determine if the typescript plugin should be loaded