### PR TITLE
(svelte-check) npm run build failed in svelte-check

### DIFF
--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -92,7 +92,9 @@ async function getDiagnostics(
         );
         return result;
     } catch (err) {
-        writer.failure(err);
+        if (err instanceof Error) {
+            writer.failure(err);
+        }
         return null;
     }
 }


### PR DESCRIPTION
There was 1 error inside the catch block when building svelte-check.  
I used a branch by instanceof and avoided it.

```sh
npm run build 

... 

src/index.ts:95:24 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'Error'.

95         writer.failure(err);
                          ~~~

Found 1 error.
```

