### PR TITLE
(fix) Adhere to code formatting settings when organizing imports

### DIFF
--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -1,6 +1,7 @@
-import { merge, get } from 'lodash';
+import { get, merge } from 'lodash';
 import { UserPreferences } from 'typescript';
 import { VSCodeEmmetConfig } from 'vscode-emmet-helper';
+import { returnObjectIfHasKeys } from './utils';
 
 /**
  * Default config for the language server.
@@ -338,6 +339,29 @@ export class LSConfigManager {
 
     getPrettierConfig(): any {
         return this.prettierConfig;
+    }
+
+    /**
+     * Returns a merged Prettier config following these rules:
+     * - If `prettierFromFileConfig` exists, that one is returned
+     * - Else the Svelte extension's Prettier config is used as a starting point,
+     *   and overridden by a possible Prettier config from the Prettier extension,
+     *   or, if that doesn't exist, a possible fallback override.
+     */
+    getMergedPrettierConfig(
+        prettierFromFileConfig: any,
+        overridesWhenNoPrettierConfig: any = {}
+    ): any {
+        return (
+            returnObjectIfHasKeys(prettierFromFileConfig) ||
+            merge(
+                {}, // merge into empty obj to not manipulate own config
+                this.get('svelte.format.config'),
+                returnObjectIfHasKeys(this.getPrettierConfig()) ||
+                    overridesWhenNoPrettierConfig ||
+                    {}
+            )
+        );
     }
 
     updateTsJsUserPreferences(config: Record<TsUserConfigLang, TSUserConfig>): void {

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -1,21 +1,22 @@
 import {
+    CancellationToken,
     CodeAction,
     CodeActionContext,
+    CompletionContext,
     CompletionList,
     Diagnostic,
     FormattingOptions,
     Hover,
     Position,
     Range,
-    TextEdit,
-    WorkspaceEdit,
     SelectionRange,
-    CancellationToken,
-    CompletionContext
+    TextEdit,
+    WorkspaceEdit
 } from 'vscode-languageserver';
-import { Document } from '../../lib/documents';
-import { LSConfigManager, LSSvelteConfig } from '../../ls-config';
 import { getPackageInfo, importPrettier } from '../../importPackage';
+import { Document } from '../../lib/documents';
+import { Logger } from '../../logger';
+import { LSConfigManager, LSSvelteConfig } from '../../ls-config';
 import {
     CodeActionsProvider,
     CompletionsProvider,
@@ -28,10 +29,8 @@ import { executeCommand, getCodeActions } from './features/getCodeActions';
 import { getCompletions } from './features/getCompletions';
 import { getDiagnostics } from './features/getDiagnostics';
 import { getHoverInfo } from './features/getHoverInfo';
-import { SvelteCompileResult, SvelteDocument } from './SvelteDocument';
-import { Logger } from '../../logger';
 import { getSelectionRange } from './features/getSelectionRanges';
-import { merge } from 'lodash';
+import { SvelteCompileResult, SvelteDocument } from './SvelteDocument';
 
 export class SveltePlugin
     implements
@@ -75,19 +74,14 @@ export class SveltePlugin
         const filePath = document.getFilePath()!;
         const prettier = importPrettier(filePath);
         // Try resolving the config through prettier and fall back to possible editor config
-        const config =
-            returnObjectIfHasKeys(await prettier.resolveConfig(filePath, { editorconfig: true })) ||
-            merge(
-                {}, // merge into empty obj to not manipulate own config
-                this.configManager.get('svelte.format.config'),
-                returnObjectIfHasKeys(this.configManager.getPrettierConfig()) ||
-                    // Be defensive here because IDEs other than VSCode might not have these settings
-                    (options && {
-                        tabWidth: options.tabSize,
-                        useTabs: !options.insertSpaces
-                    }) ||
-                    {}
-            );
+        const config = this.configManager.getMergedPrettierConfig(
+            await prettier.resolveConfig(filePath, { editorconfig: true }),
+            // Be defensive here because IDEs other than VSCode might not have these settings
+            options && {
+                tabWidth: options.tabSize,
+                useTabs: !options.insertSpaces
+            }
+        );
         // If user has prettier-plugin-svelte 1.x, then remove `options` from the sort
         // order or else it will throw a config error (`options` was not present back then).
         if (
@@ -136,12 +130,6 @@ export class SveltePlugin
                 .getSupportInfo()
                 .languages.some((l) => l.name === 'svelte');
             return hasPluginLoadedAlready ? [] : [require.resolve('prettier-plugin-svelte')];
-        }
-
-        function returnObjectIfHasKeys<T>(obj: T | undefined): T | undefined {
-            if (Object.keys(obj || {}).length > 0) {
-                return obj;
-            }
         }
     }
 

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -100,7 +100,8 @@ export class TypeScriptPlugin
         this.completionProvider = new CompletionsProviderImpl(this.lsAndTsDocResolver);
         this.codeActionsProvider = new CodeActionsProviderImpl(
             this.lsAndTsDocResolver,
-            this.completionProvider
+            this.completionProvider,
+            configManager
         );
         this.updateImportsProvider = new UpdateImportsProviderImpl(this.lsAndTsDocResolver);
         this.diagnosticsProvider = new DiagnosticsProviderImpl(this.lsAndTsDocResolver);

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -109,7 +109,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                         if (!useSemicolons) {
                             // For some reason the TS language service ignores the formatOptions
                             // we set above, so remove possible semicolons here.
-                            edit.newText = edit.newText.replace(/(;(\n))|(;(\r\n))/g, (match) =>
+                            edit.newText = edit.newText.replace(/(;\n)|(;\r\n)/g, (match) =>
                                 match.substring(1)
                             );
                         }

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -96,6 +96,8 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
             },
             {
                 semicolons: useSemicolons
+                    ? ts.SemicolonPreference.Insert
+                    : ts.SemicolonPreference.Remove
             },
             userPreferences
         );
@@ -106,13 +108,6 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                 return TextDocumentEdit.create(
                     OptionalVersionedTextDocumentIdentifier.create(document.url, null),
                     change.textChanges.map((edit) => {
-                        if (!useSemicolons) {
-                            // For some reason the TS language service ignores the formatOptions
-                            // we set above, so remove possible semicolons here.
-                            edit.newText = edit.newText.replace(/(;\n)|(;\r\n)/g, (match) =>
-                                match.substring(1)
-                            );
-                        }
                         const range = this.checkRemoveImportCodeActionRange(
                             edit,
                             fragment,

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -1,6 +1,6 @@
-import { URI } from 'vscode-uri';
-import { Position, Range } from 'vscode-languageserver';
 import { Node } from 'vscode-html-languageservice';
+import { Position, Range } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
 
 export function clamp(num: number, min: number, max: number): number {
     return Math.max(min, Math.min(max, num));
@@ -239,4 +239,13 @@ export function getIndent(text: string) {
  */
 export function possiblyComponent(node: Node): boolean {
     return !!node.tag?.[0].match(/[A-Z]/);
+}
+
+/**
+ * If the object if it has entries, else undefined
+ */
+export function returnObjectIfHasKeys<T>(obj: T | undefined): T | undefined {
+    if (Object.keys(obj || {}).length > 0) {
+        return obj;
+    }
 }

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -1,20 +1,20 @@
-import { DocumentManager, Document } from '../../../../src/lib/documents';
-import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
-import { CodeActionsProviderImpl } from '../../../../src/plugins/typescript/features/CodeActionsProvider';
-import { pathToUrl } from '../../../../src/utils';
-import ts from 'typescript';
-import * as path from 'path';
 import * as assert from 'assert';
+import * as path from 'path';
+import ts from 'typescript';
 import {
-    Range,
-    Position,
-    CodeActionKind,
-    TextDocumentEdit,
+    CancellationTokenSource,
     CodeAction,
-    CancellationTokenSource
+    CodeActionKind,
+    Position,
+    Range,
+    TextDocumentEdit
 } from 'vscode-languageserver';
-import { CompletionsProviderImpl } from '../../../../src/plugins/typescript/features/CompletionProvider';
+import { Document, DocumentManager } from '../../../../src/lib/documents';
 import { LSConfigManager } from '../../../../src/ls-config';
+import { CodeActionsProviderImpl } from '../../../../src/plugins/typescript/features/CodeActionsProvider';
+import { CompletionsProviderImpl } from '../../../../src/plugins/typescript/features/CompletionProvider';
+import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
+import { pathToUrl } from '../../../../src/utils';
 
 const testDir = path.join(__dirname, '..');
 
@@ -41,7 +41,11 @@ describe('CodeActionsProvider', () => {
             new LSConfigManager()
         );
         const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
-        const provider = new CodeActionsProviderImpl(lsAndTsDocResolver, completionProvider);
+        const provider = new CodeActionsProviderImpl(
+            lsAndTsDocResolver,
+            completionProvider,
+            new LSConfigManager()
+        );
         const filePath = getFullPath(filename);
         const document = docManager.openDocument(<any>{
             uri: pathToUrl(filePath),

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -1,7 +1,6 @@
-import ts from 'typescript';
 import assert from 'assert';
 import { join } from 'path';
-
+import ts from 'typescript';
 import {
     CodeActionContext,
     Diagnostic,
@@ -11,11 +10,11 @@ import {
     TextDocumentEdit
 } from 'vscode-languageserver';
 import { Document, DocumentManager } from '../../../../src/lib/documents';
+import { LSConfigManager, TSUserConfig } from '../../../../src/ls-config';
+import { CodeActionsProviderImpl } from '../../../../src/plugins/typescript/features/CodeActionsProvider';
 import { CompletionsProviderImpl } from '../../../../src/plugins/typescript/features/CompletionProvider';
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { pathToUrl } from '../../../../src/utils';
-import { CodeActionsProviderImpl } from '../../../../src/plugins/typescript/features/CodeActionsProvider';
-import { LSConfigManager, TSUserConfig } from '../../../../src/ls-config';
 
 const testFilesDir = join(__dirname, '..', 'testfiles', 'preferences');
 
@@ -88,7 +87,8 @@ describe('ts user preferences', () => {
         const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
         const codeActionProvider = new CodeActionsProviderImpl(
             lsAndTsDocResolver,
-            completionProvider
+            completionProvider,
+            new LSConfigManager()
         );
 
         const codeAction = await codeActionProvider.getCodeActions(document, range, context);
@@ -188,7 +188,8 @@ describe('ts user preferences', () => {
         const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
         const codeActionProvider = new CodeActionsProviderImpl(
             lsAndTsDocResolver,
-            completionProvider
+            completionProvider,
+            new LSConfigManager()
         );
 
         const codeAction = await codeActionProvider.getCodeActions(document, range, {


### PR DESCRIPTION
Add semicolon or not depending on Prettier config
#1260

Doesn't work yet, for some reason TS does not care about us passing the setting in, may need to do a regex replacement.
