### PR TITLE
Add default script language completion

### DIFF
--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -297,6 +297,10 @@ Enable code actions for Svelte. _Default_: `true`
 
 Enable selection range for Svelte. _Default_: `true`
 
+##### `svelte.plugin.svelte.defaultScriptLanguage`
+
+The default language to use when generating new script tags in Svelte. _Default_: `none`
+
 ## Credits
 
 -   [James Birtles](https://github.com/jamesbirtles) for creating the foundation which this language server is built on

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -61,7 +61,8 @@ const defaultLSConfig: LSConfig = {
         completions: { enable: true },
         hover: { enable: true },
         codeActions: { enable: true },
-        selectionRange: { enable: true }
+        selectionRange: { enable: true },
+        defaultScriptLanguage: 'none'
     }
 };
 
@@ -198,6 +199,7 @@ export interface LSSvelteConfig {
     selectionRange: {
         enable: boolean;
     };
+    defaultScriptLanguage: 'none' | 'ts';
 }
 
 /**

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -97,7 +97,10 @@ export class TypeScriptPlugin
     constructor(configManager: LSConfigManager, lsAndTsDocResolver: LSAndTSDocResolver) {
         this.configManager = configManager;
         this.lsAndTsDocResolver = lsAndTsDocResolver;
-        this.completionProvider = new CompletionsProviderImpl(this.lsAndTsDocResolver, this.configManager);
+        this.completionProvider = new CompletionsProviderImpl(
+            this.lsAndTsDocResolver,
+            this.configManager
+        );
         this.codeActionsProvider = new CodeActionsProviderImpl(
             this.lsAndTsDocResolver,
             this.completionProvider,

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -97,7 +97,7 @@ export class TypeScriptPlugin
     constructor(configManager: LSConfigManager, lsAndTsDocResolver: LSAndTSDocResolver) {
         this.configManager = configManager;
         this.lsAndTsDocResolver = lsAndTsDocResolver;
-        this.completionProvider = new CompletionsProviderImpl(this.lsAndTsDocResolver);
+        this.completionProvider = new CompletionsProviderImpl(this.lsAndTsDocResolver, this.configManager);
         this.codeActionsProvider = new CodeActionsProviderImpl(
             this.lsAndTsDocResolver,
             this.completionProvider,

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -21,6 +21,7 @@ import {
     mapRangeToOriginal,
     toRange
 } from '../../../lib/documents';
+import { LSConfigManager } from '../../../ls-config';
 import { flatten, getRegExpMatches, isNotNullOrUndefined, pathToUrl } from '../../../utils';
 import { AppCompletionItem, AppCompletionList, CompletionsProvider } from '../../interfaces';
 import { ComponentPartInfo } from '../ComponentInfoProvider';
@@ -50,7 +51,7 @@ type LastCompletion = {
 };
 
 export class CompletionsProviderImpl implements CompletionsProvider<CompletionEntryWithIdentifer> {
-    constructor(private readonly lsAndTsDocResolver: LSAndTSDocResolver) {}
+    constructor(private readonly lsAndTsDocResolver: LSAndTSDocResolver, private readonly configManager: LSConfigManager) {}
 
     /**
      * The language service throws an error if the character is not a valid trigger character.
@@ -530,9 +531,12 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         const scriptTagInfo = fragment.scriptInfo || fragment.moduleScriptInfo;
         if (!scriptTagInfo) {
             // no script tag defined yet, add it.
+            const lang = this.configManager.getConfig().svelte.defaultScriptLanguage;
+            const scriptLang = lang === 'none' ? '' : ` lang="${lang}"`;
+
             return TextEdit.replace(
                 beginOfDocumentRange,
-                `<script>${ts.sys.newLine}${change.newText}</script>${ts.sys.newLine}`
+                `<script${scriptLang}>${ts.sys.newLine}${change.newText}</script>${ts.sys.newLine}`
             );
         }
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -532,7 +532,8 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         if (!scriptTagInfo) {
             // no script tag defined yet, add it.
             const lang = this.configManager.getConfig().svelte.defaultScriptLanguage;
-            const scriptLang = lang === 'none' ? '' : ` lang="${lang}"`;
+            const useLang = lang && lang !== 'none';
+            const scriptLang = useLang ? ` lang="${lang}"` : '';
 
             return TextEdit.replace(
                 beginOfDocumentRange,

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -51,7 +51,10 @@ type LastCompletion = {
 };
 
 export class CompletionsProviderImpl implements CompletionsProvider<CompletionEntryWithIdentifer> {
-    constructor(private readonly lsAndTsDocResolver: LSAndTSDocResolver, private readonly configManager: LSConfigManager) {}
+    constructor(
+        private readonly lsAndTsDocResolver: LSAndTSDocResolver,
+        private readonly configManager: LSConfigManager
+    ) {}
 
     /**
      * The language service throws an error if the character is not a valid trigger character.

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -535,8 +535,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         if (!scriptTagInfo) {
             // no script tag defined yet, add it.
             const lang = this.configManager.getConfig().svelte.defaultScriptLanguage;
-            const useLang = lang && lang !== 'none';
-            const scriptLang = useLang ? ` lang="${lang}"` : '';
+            const scriptLang = lang === 'none' ? '' : ` lang="${lang}"`;
 
             return TextEdit.replace(
                 beginOfDocumentRange,

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -40,8 +40,10 @@ describe('CodeActionsProvider', () => {
             [pathToUrl(testDir)],
             new LSConfigManager()
         );
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, 
-            new LSConfigManager());
+        const completionProvider = new CompletionsProviderImpl(
+            lsAndTsDocResolver,
+            new LSConfigManager()
+        );
         const provider = new CodeActionsProviderImpl(
             lsAndTsDocResolver,
             completionProvider,

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -40,7 +40,8 @@ describe('CodeActionsProvider', () => {
             [pathToUrl(testDir)],
             new LSConfigManager()
         );
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, 
+            new LSConfigManager());
         const provider = new CodeActionsProviderImpl(
             lsAndTsDocResolver,
             completionProvider,

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -41,7 +41,7 @@ describe('CompletionProviderImpl', () => {
             [pathToUrl(testDir)],
             new LSConfigManager()
         );
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
         const filePath = join(testFilesDir, filename);
         const document = docManager.openDocument(<any>{
             uri: pathToUrl(filePath),

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -41,7 +41,10 @@ describe('CompletionProviderImpl', () => {
             [pathToUrl(testDir)],
             new LSConfigManager()
         );
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
+        const completionProvider = new CompletionsProviderImpl(
+            lsAndTsDocResolver,
+            new LSConfigManager()
+        );
         const filePath = join(testFilesDir, filename);
         const document = docManager.openDocument(<any>{
             uri: pathToUrl(filePath),

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -64,7 +64,7 @@ describe('ts user preferences', () => {
     it('provides auto import completion according to preferences', async () => {
         const { docManager, document } = setup('code-action.svelte');
         const lsAndTsDocResolver = createLSAndTSDocResolver(docManager);
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -84,7 +84,7 @@ describe('ts user preferences', () => {
     ) {
         const { docManager, document } = setup(filename);
         const lsAndTsDocResolver = createLSAndTSDocResolver(docManager);
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
         const codeActionProvider = new CodeActionsProviderImpl(
             lsAndTsDocResolver,
             completionProvider,
@@ -122,7 +122,7 @@ describe('ts user preferences', () => {
                 includeCompletionsForImportStatements: undefined
             }
         });
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -151,7 +151,7 @@ describe('ts user preferences', () => {
     it('provides auto import for svelte component when importModuleSpecifierEnding is js', async () => {
         const { document, lsAndTsDocResolver } = setupImportModuleSpecifierEndingJs();
 
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -166,7 +166,7 @@ describe('ts user preferences', () => {
     it('provides auto import for context="module" export when importModuleSpecifierEnding is js', async () => {
         const { document, lsAndTsDocResolver } = setupImportModuleSpecifierEndingJs();
 
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -185,7 +185,7 @@ describe('ts user preferences', () => {
         const range = Range.create(Position.create(4, 1), Position.create(4, 8));
         const { document, lsAndTsDocResolver } = setupImportModuleSpecifierEndingJs();
 
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
         const codeActionProvider = new CodeActionsProviderImpl(
             lsAndTsDocResolver,
             completionProvider,

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -64,7 +64,10 @@ describe('ts user preferences', () => {
     it('provides auto import completion according to preferences', async () => {
         const { docManager, document } = setup('code-action.svelte');
         const lsAndTsDocResolver = createLSAndTSDocResolver(docManager);
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
+        const completionProvider = new CompletionsProviderImpl(
+            lsAndTsDocResolver,
+            new LSConfigManager()
+        );
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -84,7 +87,10 @@ describe('ts user preferences', () => {
     ) {
         const { docManager, document } = setup(filename);
         const lsAndTsDocResolver = createLSAndTSDocResolver(docManager);
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
+        const completionProvider = new CompletionsProviderImpl(
+            lsAndTsDocResolver,
+            new LSConfigManager()
+        );
         const codeActionProvider = new CodeActionsProviderImpl(
             lsAndTsDocResolver,
             completionProvider,
@@ -122,7 +128,10 @@ describe('ts user preferences', () => {
                 includeCompletionsForImportStatements: undefined
             }
         });
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
+        const completionProvider = new CompletionsProviderImpl(
+            lsAndTsDocResolver,
+            new LSConfigManager()
+        );
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -151,7 +160,10 @@ describe('ts user preferences', () => {
     it('provides auto import for svelte component when importModuleSpecifierEnding is js', async () => {
         const { document, lsAndTsDocResolver } = setupImportModuleSpecifierEndingJs();
 
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
+        const completionProvider = new CompletionsProviderImpl(
+            lsAndTsDocResolver,
+            new LSConfigManager()
+        );
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -166,7 +178,10 @@ describe('ts user preferences', () => {
     it('provides auto import for context="module" export when importModuleSpecifierEnding is js', async () => {
         const { document, lsAndTsDocResolver } = setupImportModuleSpecifierEndingJs();
 
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
+        const completionProvider = new CompletionsProviderImpl(
+            lsAndTsDocResolver,
+            new LSConfigManager()
+        );
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -185,7 +200,10 @@ describe('ts user preferences', () => {
         const range = Range.create(Position.create(4, 1), Position.create(4, 8));
         const { document, lsAndTsDocResolver } = setupImportModuleSpecifierEndingJs();
 
-        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, new LSConfigManager());
+        const completionProvider = new CompletionsProviderImpl(
+            lsAndTsDocResolver,
+            new LSConfigManager()
+        );
         const codeActionProvider = new CodeActionsProviderImpl(
             lsAndTsDocResolver,
             completionProvider,

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -382,6 +382,13 @@
                     "default": true,
                     "title": "Svelte: Rename",
                     "description": "Enable rename/move Svelte files functionality"
+                },
+                "svelte.plugin.svelte.defaultScriptLanguage": {
+                    "type": "string",
+                    "default": "none",
+                    "title": "Svelte: Default Script Language",
+                    "description": "The default language to use when generating new script tags",
+                    "enum": ["none", "ts"]
                 }
             }
         },

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -388,7 +388,10 @@
                     "default": "none",
                     "title": "Svelte: Default Script Language",
                     "description": "The default language to use when generating new script tags",
-                    "enum": ["none", "ts"]
+                    "enum": [
+                        "none",
+                        "ts"
+                    ]
                 }
             }
         },


### PR DESCRIPTION
This PR fixes #1262 by adding a new configuration option: `svelte.plugin.svelte.defaultScriptLanguage`. This option can either be `none` or `ts`, which will configure Svelte VSCode to use `<script>` or `<script lang="ts">` respectively when generating new script tags on auto import.

Let me know if you'd like any changes. Thanks!