### PR TITLE
(feat) error-forgiving parser

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/await.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/await.ts
@@ -3,6 +3,7 @@ import { IfScope } from './if-scope';
 import { TemplateScopeManager } from './template-scope';
 import { surroundWithIgnoreComments } from '../../utils/ignore';
 import { BaseNode } from '../../interfaces';
+import { fillMissingExpressionAndEnd } from '../utils/node-utils';
 
 /**
  * Transform {#await ...} into something JSX understands
@@ -14,6 +15,7 @@ export function handleAwait(
     ifScope: IfScope,
     templateScopeManager: TemplateScopeManager
 ): void {
+    fillMissingExpressionAndEnd(awaitBlock, 'await', htmlx);
     // {#await somePromise then value} ->
     // {() => {let _$$p = (somePromise);
     let ifCondition = ifScope.getFullCondition();

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/each.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/each.ts
@@ -1,6 +1,7 @@
 import MagicString from 'magic-string';
 import { Node } from 'estree-walker';
 import { IfScope } from './if-scope';
+import { fillMissingExpressionAndEnd } from '../utils/node-utils';
 
 /**
  * Transform each block into something JSX can understand.
@@ -11,6 +12,7 @@ export function handleEach(
     eachBlock: Node,
     ifScope: IfScope
 ): void {
+    fillMissingExpressionAndEnd(eachBlock, 'each', htmlx);
     // {#each items as item,i (key)} ->
     // {__sveltets_1_each(items, (item,i) => (key) && (possible if expression &&) <>
     const constRedeclares = ifScope.getConstDeclaration();

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/if-else.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/if-else.ts
@@ -1,6 +1,7 @@
 import MagicString from 'magic-string';
 import { IfScope } from './if-scope';
 import { BaseNode } from '../../interfaces';
+import { fillMissingExpressionAndEnd } from '../utils/node-utils';
 
 /**
  * {# if ...}...{/if}   --->   {() => {if(...){<>...</>}}}
@@ -11,6 +12,7 @@ export function handleIf(
     ifBlock: BaseNode,
     ifScope: IfScope
 ): void {
+    fillMissingExpressionAndEnd(ifBlock, 'if', htmlx);
     const endIf = htmlx.lastIndexOf('{', ifBlock.end - 1);
 
     if (ifBlock.elseif) {

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/if-scope.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/if-scope.ts
@@ -275,6 +275,9 @@ export class IfScope {
      * Adds a new child IfScope.
      */
     addNestedIf(expression: Node, str: MagicString): void {
+        if (!expression) {
+            return;
+        }
         const condition = this.getConditionInfo(str, expression);
         const ifScope = new IfScope(this.scope, { condition, type: IfType.If }, this);
         this.child = ifScope;
@@ -284,6 +287,9 @@ export class IfScope {
      * Adds a `else if` branch to the scope and enhances the condition accordingly.
      */
     addElseIf(expression: Node, str: MagicString): void {
+        if (!expression) {
+            return;
+        }
         const condition = this.getConditionInfo(str, expression);
         this.current = addElseIfCondition(this.current as IfCondition | ElseIfCondition, condition);
     }

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/key.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/key.ts
@@ -1,10 +1,12 @@
 import MagicString from 'magic-string';
 import { BaseNode } from '../../interfaces';
+import { fillMissingExpressionAndEnd } from '../utils/node-utils';
 
 /**
  * {#key expr}content{/key}   --->   {expr} content
  */
 export function handleKey(htmlx: string, str: MagicString, keyBlock: BaseNode): void {
+    fillMissingExpressionAndEnd(keyBlock, 'key', htmlx);
     // {#key expr}   ->   {expr}
     str.overwrite(keyBlock.start, keyBlock.expression.start, '{');
     const end = htmlx.indexOf('}', keyBlock.expression.end);

--- a/packages/svelte2tsx/src/htmlxtojsx/utils/node-utils.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/utils/node-utils.ts
@@ -225,3 +225,17 @@ export function getIdentifiersInIfExpression(
 export function usesLet(node: BaseNode): boolean {
     return node.attributes?.some((attr) => attr.type === 'Let');
 }
+
+export function fillMissingExpressionAndEnd<T extends BaseNode>(
+    node: T & { expression?: any },
+    blockStart: string,
+    originalStr: string
+): T & { expression: any } {
+    node.end = node.end || originalStr.length;
+    node.expression = node.expression || {};
+    node.expression.start =
+        node.expression?.start || originalStr.indexOf(blockStart, node.start) + blockStart.length;
+    node.expression.end =
+        node.expression?.end || originalStr.indexOf('}', node.start) || originalStr.length - 1;
+    return node as any;
+}


### PR DESCRIPTION
This adds some more robustness to svelte2tsx with regards to missing properties. This assumes that there's a Svelte parser mode which will continue parsing no matter what and ignore all errors along the way, resulting in a possibly very wrong but somewhat functional AST.
If such a parser mode was implemented in Svelte, it should return the first error it encountered, so that svelte2tsx can fall back to throwing this error if it encounters an error while parsing the broken AST.
I tested this and it resulted in better intellisense in situations where Svelte would bail out on the first parsing error.