### PR TITLE
(chore) make interface typings more robust

### DIFF
--- a/docs/preprocessors/typescript.md
+++ b/docs/preprocessors/typescript.md
@@ -20,9 +20,10 @@ To tell us to treat your script tags as typescript, add a `lang` attribute to yo
 </script>
 ```
 
-You may optionally want to add a `svelte.config.js` file - but it is not required as long as you only use TypeScript.Depending on your setup, this config file needs to be written either in ESM-style or CJS-Style.
+You may optionally want to add a `svelte.config.js` file - but it is not required as long as you only use TypeScript. Depending on your setup, this config file needs to be written either in ESM-style or CJS-Style.
 
 ESM-style (for everything with `"type": "module"` in its `package.json`, like SvelteKit):
+
 ```js
 import sveltePreprocess from 'svelte-preprocess';
 
@@ -30,7 +31,9 @@ export default {
     preprocess: sveltePreprocess()
 };
 ```
+
 CJS-style:
+
 ```js
 const sveltePreprocess = require('svelte-preprocess');
 

--- a/packages/svelte2tsx/src/interfaces.ts
+++ b/packages/svelte2tsx/src/interfaces.ts
@@ -1,11 +1,5 @@
-import { ArrayPattern, ObjectPattern, Identifier } from 'estree';
-import {
-    Directive,
-    TemplateNode,
-    Transition,
-    MustacheTag,
-    Text
-} from 'svelte/types/compiler/interfaces';
+import { ArrayPattern, Identifier, ObjectPattern, Node } from 'estree';
+import { DirectiveType, TemplateNode } from 'svelte/types/compiler/interfaces';
 
 export interface NodeRange {
     start: number;
@@ -23,9 +17,21 @@ export interface WithName {
     name: string;
 }
 
-export type BaseNode = Exclude<TemplateNode, Text | MustacheTag | Directive | Transition>;
+// Copied from the Svelte type definitions
+export interface BaseNode {
+    start: number;
+    end: number;
+    type: string;
+    children?: TemplateNode[];
+    [prop_name: string]: any;
+}
 
-export type BaseDirective = Exclude<Directive, Transition>;
+export interface BaseDirective extends BaseNode {
+    type: DirectiveType;
+    expression: null | Node;
+    name: string;
+    modifiers: string[];
+}
 
 export interface Attribute extends BaseNode {
     value: BaseNode[] | true;


### PR DESCRIPTION
Less dependent on internal Svelte types which would require adjustments of the `BaseNode` type every time some new node is added