### PR TITLE
(perf) typescript language service size limit

### DIFF
--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -26,6 +26,7 @@ export class LSAndTSDocResolver {
         private readonly docManager: DocumentManager,
         private readonly workspaceUris: string[],
         private readonly configManager: LSConfigManager,
+        private readonly notifyExceedSizeLimit?: () => void,
         private readonly isSvelteCheck = false,
         private readonly tsconfigPath?: string
     ) {
@@ -69,7 +70,8 @@ export class LSAndTSDocResolver {
             ambientTypesSource: this.isSvelteCheck ? 'svelte-check' : 'svelte2tsx',
             createDocument: this.createDocument,
             transformOnTemplateError: !this.isSvelteCheck,
-            globalSnapshotsManager: this.globalSnapshotsManager
+            globalSnapshotsManager: this.globalSnapshotsManager,
+            notifyExceedSizeLimit: this.notifyExceedSizeLimit
         };
     }
 

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -13,7 +13,7 @@ import {
     ignoredBuildDirectories,
     SnapshotManager
 } from './SnapshotManager';
-import { ensureRealSvelteFilePath, findTsConfigPath } from './utils';
+import { ensureRealSvelteFilePath, findTsConfigPath, hasTsExtensions } from './utils';
 
 export interface LanguageServiceContainer {
     readonly tsconfigPath: string;
@@ -411,11 +411,7 @@ function getFilenameForExceededTotalSizeLimitForNonTsFiles(
 
     const filesNames = snapshotManager.getProjectFileNames();
     for (const fileName of filesNames) {
-        if (
-            fileName.endsWith(ts.Extension.Dts) ||
-            fileName.endsWith(ts.Extension.Tsx) ||
-            fileName.endsWith(ts.Extension.Dts)
-        ) {
+        if (hasTsExtensions(fileName)) {
             continue;
         }
 
@@ -426,7 +422,7 @@ function getFilenameForExceededTotalSizeLimitForNonTsFiles(
             totalNonTsFileSize > availableSpace
         ) {
             const top5LargestFiles = filesNames
-                .filter((name) => !name.endsWith('.ts'))
+                .filter((name) => !hasTsExtensions(name))
                 .map((name) => ({ name, size: ts.sys.getFileSize?.(name) ?? 0 }))
                 .sort((a, b) => b.size - a.size)
                 .slice(0, 5);

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -249,7 +249,12 @@ async function createLanguageService(
 
     function updateProjectFiles(): void {
         snapshotManager.updateProjectFiles();
-        if (lastFileExceededProgramSize) {
+        if (
+            getFilenameForExceededTotalSizeLimitForNonTsFiles(
+            compilerOptions,
+            tsconfigPath,
+            snapshotManager
+        )) {
             disableLanguageService();
         }
     }

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -163,7 +163,7 @@ async function createLanguageService(
     );
 
     if (lastFileExceededProgramSize) {
-        disableLanguageService();
+        reduceLanguageServiceCapability();
     }
 
     return {
@@ -251,11 +251,12 @@ async function createLanguageService(
         snapshotManager.updateProjectFiles();
         if (
             getFilenameForExceededTotalSizeLimitForNonTsFiles(
-            compilerOptions,
-            tsconfigPath,
-            snapshotManager
-        )) {
-            disableLanguageService();
+                compilerOptions,
+                tsconfigPath,
+                snapshotManager
+            )
+        ) {
+            reduceLanguageServiceCapability();
         }
     }
 
@@ -375,7 +376,12 @@ async function createLanguageService(
         return ['node_modules', ...ignoredBuildDirectories];
     }
 
-    function disableLanguageService() {
+    /**
+     * Disable usage of project files.
+     * running language service in a reduced mode for
+     * large projects with improperly excluded tsconfig.
+     */
+    function reduceLanguageServiceCapability() {
         languageService.cleanupSemanticCache();
         languageServiceReducedMode = true;
         docContext.notifyExceedSizeLimit?.();

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -49,6 +49,7 @@ export interface LanguageServiceDocumentContext {
     transformOnTemplateError: boolean;
     createDocument: (fileName: string, content: string) => Document;
     globalSnapshotsManager: GlobalSnapshotsManager;
+    notifyExceedSizeLimit: (() => void) | undefined;
 }
 
 export async function getService(
@@ -372,6 +373,7 @@ async function createLanguageService(
     function disableLanguageService() {
         languageService.cleanupSemanticCache();
         languageServiceReducedMode = true;
+        docContext.notifyExceedSizeLimit?.();
     }
 }
 

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -313,3 +313,11 @@ export function getDiagnosticTag(diagnostic: ts.Diagnostic): DiagnosticTag[] {
     }
     return tags;
 }
+
+export function hasTsExtensions(fileName: string) {
+    return (
+        fileName.endsWith(ts.Extension.Dts) ||
+        fileName.endsWith(ts.Extension.Tsx) ||
+        fileName.endsWith(ts.Extension.Dts)
+    );
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -145,7 +145,12 @@ export function startServer(options?: LSOptions) {
         pluginHost.register(
             new TypeScriptPlugin(
                 configManager,
-                new LSAndTSDocResolver(docManager, workspaceUris.map(normalizeUri), configManager)
+                new LSAndTSDocResolver(
+                    docManager,
+                    workspaceUris.map(normalizeUri),
+                    configManager,
+                    notifyTsServiceExceedSizeLimit
+                )
             )
         );
 
@@ -240,6 +245,16 @@ export function startServer(options?: LSOptions) {
             }
         };
     });
+
+    function notifyTsServiceExceedSizeLimit() {
+        connection?.sendNotification(ShowMessageNotification.type, {
+            message:
+                'Svelte language server detected large amount of js/svelte files. ' +
+                'To enable project-wide JavaScript/TypeScript language features for svelte files,' +
+                'exclude large folders with source files that you do not work on.',
+            type: MessageType.Warning
+        });
+    }
 
     connection.onExit(() => {
         watcher?.dispose();

--- a/packages/language-server/src/svelte-check.ts
+++ b/packages/language-server/src/svelte-check.ts
@@ -64,6 +64,7 @@ export class SvelteCheck {
                 this.docManager,
                 [pathToUrl(workspacePath)],
                 this.configManager,
+                undefined,
                 true,
                 options.tsconfig
             );


### PR DESCRIPTION
#965
Add a size limit for typescript language service similar to the one in the tsserver. When the size limit exceeds, ts language service goes into a reduced mode. Project-wide IntelliSense is disabled. It would only use the files opened in the client. Kind of like when you don't have a tsconfig.json file. When this happens a warning message will show up.  

Noted if you have a really big project and you have excluded everything needed but it still exceeds this limit. You can disable it with the `disableSizeLimit` compiler options in the tsconfig/jsconfig.