### PR TITLE
(fix) string completion with special characters

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -275,10 +275,9 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         if (isSvelteComp && existingImports.has(label)) {
             return null;
         }
-        const textEdit =
-            replacementSpan && insertText
-                ? TextEdit.replace(convertRange(fragment, replacementSpan), insertText)
-                : undefined;
+        const textEdit = replacementSpan
+            ? TextEdit.replace(convertRange(fragment, replacementSpan), insertText ?? label)
+            : undefined;
 
         return {
             label,
@@ -324,11 +323,11 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             };
         }
 
-        if (insertText && comp.replacementSpan) {
+        if (comp.replacementSpan) {
             return {
                 label: name,
                 isSvelteComp,
-                insertText: changeSvelteComponentName(insertText),
+                insertText: insertText ? changeSvelteComponentName(insertText) : undefined,
                 replacementSpan: comp.replacementSpan
             };
         }

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1109,6 +1109,47 @@ describe('CompletionProviderImpl', () => {
             }
         });
     });
+
+    it('provide replacement for string completions', async () => {
+        const { completionProvider, document } = setup('string-completion.svelte');
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            {
+                line: 1,
+                character: 10
+            },
+            {
+                triggerKind: CompletionTriggerKind.Invoked
+            }
+        );
+
+        const item = completions?.items.find((item) => item.label === '@hi');
+
+        delete item?.data;
+
+        assert.deepStrictEqual(item, {
+            label: '@hi',
+            kind: CompletionItemKind.Constant,
+            sortText: '11',
+            preselect: undefined,
+            insertText: undefined,
+            commitCharacters: undefined,
+            textEdit: {
+                newText: '@hi',
+                range: {
+                    end: {
+                        character: 10,
+                        line: 1
+                    },
+                    start: {
+                        character: 9,
+                        line: 1
+                    }
+                }
+            }
+        });
+    });
 });
 
 function harmonizeNewLines(input?: string) {

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/string-completion.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/string-completion.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    abc('@');
+
+    function abc(str: 'hi' | '@hi' | '~hi') {}
+</script>


### PR DESCRIPTION
#1226 #1211

Changes to always use the `replacementSpan` typescript provides. And map it to the `TextEdit`. The issue also happens in string literal type so I just use that to write tests.