### PR TITLE
(fix) don't do any diagnostics for node_module files

### DIFF
--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -75,6 +75,20 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
             throw new Error('Cannot call methods on an unopened document');
         }
 
+        if (
+            (document.getFilePath()?.includes('/node_modules/') ||
+                document.getFilePath()?.includes('\\node_modules\\')) &&
+            // Sapper convention: Put stuff inside node_modules below src
+            !(
+                document.getFilePath()?.includes('/src/node_modules/') ||
+                document.getFilePath()?.includes('\\src\\node_modules\\')
+            )
+        ) {
+            // Don't return diagnostics for files inside node_modules. These are considered read-only (cannot be changed)
+            // and in case of svelte-check they would pollute/skew the output
+            return [];
+        }
+
         return flatten(
             await this.execute<Diagnostic[]>(
                 'getDiagnostics',

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -15,20 +15,6 @@ export class DiagnosticsProviderImpl implements DiagnosticsProvider {
         document: Document,
         cancellationToken?: CancellationToken
     ): Promise<Diagnostic[]> {
-        if (
-            (document.getFilePath()?.includes('/node_modules/') ||
-                document.getFilePath()?.includes('\\node_modules\\')) &&
-            // Sapper convention: Put stuff inside node_modules below src
-            !(
-                document.getFilePath()?.includes('/src/node_modules/') ||
-                document.getFilePath()?.includes('\\src\\node_modules\\')
-            )
-        ) {
-            // Don't return diagnostics for files inside node_modules. These are considered read-only (cannot be changed)
-            // and in case of svelte-check they would pollute/skew the output
-            return [];
-        }
-
         const { lang, tsDoc } = await this.getLSAndTSDoc(document);
 
         if (


### PR DESCRIPTION
Previously, only TS diagnostics were omitted
#1056