### PR TITLE
Allow usage of alternative config file names other than `tsconfig.json` and `jsconfig.json`

### DIFF
--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'path';
+import { dirname, basename } from 'path';
 import ts from 'typescript';
 import {
     CompletionItemKind,
@@ -106,8 +106,10 @@ export function convertToLocationRange(defDoc: SnapshotFragment, textSpan: ts.Te
 
 export function findTsConfigPath(fileName: string, rootUris: string[]) {
     const searchDir = dirname(fileName);
+    const configName = basename(fileName);
 
     const path =
+        configName.endsWith('.json') ? ts.findConfigFile(searchDir, ts.sys.fileExists, configName) : null ||
         ts.findConfigFile(searchDir, ts.sys.fileExists, 'tsconfig.json') ||
         ts.findConfigFile(searchDir, ts.sys.fileExists, 'jsconfig.json') ||
         '';


### PR DESCRIPTION
This change will allow alternative config file names other than the standard convention to be used (e.g. `tsconfig.dev.json`). Issue #1232 

Was confused why the `--tsconfig` flag for svelte-check wasn't working as expected when I included the filename, but realised it's just ignored inside this helper.