### PR TITLE
(feat) auto-add types to exports when $$Props used

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -357,21 +357,24 @@ export function processInstanceScriptContent(
             handleTypeAssertion(str, node, astOffset);
         }
 
-        //to save a bunch of condition checks on each node, we recurse into processChild which skips all the checks for top level items
+        // to save a bunch of condition checks on each node, we recurse into processChild which skips all the checks for top level items
         ts.forEachChild(node, (n) => walk(n, node));
-        //fire off the on leave callbacks
+        // fire off the on leave callbacks
         onLeaveCallbacks.map((c) => c());
     };
 
-    //walk the ast and convert to tsx as we go
+    // walk the ast and convert to tsx as we go
     tsAst.forEachChild((n) => walk(n, tsAst));
 
-    //resolve stores
+    // resolve stores
     pendingStoreResolutions.map(resolveStore);
 
     // declare implicit reactive variables we found in the script
     implicitTopLevelNames.modifyCode(rootScope.declared);
     implicitStoreValues.modifyCode(astOffset, str);
+
+    // add types from $$Props to props that don't have a type defined
+    exportedNames.addTypesToExportsIf$$PropsUsed();
 
     const firstImport = tsAst.statements
         .filter(ts.isImportDeclaration)

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-auto-add-type/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-auto-add-type/expected.tsx
@@ -1,0 +1,24 @@
+///<reference types="svelte" />
+<></>;function render() {
+
+
+    interface $$Props {
+        exported1: string;
+        exported2?: boolean;
+        exported3: number;
+        exported4?: 'foo';
+        exported5?: '1';
+        exported6?: '2';
+    }
+
+     let exported1: $$Props['exported1'];
+     let exported2: $$Props['exported2'] = true;exported2 = __sveltets_1_any(exported2);;
+     let exported3: number;
+     let exported4: 'foo' = 'foo';exported4 = __sveltets_1_any(exported4);;
+     let exported5: '1' = '1';exported5 = __sveltets_1_any(exported5);;let  exported6: $$Props['exported6'] = '2';
+;
+() => (<></>);
+return { props: {...__sveltets_1_ensureRightProps<{exported1: typeof exported1,exported2?: typeof exported2,exported3: number,exported4?: 'foo',exported5?: '1',exported6?: typeof exported6}>(__sveltets_1_any("") as $$Props), ...__sveltets_1_ensureRightProps<Partial<$$Props>>({exported1: exported1,exported2: exported2,exported3: exported3,exported4: exported4,exported5: exported5,exported6: exported6}), ...{} as unknown as $$Props, ...{} as {}}, slots: {}, getters: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_with_any_event(render())) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-auto-add-type/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-auto-add-type/input.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+
+    interface $$Props {
+        exported1: string;
+        exported2?: boolean;
+        exported3: number;
+        exported4?: 'foo';
+        exported5?: '1';
+        exported6?: '2';
+    }
+
+    export let exported1;
+    export let exported2 = true;
+    export let exported3: number;
+    export let exported4: 'foo' = 'foo';
+    export let exported5: '1' = '1', exported6 = '2';
+</script>


### PR DESCRIPTION
So people don't have to do the type work twice
TODO: results in buggy behavior for rename