### PR TITLE
(fix) Adjust invalid position in ParserError diagnostics

### DIFF
--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -64,9 +64,9 @@ async function tryGetDiagnostics(
             .map((diag) => adjustMappings(diag, document))
             .filter((diag) => isNoFalsePositive(diag, document));
     } catch (err) {
-        return (await createParserErrorDiagnostic(err, document)).map((diag) =>
-            mapObjWithRangeToOriginal(transpiled, diag)
-        );
+        return (await createParserErrorDiagnostic(err, document))
+            .map((diag) => mapObjWithRangeToOriginal(transpiled, diag))
+            .map((diag) => adjustMappings(diag, document));
     }
 }
 

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -238,6 +238,43 @@ describe('SveltePlugin#getDiagnostics', () => {
         ]);
     });
 
+    it('expect valid position for compilation error', async () => {
+        const message =
+            'Stores must be declared at the top level of the component (this may change in a future version of Svelte)';
+        (
+            await expectDiagnosticsFor({
+                getTranspiled: () => ({
+                    getOriginalPosition: () => Position.create(-1, -1)
+                }),
+                getCompiled: () => {
+                    const e: any = new Error();
+                    e.message = message;
+                    e.code = 123;
+                    e.start = { line: 1, column: 8 };
+                    throw e;
+                },
+                config: {}
+            })
+        ).toEqual([
+            {
+                code: 123,
+                message,
+                range: {
+                    start: {
+                        character: 0,
+                        line: 0
+                    },
+                    end: {
+                        character: 0,
+                        line: 0
+                    }
+                },
+                severity: DiagnosticSeverity.Error,
+                source: 'svelte'
+            }
+        ]);
+    });
+
     it('expect warnings', async () => {
         (
             await expectDiagnosticsFor({


### PR DESCRIPTION
 #1271 
 This would still happen if somehow the user explicitly disabled the ts sourcemap or there's other source map issues. 