### PR TITLE
(fix) various emmet fixes

### DIFF
--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -219,17 +219,42 @@ export class CSSPlugin
         }
 
         const lang = getLanguageService(type);
-        const emmetResults: CompletionList = (this.configManager.getConfig().css.completions
-            .emmet &&
-            doEmmetComplete(
-                cssDocument,
-                cssDocument.getGeneratedPosition(position),
-                getLanguage(type),
-                this.configManager.getEmmetConfig()
-            )) || {
+        let emmetResults: CompletionList = {
             isIncomplete: false,
             items: []
         };
+        if (
+            this.configManager.getConfig().css.completions.emmet &&
+            this.configManager.getEmmetConfig().showExpandedAbbreviation !== 'never'
+        ) {
+            lang.setCompletionParticipants([
+                {
+                    onCssProperty: (context) => {
+                        if (context?.propertyName) {
+                            emmetResults =
+                                doEmmetComplete(
+                                    cssDocument,
+                                    cssDocument.getGeneratedPosition(position),
+                                    getLanguage(type),
+                                    this.configManager.getEmmetConfig()
+                                ) || emmetResults;
+                        }
+                    },
+                    onCssPropertyValue: (context) => {
+                        if (context?.propertyValue) {
+                            emmetResults =
+                                doEmmetComplete(
+                                    cssDocument,
+                                    cssDocument.getGeneratedPosition(position),
+                                    getLanguage(type),
+                                    this.configManager.getEmmetConfig()
+                                ) || emmetResults;
+                        }
+                    }
+                }
+            ]);
+        }
+
         const results = lang.doComplete(
             cssDocument,
             cssDocument.getGeneratedPosition(position),

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -88,12 +88,27 @@ export class HTMLPlugin
             return null;
         }
 
-        const emmetResults: CompletionList = (this.configManager.getConfig().html.completions
-            .emmet &&
-            doEmmetComplete(document, position, 'html', this.configManager.getEmmetConfig())) || {
+        let emmetResults: CompletionList = {
             isIncomplete: false,
             items: []
         };
+        if (
+            this.configManager.getConfig().html.completions.emmet &&
+            this.configManager.getEmmetConfig().showExpandedAbbreviation !== 'never'
+        ) {
+            this.lang.setCompletionParticipants([
+                {
+                    onHtmlContent: () =>
+                        (emmetResults =
+                            doEmmetComplete(
+                                document,
+                                position,
+                                'html',
+                                this.configManager.getEmmetConfig()
+                            ) || emmetResults)
+                }
+            ]);
+        }
 
         const results = this.isInComponentTag(html, document, position)
             ? // Only allow emmet inside component element tags.

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -89,11 +89,13 @@ export function activate(context: ExtensionContext) {
         documentSelector: [{ scheme: 'file', language: 'svelte' }],
         revealOutputChannelOn: RevealOutputChannelOn.Never,
         synchronize: {
+            // TODO deprecated, rework upon next VS Code minimum version bump
             configurationSection: [
                 'svelte',
+                'prettier',
+                'emmet',
                 'javascript',
                 'typescript',
-                'prettier',
                 'css',
                 'less',
                 'scss'


### PR DESCRIPTION
- add back completion participant behavior, using old emmet code that was thrown out as inspiration. That way emmet completions don't show up in weird places
- don't show completions when user disabled emmet completions through emmet VS Code settings
- synchronize updates to VS Code emmet settings with language server