### PR TITLE
(fix) improve bind:this diagnostics

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -1898,4 +1898,127 @@ describe('DiagnosticsProvider', () => {
             }
         ]);
     });
+
+    it('diagnoses bind:this', async () => {
+        const { plugin, document } = setup('diagnostics-bind-this.svelte');
+
+        const diagnostics = await plugin.getDiagnostics(document);
+        assert.deepStrictEqual(diagnostics, [
+            {
+                range: {
+                    start: {
+                        line: 14,
+                        character: 6
+                    },
+                    end: {
+                        line: 14,
+                        character: 13
+                    }
+                },
+                severity: 4,
+                source: 'ts',
+                message: "'element' is declared but its value is never read.",
+                code: 6133,
+                tags: [1]
+            },
+            {
+                range: {
+                    start: {
+                        line: 23,
+                        character: 2
+                    },
+                    end: {
+                        line: 23,
+                        character: 11
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                message: "Variable 'component' is used before being assigned.",
+                code: 2454,
+                tags: []
+            },
+            {
+                range: {
+                    start: {
+                        line: 44,
+                        character: 16
+                    },
+                    end: {
+                        line: 44,
+                        character: 23
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                message:
+                    "Type 'HTMLDivElement' is missing the following properties from type 'HTMLInputElement': accept, alt, autocomplete, capture, and 51 more.",
+                code: 2740,
+                tags: []
+            },
+            {
+                range: {
+                    start: {
+                        line: 45,
+                        character: 34
+                    },
+                    end: {
+                        line: 45,
+                        character: 48
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                message:
+                    "Type 'Component' is not assignable to type 'OtherComponent'.\n" +
+                    "  Types of property '$set' are incompatible.\n" +
+                    "    Type '(props?: Partial<{ prop: boolean; }> | undefined) => void' is not assignable to type '(props?: Partial<{ prop: string; }> | undefined) => void'.\n" +
+                    "      Types of parameters 'props' and 'props' are incompatible.\n" +
+                    "        Type 'Partial<{ prop: string; }> | undefined' is not assignable to type 'Partial<{ prop: boolean; }> | undefined'.\n" +
+                    "          Type 'Partial<{ prop: string; }>' is not assignable to type 'Partial<{ prop: boolean; }>'.\n" +
+                    "            Types of property 'prop' are incompatible.\n" +
+                    "              Type 'string | undefined' is not assignable to type 'boolean | undefined'.\n" +
+                    "                Type 'string' is not assignable to type 'boolean | undefined'.",
+                code: 2322,
+                tags: []
+            },
+            {
+                range: {
+                    start: {
+                        line: 46,
+                        character: 35
+                    },
+                    end: {
+                        line: 46,
+                        character: 57
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                message:
+                    "Type 'ComponentWithFunction1' is not assignable to type 'ComponentWithFunction2'.\n" +
+                    "  Types of property 'action' are incompatible.\n" +
+                    "    Type '(a: number) => string | number' is not assignable to type '() => string'.",
+                code: 2322,
+                tags: []
+            },
+            {
+                range: {
+                    start: {
+                        line: 47,
+                        character: 46
+                    },
+                    end: {
+                        line: 47,
+                        character: 60
+                    }
+                },
+                severity: 1,
+                source: 'ts',
+                message: "Type 'Component' is not assignable to type 'OtherComponent'.",
+                code: 2322,
+                tags: []
+            }
+        ]);
+    });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/diagnostics-bind-this.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/diagnostics-bind-this.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { SvelteComponentTyped } from 'svelte';
+  class Component extends SvelteComponentTyped<{prop: boolean}> {}
+  class OtherComponent extends SvelteComponentTyped<{prop: string}> {}
+  class ComponentWithFunction1 extends SvelteComponentTyped {
+      action(a: number): string | number {
+          return a;
+      }
+  }
+  class ComponentWithFunction2 extends SvelteComponentTyped {
+      action(): string { return ''; }
+  }
+  class ComponentWithGeneric<T> extends SvelteComponentTyped<{prop: T}> {}
+
+  let element: HTMLInputElement;
+  let component: Component;
+  let otherComponent: OtherComponent;
+  let componentWithFunction1: ComponentWithFunction1;
+  let componentWithFunction2: ComponentWithFunction2;
+  let componentWithGeneric: ComponentWithGeneric<string>;
+
+  // element not read -> error
+  // used before being assigned (allowed only after on mount)
+  component;
+
+  $: otherComponent && console.log('foo');
+  function callback() {
+    otherComponent;
+    componentWithFunction1;
+    componentWithFunction2;
+    componentWithGeneric;
+  }
+  callback();
+</script>
+
+<!-- correct -->
+<input bind:this={element} />
+<Component prop={true} bind:this={component} />
+<ComponentWithFunction1 bind:this={componentWithFunction1} />
+<ComponentWithFunction2 bind:this={componentWithFunction1} />
+<ComponentWithGeneric prop={''} bind:this={componentWithGeneric} />
+<svelte:component this={Component} bind:this={component} />
+
+<!-- errors -->
+<div bind:this={element} />
+<Component prop={true} bind:this={otherComponent} />
+<ComponentWithFunction1 bind:this={componentWithFunction2} />
+<svelte:component this={Component} bind:this={otherComponent} />
+
+<!-- ideally throws an error, but for now the generated code isn't in a way which makes it throw an error -->
+<ComponentWithGeneric prop={true} bind:this={componentWithGeneric} />

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-component/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-component/expected.jsx
@@ -1,1 +1,1 @@
-<><Component type="radio" {...__sveltets_1_empty((element = __sveltets_1_instanceOf(Component) || null))} value="Plain"/></>
+<><Component type="radio" {...__sveltets_1_empty((element = /*Ωignore_startΩ*/new Component({target: __sveltets_1_any(''), props: __sveltets_1_any('')})/*Ωignore_endΩ*/))} value="Plain"/></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-body/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-body/expected.jsx
@@ -1,1 +1,1 @@
-<><sveltebody {...__sveltets_1_ensureType(HTMLBodyElement, element)} /></>
+<><sveltebody {...__sveltets_1_empty((element = /*Ωignore_startΩ*/__sveltets_1_instanceOf(HTMLBodyElement)/*Ωignore_endΩ*/))} /></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-component/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-component/expected.jsx
@@ -1,1 +1,1 @@
-<><sveltecomponent this={A} {...__sveltets_1_empty((element = __sveltets_1_instanceOf(A) || null))} /></>
+<><sveltecomponent this={A} {...__sveltets_1_empty((element = /*Ωignore_startΩ*/new (A)({target: __sveltets_1_any(''), props: __sveltets_1_any('')})/*Ωignore_endΩ*/))} /></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-self/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this-svelte-self/expected.jsx
@@ -1,3 +1,3 @@
 <>{(false) ? <>
-    <svelteself {...__sveltets_1_empty((element = __sveltets_1_instanceOf(__sveltets_1_componentType()) || null))} />
+    <svelteself {...__sveltets_1_empty((element = /*Ωignore_startΩ*/__sveltets_1_instanceOf(__sveltets_1_componentType())/*Ωignore_endΩ*/))} />
 </> : <></>}</>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-this/expected.jsx
@@ -1,1 +1,1 @@
-<><input type="radio" {...__sveltets_1_ensureType(__sveltets_1_ctorOf(__sveltets_1_mapElementTag('input')), element)} value="Plain"/></>
+<><input type="radio" {...__sveltets_1_empty((element = /*Ωignore_startΩ*/__sveltets_1_instanceOf(__sveltets_1_ctorOf(__sveltets_1_mapElementTag('input')))/*Ωignore_endΩ*/))} value="Plain"/></>

--- a/packages/svelte2tsx/test/sourcemaps/samples/component-props/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/component-props/mappings.jsx
@@ -27,11 +27,11 @@
 
 <Component                                                                                                                                            {/**
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-    {...__sveltets_1_empty((bar = __sveltets_1_instanceOf(Component) || null))}                                                                       {/**
-   ╚{...__sveltets_1_empty((bar•=•__sveltets_1_instanceOf(Component)•||•null))}↲    [generated] line 18                                               
-   ╚b                       bar                                    }           ↲                                                                      
+    {...__sveltets_1_empty((bar = /*Ωignore_startΩ*/new Component({target: __sveltets_1_any(''), props: __sveltets_1_any('')})/*Ωignore_endΩ*/))}     {/**
+   ╚{...__sveltets_1_empty((bar•=•/*Ωignore_startΩ*/new•Component({target:•__sveltets_1_any(''),•props:•__sveltets_1_any('')})/*Ωignore_endΩ*/))}↲    [generated] line 18
+   ╚b                       bar}                                                                                                                 ↲    
    ╚b          bar}↲                                                                                                                                  
-   ╚bind:this={bar}↲                                                                [original] line 16                                                
+   ╚bind:this={bar}↲                                                                                                                                  [original] line 16 
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
 /></>                                                                                                                                                 {/**
 /></>↲    [generated] line 19                                                                                                                         

--- a/packages/svelte2tsx/test/sourcemaps/samples/large-sample-1/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/large-sample-1/mappings.jsx
@@ -323,11 +323,11 @@ s
             </div>
                                                                                                                                                       {/**
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-            <div class="chapter-markup" {...__sveltets_1_ensureType(__sveltets_1_ctorOf(__sveltets_1_mapElementTag('div')), scrollable)}>             {/**
-         ╚╚╚<div•class="chapter-markup"•{...__sveltets_1_ensureType(__sveltets_1_ctorOf(__sveltets_1_mapElementTag('div')),•scrollable)}>↲    [generated] line 139
-         ╚╚╚<div•c    ="chapter-markup"•                                                                                    scrollable} >↲            
-         ╚╚╚<div•c    ="chapter-markup"•           scrollable}>↲                                                                                      
-         ╚╚╚<div•class="chapter-markup"•bind:this={scrollable}>↲                                                                              [original] line 278 
+            <div class="chapter-markup" {...__sveltets_1_empty((scrollable = /*Ωignore_startΩ*/__sveltets_1_instanceOf(__sveltets_1_ctorOf(__sveltets_1_mapElementTag('div')))/*Ωignore_endΩ*/))}>{/**
+         ╚╚╚<div•class="chapter-markup"•{...__sveltets_1_empty((scrollable•=•/*Ωignore_startΩ*/__sveltets_1_instanceOf(__sveltets_1_ctorOf(__sveltets_1_mapElementTag('div')))/*Ωignore_endΩ*/))}>↲    [generated] line 139
+         ╚╚╚<div•c    ="chapter-markup"•b                       scrollable}                                                                                                                      >↲    
+         ╚╚╚<div•c    ="chapter-markup"•b          scrollable}>↲                                                                                                                                       
+         ╚╚╚<div•class="chapter-markup"•bind:this={scrollable}>↲                                                                                                                                       [original] line 278 
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
                 { chapter.html}                                                                                                                       {/**
             ╚╚╚╚{•chapter.html}↲         [generated] line 140                                                                                         
@@ -400,11 +400,11 @@ s
         <div class="tutorial-repl">
             <Repl                                                                                                                                     {/**
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-                {...__sveltets_1_empty((repl = __sveltets_1_instanceOf(Repl) || null))}                                                               {/**
-            ╚╚╚╚{...__sveltets_1_empty((repl•=•__sveltets_1_instanceOf(Repl)•||•null))}↲    [generated] line 163                                      
-            ╚╚╚╚b                       repl                               }           ↲                                                              
-            ╚╚╚╚b          repl}↲                                                                                                                     
-            ╚╚╚╚bind:this={repl}↲                                                           [original] line 303                                       
+                {...__sveltets_1_empty((repl = /*Ωignore_startΩ*/new Repl({target: __sveltets_1_any(''), props: __sveltets_1_any('')})/*Ωignore_endΩ*/))}{/**
+            ╚╚╚╚{...__sveltets_1_empty((repl•=•/*Ωignore_startΩ*/new•Repl({target:•__sveltets_1_any(''),•props:•__sveltets_1_any('')})/*Ωignore_endΩ*/))}↲    [generated] line 163
+            ╚╚╚╚b                       repl}                                                                                                            ↲    
+            ╚╚╚╚b          repl}↲                                                                                                                             
+            ╚╚╚╚bind:this={repl}↲                                                                                                                             [original] line 303 
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
                 workersUrl="workers"                                                                                                                  {/**
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/slot-bind-this/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/slot-bind-this/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 /*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_1_createEnsureSlot();/*Ωignore_endΩ*/
-<><slot name="s" {...__sveltets_1_ensureType(HTMLSlotElement, s)} /></>
+<><slot name="s" {...__sveltets_1_empty((s = /*Ωignore_startΩ*/__sveltets_1_instanceOf(HTMLSlotElement)/*Ωignore_endΩ*/))} /></>
 return { props: {}, slots: {'s': {}}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {


### PR DESCRIPTION
This may result in some more type errors occuring (rightfully so)
- Will now detect if variable is used before being assigned
- Will now detect if variable is only assigned to but never read
- More correct typings for the instance type of a component/element which silences false positives and may surface previously hidden type bugs

Closes #1214  

@mvolfik FYI I dug into this some more and refined/finished the implementation. As you can see we don't need `copy` as the code in question is completely generated (needs no mapping to the original code).