### PR TITLE
(fix) adjust error message

### DIFF
--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -96,7 +96,7 @@ async function createParserErrorDiagnostic(error: any, document: Document) {
                 '\n\nIf you expect this syntax to work, here are some suggestions: ';
             if (isInScript) {
                 diagnostic.message +=
-                    '\nIf you use typescript with `svelte-preprocess`, did you add `lang="typescript"` to your `script` tag? ';
+                    '\nIf you use typescript with `svelte-preprocess`, did you add `lang="ts"` to your `script` tag? ';
             } else {
                 diagnostic.message +=
                     '\nIf you use less/SCSS with `svelte-preprocess`, did you add `lang="scss"`/`lang="less"` to you `style` tag? ' +

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -219,7 +219,7 @@ describe('SveltePlugin#getDiagnostics', () => {
                 message:
                     'expected x to not be here' +
                     '\n\nIf you expect this syntax to work, here are some suggestions: ' +
-                    '\nIf you use typescript with `svelte-preprocess`, did you add `lang="typescript"` to your `script` tag? ' +
+                    '\nIf you use typescript with `svelte-preprocess`, did you add `lang="ts"` to your `script` tag? ' +
                     '\nDid you setup a `svelte.config.js`? ' +
                     '\nSee https://github.com/sveltejs/language-tools/tree/master/docs#using-with-preprocessors for more info.',
                 range: {


### PR DESCRIPTION
suggest lang="ts" instead of lang="typescript" as the former is more common, shorter, and right now Vite does not support the latter