### PR TITLE
vscodeIgnore some unused files to optimize extension size

### DIFF
--- a/packages/svelte-vscode/.vscodeignore
+++ b/packages/svelte-vscode/.vscodeignore
@@ -2,3 +2,17 @@
 /src
 /scripts
 /.vscode
+
+node_modules/@types
+node_modules/typescript/loc
+node_modules/typescript/lib/*/*
+node_modules/typescript/lib/tsc.js
+node_modules/typescript/lib/tsserver.js
+node_modules/typescript/lib/tsserverlibrary.js
+node_modules/typescript/lib/typescriptServices.js
+node_modules/typescript/lib/typingsInstaller.js
+node_modules/prettier/esm
+node_modules/svelte/compiler.mjs
+node_modules/svelte/compiler.mjs.map
+node_modules/vscode-css-languageservice/lib/esm
+node_modules/vscode-html-languageservice/lib/esm

--- a/packages/svelte-vscode/.vscodeignore
+++ b/packages/svelte-vscode/.vscodeignore
@@ -4,13 +4,31 @@
 /.vscode
 
 node_modules/@types
+
+# typescript localization files
 node_modules/typescript/loc
-node_modules/typescript/lib/*/*
+node_modules/typescript/lib/cs
+node_modules/typescript/lib/de
+node_modules/typescript/lib/es
+node_modules/typescript/lib/fr
+node_modules/typescript/lib/it
+node_modules/typescript/lib/ja
+node_modules/typescript/lib/ko
+node_modules/typescript/lib/pl
+node_modules/typescript/lib/pt-br
+node_modules/typescript/lib/ru
+node_modules/typescript/lib/tr
+node_modules/typescript/lib/zh-cn
+node_modules/typescript/lib/zh-tw
+
+# unused typescript builds
 node_modules/typescript/lib/tsc.js
 node_modules/typescript/lib/tsserver.js
 node_modules/typescript/lib/tsserverlibrary.js
 node_modules/typescript/lib/typescriptServices.js
 node_modules/typescript/lib/typingsInstaller.js
+
+# esm builds
 node_modules/prettier/esm
 node_modules/svelte/compiler.mjs
 node_modules/svelte/compiler.mjs.map

--- a/packages/svelte-vscode/.vscodeignore
+++ b/packages/svelte-vscode/.vscodeignore
@@ -25,7 +25,9 @@ node_modules/typescript/lib/zh-tw
 node_modules/typescript/lib/tsc.js
 node_modules/typescript/lib/tsserver.js
 node_modules/typescript/lib/tsserverlibrary.js
+node_modules/typescript/lib/tsserverlibrary.d.ts
 node_modules/typescript/lib/typescriptServices.js
+node_modules/typescript/lib/typescriptServices.d.ts
 node_modules/typescript/lib/typingsInstaller.js
 
 # esm builds


### PR DESCRIPTION
#139 

- Ignore some different purpose builds for typescript. We didn't use them.
- Ignore typescript localization. We didn't enable localized diagnostic.
- Ignore large ESM files, We're currently using common js

Tested and it brings the size down from 105MB to 42MB. With this file size reduction, it might make sense to ship some commonly used preprocess libraries to improve UX. 
About typescript localization, it's possible to enable this. So if we want to enable it in the future, I think we can keep these files. 

To test packaging this, run these commands:
```sh
rm package.json yarn.lock
cd packages/svelte-vscode
yarn install
vsce package
```

And install the vsix file or unzip it to see the folder structure. 