### PR TITLE
(fix) new line for ts completion and code action

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -150,7 +150,8 @@ async function createLanguageService(
         getDirectories: ts.sys.getDirectories,
         useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
         getScriptKind: (fileName: string) => getSnapshot(fileName).scriptKind,
-        getProjectVersion: () => projectVersion.toString()
+        getProjectVersion: () => projectVersion.toString(),
+        getNewLine: () => ts.sys.newLine
     };
 
     let languageService = ts.createLanguageService(host);

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -300,7 +300,9 @@ describe('CodeActionsProvider', () => {
                         {
                             edits: [
                                 {
-                                    newText: harmonizeNewLines("import Empty from '../empty.svelte';\n"),
+                                    newText: harmonizeNewLines(
+                                        "import Empty from '../empty.svelte';\n"
+                                    ),
                                     range: {
                                         end: Position.create(5, 0),
                                         start: Position.create(5, 0)

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -300,7 +300,7 @@ describe('CodeActionsProvider', () => {
                         {
                             edits: [
                                 {
-                                    newText: "import Empty from '../empty.svelte';\r\n",
+                                    newText: harmonizeNewLines("import Empty from '../empty.svelte';\n"),
                                     range: {
                                         end: Position.create(5, 0),
                                         start: Position.create(5, 0)

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1150,6 +1150,25 @@ describe('CompletionProviderImpl', () => {
             }
         });
     });
+
+    it('auto import with system new line', async () => {
+        const { completionProvider, document } = setup('importcompletions-new-line.svelte');
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            Position.create(1, 7)
+        );
+
+        const items = completions?.items.filter((item) => item.label === 'ScndImport');
+        const item = items?.[0];
+
+        const { additionalTextEdits } = await completionProvider.resolveCompletion(document, item!);
+
+        assert.strictEqual(
+            additionalTextEdits?.[0].newText,
+            `${newLine}import { ScndImport } from "./to-import";${newLine}${newLine}`
+        );
+    });
 });
 
 function harmonizeNewLines(input?: string) {

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/importcompletions-new-line.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/importcompletions-new-line.svelte
@@ -1,0 +1,3 @@
+<script>
+    Scn
+</script>


### PR DESCRIPTION
Related to #854. This come up multiple times mainly for coc-svelte folks. Finally found out Typescript default to CRLF if `host.getNewLine` is not implemented and if there's no user config: 

https://github.com/microsoft/TypeScript/blob/97a7901f26290a13ea6c3b057c8720c1614cb221/src/services/utilities.ts#L2352