### PR TITLE
(fix) Component auto Import when the import specifier config is js

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -328,6 +328,9 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
 
         const name = node.tagName.getText();
         const suffixedName = name + '__SvelteComponent_';
+        const errorPreventingUserPreferences =
+            this.completionProvider.fixUserPreferencesForSvelteComponentImport(userPreferences);
+
         const toFix = (c: ts.CompletionEntry) =>
             lang
                 .getCompletionEntryDetails(
@@ -336,7 +339,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                     c.name,
                     {},
                     c.source,
-                    userPreferences,
+                    errorPreventingUserPreferences,
                     c.data
                 )
                 ?.codeActions?.map((a) => ({

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -392,6 +392,11 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         return completionItem;
     }
 
+    /**
+     * TypeScript throws a debug assertion error if the importModuleSpecifierEnding config is
+     * 'js' and there's an unknown file extension - which is the case for `.svelte`. Therefore
+     * rewrite the importModuleSpecifierEnding for this case to silence the error.
+     */
     fixUserPreferencesForSvelteComponentImport(
         userPreferences: ts.UserPreferences
     ): ts.UserPreferences {

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -392,6 +392,19 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         return completionItem;
     }
 
+    fixUserPreferencesForSvelteComponentImport(
+        userPreferences: ts.UserPreferences
+    ): ts.UserPreferences {
+        if (userPreferences.importModuleSpecifierEnding === 'js') {
+            return {
+                ...userPreferences,
+                importModuleSpecifierEnding: 'auto'
+            };
+        }
+
+        return userPreferences;
+    }
+
     async resolveCompletion(
         document: Document,
         completionItem: AppCompletionItem<CompletionEntryWithIdentifer>,
@@ -409,6 +422,9 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         }
 
         const fragment = await tsDoc.getFragment();
+        const errorPreventingUserPreferences = this.isSvelteComponentImport(comp.name)
+            ? this.fixUserPreferencesForSvelteComponentImport(userPreferences)
+            : userPreferences;
 
         const detail = lang.getCompletionEntryDetails(
             filePath,
@@ -416,7 +432,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             comp.name,
             {},
             comp.source,
-            userPreferences,
+            errorPreventingUserPreferences,
             comp.data
         );
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -398,7 +398,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         if (userPreferences.importModuleSpecifierEnding === 'js') {
             return {
                 ...userPreferences,
-                importModuleSpecifierEnding: 'auto'
+                importModuleSpecifierEnding: 'index'
             };
         }
 
@@ -422,7 +422,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         }
 
         const fragment = await tsDoc.getFragment();
-        const errorPreventingUserPreferences = this.isSvelteComponentImport(comp.name)
+        const errorPreventingUserPreferences = comp.source?.endsWith('.svelte')
             ? this.fixUserPreferencesForSvelteComponentImport(userPreferences)
             : userPreferences;
 

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -136,7 +136,7 @@ describe('ts user preferences', () => {
     const expectedComponentImportEdit = "import Imports from '~/imports.svelte';";
 
     function setupImportModuleSpecifierEndingJs() {
-        const { docManager, document } = setup('code-action.svelte');
+        const { docManager, document } = setup('module-specifier-js.svelte');
         const lsAndTsDocResolver = createLSAndTSDocResolver(docManager, {
             preferences: {
                 importModuleSpecifier: 'non-relative',
@@ -161,6 +161,24 @@ describe('ts user preferences', () => {
         const item = completions?.items.find((item) => item.label === 'Imports');
         const { additionalTextEdits } = await completionProvider.resolveCompletion(document, item!);
         assert.strictEqual(additionalTextEdits![0].newText.trim(), expectedComponentImportEdit);
+    });
+
+    it('provides auto import for context="module" export when importModuleSpecifierEnding is js', async () => {
+        const { document, lsAndTsDocResolver } = setupImportModuleSpecifierEndingJs();
+
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            Position.create(1, 6)
+        );
+
+        const item = completions?.items.find((item) => item.label === 'hi');
+        const { additionalTextEdits } = await completionProvider.resolveCompletion(document, item!);
+        assert.strictEqual(
+            additionalTextEdits![0].newText.trim(),
+            "import { hi } from '~/with-context-module.svelte';"
+        );
     });
 
     it('provides import code action for svelte component when importModuleSpecifierEnding is js', async () => {

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -132,4 +132,62 @@ describe('ts user preferences', () => {
         const item = completions?.items.find((item) => item.label === 'definition');
         assert.strictEqual(item, undefined, 'Expected no auto import suggestions');
     });
+
+    const expectedComponentImportEdit = "import Imports from '~/imports.svelte';";
+
+    function setupImportModuleSpecifierEndingJs() {
+        const { docManager, document } = setup('code-action.svelte');
+        const lsAndTsDocResolver = createLSAndTSDocResolver(docManager, {
+            preferences: {
+                importModuleSpecifier: 'non-relative',
+                importModuleSpecifierEnding: 'js',
+                quoteStyle: 'single'
+            }
+        });
+
+        return { document, lsAndTsDocResolver };
+    }
+
+    it('provides auto import for svelte component when importModuleSpecifierEnding is js', async () => {
+        const { document, lsAndTsDocResolver } = setupImportModuleSpecifierEndingJs();
+
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            Position.create(4, 8)
+        );
+
+        const item = completions?.items.find((item) => item.label === 'Imports');
+        const { additionalTextEdits } = await completionProvider.resolveCompletion(document, item!);
+        assert.strictEqual(additionalTextEdits![0].newText.trim(), expectedComponentImportEdit);
+    });
+
+    it('provides import code action for svelte component when importModuleSpecifierEnding is js', async () => {
+        const range = Range.create(Position.create(4, 1), Position.create(4, 8));
+        const { document, lsAndTsDocResolver } = setupImportModuleSpecifierEndingJs();
+
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const codeActionProvider = new CodeActionsProviderImpl(
+            lsAndTsDocResolver,
+            completionProvider
+        );
+
+        const codeAction = await codeActionProvider.getCodeActions(document, range, {
+            diagnostics: [
+                Diagnostic.create(
+                    range,
+                    "Cannot find name 'Imports'",
+                    DiagnosticSeverity.Error,
+                    2304,
+                    'ts'
+                )
+            ]
+        });
+
+        const documentChange = codeAction[0].edit?.documentChanges?.[0] as
+            | TextDocumentEdit
+            | undefined;
+        assert.strictEqual(documentChange?.edits[0].newText.trim(), expectedComponentImportEdit);
+    });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/preferences/code-action.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/preferences/code-action.svelte
@@ -1,3 +1,5 @@
 <script lang="ts">
     definition
 </script>
+
+<Imports></Imports>

--- a/packages/language-server/test/plugins/typescript/testfiles/preferences/module-specifier-js.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/preferences/module-specifier-js.svelte
@@ -1,3 +1,5 @@
 <script lang="ts">
-    definition
+    hi
 </script>
+
+<Imports></Imports>

--- a/packages/language-server/test/plugins/typescript/testfiles/preferences/with-context-module.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/preferences/with-context-module.svelte
@@ -1,0 +1,3 @@
+<script lang="ts" context="module">
+    export function hi() {}
+</script>


### PR DESCRIPTION
Possibly related to #1187
typescript would throw a debug assertion error if the `importModuleSpecifierEnding` config is `js` and there's an unknown file extension.

Although it's probably better to fix this on the typescript side. But it would probably take a while. So I add a workaround for now. Not all cases are fixed. But at least it's less likely to happen. 