### PR TITLE
(fix) Language Server: ignore refs in generated tsx / non user code

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/FindReferencesProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/FindReferencesProvider.ts
@@ -43,9 +43,7 @@ export class FindReferencesProviderImpl implements FindReferencesProvider {
                 })
         );
 
-        const nonZeroLocations = locations.filter(hasNonZeroRange);
-
-        return nonZeroLocations.length > 0 ? nonZeroLocations : locations;
+        return locations.filter(hasNonZeroRange);
     }
 
     private async getLSAndTSDoc(document: Document) {

--- a/packages/language-server/src/plugins/typescript/features/FindReferencesProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/FindReferencesProvider.ts
@@ -45,7 +45,7 @@ export class FindReferencesProviderImpl implements FindReferencesProvider {
 
         const nonZeroLocations = locations.filter(hasNonZeroRange);
 
-        return nonZeroLocations.length > 0 ? nonZeroLocations : locations
+        return nonZeroLocations.length > 0 ? nonZeroLocations : locations;
     }
 
     private async getLSAndTSDoc(document: Document) {

--- a/packages/language-server/src/plugins/typescript/features/FindReferencesProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/FindReferencesProvider.ts
@@ -42,7 +42,8 @@ export class FindReferencesProviderImpl implements FindReferencesProvider {
                     );
                 })
         );
-
+        // Some references are in generated code but not wrapped with explicit ignore comments.
+        // These show up as zero-length ranges, so filter them out.
         return locations.filter(hasNonZeroRange);
     }
 

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -104,6 +104,13 @@ export function convertToLocationRange(defDoc: SnapshotFragment, textSpan: ts.Te
     return range;
 }
 
+export function hasNonZeroRange({ range }: { range?: Range }) {
+    return (
+        range &&
+        (range.start.line !== range.end.line || range.start.character !== range.end.character)
+    );
+}
+
 export function findTsConfigPath(fileName: string, rootUris: string[]) {
     const searchDir = dirname(fileName);
 

--- a/packages/language-server/test/plugins/typescript/features/FindReferencesProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/FindReferencesProvider.test.ts
@@ -191,4 +191,57 @@ describe('FindReferencesProvider', () => {
             }
         ]);
     });
+
+    it('ignores references inside generated TSX code', async () => {
+        const file = 'find-references-ignore-generated-tsx.svelte';
+        const uri = getUri(file);
+        const { provider, document } = setup(file);
+
+        const pos = Position.create(3, 15);
+        const results = await provider.findReferences(document, pos, {
+            includeDeclaration: true
+        });
+
+        assert.deepStrictEqual(results, [
+            {
+                uri,
+                range: {
+                    start: {
+                        line: 1,
+                        character: 13
+                    },
+                    end: {
+                        line: 1,
+                        character: 16
+                    }
+                }
+            },
+            {
+                uri,
+                range: {
+                    start: {
+                        line: 3,
+                        character: 14
+                    },
+                    end: {
+                        line: 3,
+                        character: 17
+                    }
+                }
+            },
+            {
+                uri,
+                range: {
+                    start: {
+                        line: 7,
+                        character: 4
+                    },
+                    end: {
+                        line: 7,
+                        character: 7
+                    }
+                }
+            }
+        ]);
+    });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/find-references-ignore-generated-tsx.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/find-references-ignore-generated-tsx.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  export let foo = false;
+
+  console.log(foo);
+
+</script>
+
+<p>{foo}</p>


### PR DESCRIPTION
A lot of variables references currently end up in generated tsx but are not surrounded by "generated code" guards.

For example, this:

```svelte
<script lang="ts">
  export let foo = false;
  console.log(foo);
</script>
<p>{foo}</p>
```

becomes this:

```tsx
///<reference types="svelte" />
<></>;function render() {

   let foo = false;foo = __sveltets_1_any(foo);;
  console.log(foo);
;
() => (<>
<p>{foo}</p>
</>);
return { props: {foo: foo} as {foo?: typeof foo}, slots: {}, getters: {}, events: {} }}

export default class FindReferencesIgnoreGeneratedTsx__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_with_any_event(render())) {
}
```

As a result, the language servers currently emits references for locations (and refs / code) that don't exist in user's source code.

It turns out those ghost references are petty easy to filter out because, as they don't match anything in user's code, they are source mapped back to 0 length ranges.

I believe it is always safe to ignore zero-length references since I don't see how any IDE feature could benefit from them. You can't refactor/rename a zero-length text. On the other hand, references navigation plugins are harmed by those incorrect refs, since the references don't actually exist in user code.

This PR adds a test that illustrates the problem, and implements filtering of zero-length references to make it pass.