### PR TITLE
(fix) add open tag checks to html scanner

### DIFF
--- a/packages/language-server/src/lib/documents/parseHtml.ts
+++ b/packages/language-server/src/lib/documents/parseHtml.ts
@@ -42,7 +42,11 @@ function preprocess(text: string) {
         const offset = scanner.getTokenOffset();
 
         if (token === TokenType.StartTagOpen) {
-            currentStartTagStart = offset;
+            if (shouldBlankStartOrEndTagLike(offset)) {
+                blankStartOrEndTagLike(offset);
+            } else {
+                currentStartTagStart = offset;
+            }
         }
 
         if (token === TokenType.StartTagClose) {
@@ -74,11 +78,7 @@ function preprocess(text: string) {
     return text;
 
     function shouldBlankStartOrEndTagLike(offset: number) {
-        // not null rather than falsy, otherwise it won't work on first tag(0)
-        return (
-            currentStartTagStart !== null &&
-            isInsideMoustacheTag(text, currentStartTagStart, offset)
-        );
+        return isInsideMoustacheTag(text, currentStartTagStart, offset);
     }
 
     function blankStartOrEndTagLike(offset: number) {

--- a/packages/language-server/test/lib/documents/parseHtml.test.ts
+++ b/packages/language-server/test/lib/documents/parseHtml.test.ts
@@ -37,6 +37,22 @@ describe('parseHtml', () => {
         );
     });
 
+    it('ignore less than operator inside control flow moustache', () => {
+        testRootElements(
+            parseHtml(
+                `<Foo>
+                    {#if 1 < 2 && innWidth <= 700}
+                        <Foo>
+                            <SelfClosing />
+                        </Foo>
+                        <div>hi</div>
+                    {/if}
+                </Foo>
+                <style></style>`
+            )
+        );
+    });
+
     it('ignore less than operator inside moustache with tag not self closed', () => {
         testRootElements(
             parseHtml(
@@ -60,6 +76,19 @@ describe('parseHtml', () => {
         testRootElements(
             parseHtml(
                 `<Foo checked={a} />
+                <style></style>`
+            )
+        );
+    });
+
+    it('parse baseline html with control flow moustache', () => {
+        testRootElements(
+            parseHtml(
+                `<Foo>
+                    {#if true}
+                        foo
+                    {/if}
+                </Foo>
                 <style></style>`
             )
         );


### PR DESCRIPTION
the html parser does treat a "<" tag inside the body of another tag as the start of another tag. This is a common situation inside #if control flow tags, so these were blanked out inside parseTag previously. But that blanking logic did not take place when parsed html nodes were passed in. Therefore moved the logic of stripping #if tags inside the preprocess scanner.

@jasonlyu123 could you take a look since you wrote the preprocessing scanner originally?