### PR TITLE
(fix) allow null on all HTML props

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -81,514 +81,514 @@ declare namespace svelte.JSX {
       ref?: ((e: T) => void) | Ref<T>; */
 
       // Clipboard Events
-      oncopy?: ClipboardEventHandler<T> | undefined;
-      oncut?: ClipboardEventHandler<T> | undefined;
-      onpaste?: ClipboardEventHandler<T> | undefined;
+      oncopy?: ClipboardEventHandler<T> | undefined | null;
+      oncut?: ClipboardEventHandler<T> | undefined | null;
+      onpaste?: ClipboardEventHandler<T> | undefined | null;
 
       // Composition Events
-      oncompositionend?: CompositionEventHandler<T> | undefined;
-      oncompositionstart?: CompositionEventHandler<T> | undefined;
-      oncompositionupdate?: CompositionEventHandler<T> | undefined;
+      oncompositionend?: CompositionEventHandler<T> | undefined | null;
+      oncompositionstart?: CompositionEventHandler<T> | undefined | null;
+      oncompositionupdate?: CompositionEventHandler<T> | undefined | null;
 
       // Focus Events
-      onfocus?: FocusEventHandler<T> | undefined;
-      onfocusin?: FocusEventHandler<T> | undefined;
-      onfocusout?: FocusEventHandler<T> | undefined;
-      onblur?: FocusEventHandler<T> | undefined;
+      onfocus?: FocusEventHandler<T> | undefined | null;
+      onfocusin?: FocusEventHandler<T> | undefined | null;
+      onfocusout?: FocusEventHandler<T> | undefined | null;
+      onblur?: FocusEventHandler<T> | undefined | null;
 
       // Form Events
-      onchange?: FormEventHandler<T> | undefined;
-      oninput?: FormEventHandler<T> | undefined;
-      onreset?: FormEventHandler<T> | undefined;
-      onsubmit?: FormEventHandler<T> | undefined;
-      oninvalid?: EventHandler<Event, T> | undefined;
-      onbeforeinput?: EventHandler<InputEvent, T> | undefined;
+      onchange?: FormEventHandler<T> | undefined | null;
+      oninput?: FormEventHandler<T> | undefined | null;
+      onreset?: FormEventHandler<T> | undefined | null;
+      onsubmit?: FormEventHandler<T> | undefined | null;
+      oninvalid?: EventHandler<Event, T> | undefined | null;
+      onbeforeinput?: EventHandler<InputEvent, T> | undefined | null;
 
       // Image Events
-      onload?: EventHandler | undefined;
-      onerror?: EventHandler | undefined; // also a Media Event
+      onload?: EventHandler | undefined | null;
+      onerror?: EventHandler | undefined | null; // also a Media Event
 
       // Detail Events
-      ontoggle?: EventHandler<Event, T> | undefined;
+      ontoggle?: EventHandler<Event, T> | undefined | null;
 
       // Keyboard Events
-      onkeydown?: KeyboardEventHandler<T> | undefined;
-      onkeypress?: KeyboardEventHandler<T> | undefined;
-      onkeyup?: KeyboardEventHandler<T> | undefined;
+      onkeydown?: KeyboardEventHandler<T> | undefined | null;
+      onkeypress?: KeyboardEventHandler<T> | undefined | null;
+      onkeyup?: KeyboardEventHandler<T> | undefined | null;
 
       // Media Events
-      onabort?: EventHandler<Event, T> | undefined;
-      oncanplay?: EventHandler<Event, T> | undefined;
-      oncanplaythrough?: EventHandler<Event, T> | undefined;
-      oncuechange?: EventHandler<Event, T> | undefined;
-      ondurationchange?: EventHandler<Event, T> | undefined;
-      onemptied?: EventHandler<Event, T> | undefined;
-      onencrypted?: EventHandler<Event, T> | undefined;
-      onended?: EventHandler<Event, T> | undefined;
-      onloadeddata?: EventHandler<Event, T> | undefined;
-      onloadedmetadata?: EventHandler<Event, T> | undefined;
-      onloadstart?: EventHandler<Event, T> | undefined;
-      onpause?: EventHandler<Event, T> | undefined;
-      onplay?: EventHandler<Event, T> | undefined;
-      onplaying?: EventHandler<Event, T> | undefined;
-      onprogress?: EventHandler<Event, T> | undefined;
-      onratechange?: EventHandler<Event, T> | undefined;
-      onseeked?: EventHandler<Event, T> | undefined;
-      onseeking?: EventHandler<Event, T> | undefined;
-      onstalled?: EventHandler<Event, T> | undefined;
-      onsuspend?: EventHandler<Event, T> | undefined;
-      ontimeupdate?: EventHandler<Event, T> | undefined;
-      onvolumechange?: EventHandler<Event, T> | undefined;
-      onwaiting?: EventHandler<Event, T> | undefined;
+      onabort?: EventHandler<Event, T> | undefined | null;
+      oncanplay?: EventHandler<Event, T> | undefined | null;
+      oncanplaythrough?: EventHandler<Event, T> | undefined | null;
+      oncuechange?: EventHandler<Event, T> | undefined | null;
+      ondurationchange?: EventHandler<Event, T> | undefined | null;
+      onemptied?: EventHandler<Event, T> | undefined | null;
+      onencrypted?: EventHandler<Event, T> | undefined | null;
+      onended?: EventHandler<Event, T> | undefined | null;
+      onloadeddata?: EventHandler<Event, T> | undefined | null;
+      onloadedmetadata?: EventHandler<Event, T> | undefined | null;
+      onloadstart?: EventHandler<Event, T> | undefined | null;
+      onpause?: EventHandler<Event, T> | undefined | null;
+      onplay?: EventHandler<Event, T> | undefined | null;
+      onplaying?: EventHandler<Event, T> | undefined | null;
+      onprogress?: EventHandler<Event, T> | undefined | null;
+      onratechange?: EventHandler<Event, T> | undefined | null;
+      onseeked?: EventHandler<Event, T> | undefined | null;
+      onseeking?: EventHandler<Event, T> | undefined | null;
+      onstalled?: EventHandler<Event, T> | undefined | null;
+      onsuspend?: EventHandler<Event, T> | undefined | null;
+      ontimeupdate?: EventHandler<Event, T> | undefined | null;
+      onvolumechange?: EventHandler<Event, T> | undefined | null;
+      onwaiting?: EventHandler<Event, T> | undefined | null;
 
       // MouseEvents
-      onauxclick?: MouseEventHandler<T> | undefined;
-      onclick?: MouseEventHandler<T> | undefined;
-      oncontextmenu?: MouseEventHandler<T> | undefined;
-      ondblclick?: MouseEventHandler<T> | undefined;
-      ondrag?: DragEventHandler<T> | undefined;
-      ondragend?: DragEventHandler<T> | undefined;
-      ondragenter?: DragEventHandler<T> | undefined;
-      ondragexit?: DragEventHandler<T> | undefined;
-      ondragleave?: DragEventHandler<T> | undefined;
-      ondragover?: DragEventHandler<T> | undefined;
-      ondragstart?: DragEventHandler<T> | undefined;
-      ondrop?: DragEventHandler<T> | undefined;
-      onmousedown?: MouseEventHandler<T> | undefined;
-      onmouseenter?: MouseEventHandler<T> | undefined;
-      onmouseleave?: MouseEventHandler<T> | undefined;
-      onmousemove?: MouseEventHandler<T> | undefined;
-      onmouseout?: MouseEventHandler<T> | undefined;
-      onmouseover?: MouseEventHandler<T> | undefined;
-      onmouseup?: MouseEventHandler<T> | undefined;
+      onauxclick?: MouseEventHandler<T> | undefined | null;
+      onclick?: MouseEventHandler<T> | undefined | null;
+      oncontextmenu?: MouseEventHandler<T> | undefined | null;
+      ondblclick?: MouseEventHandler<T> | undefined | null;
+      ondrag?: DragEventHandler<T> | undefined | null;
+      ondragend?: DragEventHandler<T> | undefined | null;
+      ondragenter?: DragEventHandler<T> | undefined | null;
+      ondragexit?: DragEventHandler<T> | undefined | null;
+      ondragleave?: DragEventHandler<T> | undefined | null;
+      ondragover?: DragEventHandler<T> | undefined | null;
+      ondragstart?: DragEventHandler<T> | undefined | null;
+      ondrop?: DragEventHandler<T> | undefined | null;
+      onmousedown?: MouseEventHandler<T> | undefined | null;
+      onmouseenter?: MouseEventHandler<T> | undefined | null;
+      onmouseleave?: MouseEventHandler<T> | undefined | null;
+      onmousemove?: MouseEventHandler<T> | undefined | null;
+      onmouseout?: MouseEventHandler<T> | undefined | null;
+      onmouseover?: MouseEventHandler<T> | undefined | null;
+      onmouseup?: MouseEventHandler<T> | undefined | null;
 
       // Selection Events
-      onselect?: EventHandler<Event, T> | undefined;
-      onselectionchange?: EventHandler<Event, T> | undefined;
-      onselectstart?: EventHandler<Event, T> | undefined;
+      onselect?: EventHandler<Event, T> | undefined | null;
+      onselectionchange?: EventHandler<Event, T> | undefined | null;
+      onselectstart?: EventHandler<Event, T> | undefined | null;
 
       // Touch Events
-      ontouchcancel?: TouchEventHandler<T> | undefined;
-      ontouchend?: TouchEventHandler<T> | undefined;
-      ontouchmove?: TouchEventHandler<T> | undefined;
-      ontouchstart?: TouchEventHandler<T> | undefined;
+      ontouchcancel?: TouchEventHandler<T> | undefined | null;
+      ontouchend?: TouchEventHandler<T> | undefined | null;
+      ontouchmove?: TouchEventHandler<T> | undefined | null;
+      ontouchstart?: TouchEventHandler<T> | undefined | null;
 
       // Pointer Events
-      ongotpointercapture?: PointerEventHandler<T> | undefined;
-      onpointercancel?: PointerEventHandler<T> | undefined;
-      onpointerdown?: PointerEventHandler<T> | undefined;
-      onpointerenter?: PointerEventHandler<T> | undefined;
-      onpointerleave?: PointerEventHandler<T> | undefined;
-      onpointermove?: PointerEventHandler<T> | undefined;
-      onpointerout?: PointerEventHandler<T> | undefined;
-      onpointerover?: PointerEventHandler<T> | undefined;
-      onpointerup?: PointerEventHandler<T> | undefined;
-      onlostpointercapture?: PointerEventHandler<T> | undefined;
+      ongotpointercapture?: PointerEventHandler<T> | undefined | null;
+      onpointercancel?: PointerEventHandler<T> | undefined | null;
+      onpointerdown?: PointerEventHandler<T> | undefined | null;
+      onpointerenter?: PointerEventHandler<T> | undefined | null;
+      onpointerleave?: PointerEventHandler<T> | undefined | null;
+      onpointermove?: PointerEventHandler<T> | undefined | null;
+      onpointerout?: PointerEventHandler<T> | undefined | null;
+      onpointerover?: PointerEventHandler<T> | undefined | null;
+      onpointerup?: PointerEventHandler<T> | undefined | null;
+      onlostpointercapture?: PointerEventHandler<T> | undefined | null;
 
       // UI Events
-      onscroll?: UIEventHandler<T> | undefined;
-      onresize?: UIEventHandler<T> | undefined;
+      onscroll?: UIEventHandler<T> | undefined | null;
+      onresize?: UIEventHandler<T> | undefined | null;
 
       // Wheel Events
-      onwheel?: WheelEventHandler<T> | undefined;
+      onwheel?: WheelEventHandler<T> | undefined | null;
 
       // Animation Events
-      onanimationstart?: AnimationEventHandler<T> | undefined;
-      onanimationend?: AnimationEventHandler<T> | undefined;
-      onanimationiteration?: AnimationEventHandler<T> | undefined;
+      onanimationstart?: AnimationEventHandler<T> | undefined | null;
+      onanimationend?: AnimationEventHandler<T> | undefined | null;
+      onanimationiteration?: AnimationEventHandler<T> | undefined | null;
 
       // Transition Events
-      ontransitionstart?: TransitionEventHandler<T> | undefined;
-      ontransitionrun?: TransitionEventHandler<T> | undefined;
-      ontransitionend?: TransitionEventHandler<T> | undefined;
-      ontransitioncancel?: TransitionEventHandler<T> | undefined;
+      ontransitionstart?: TransitionEventHandler<T> | undefined | null;
+      ontransitionrun?: TransitionEventHandler<T> | undefined | null;
+      ontransitionend?: TransitionEventHandler<T> | undefined | null;
+      ontransitioncancel?: TransitionEventHandler<T> | undefined | null;
 
       // Svelte Transition Events
-      onoutrostart?: EventHandler<CustomEvent<null>, T> | undefined;
-      onoutroend?: EventHandler<CustomEvent<null>, T> | undefined;
-      onintrostart?: EventHandler<CustomEvent<null>, T> | undefined;
-      onintroend?: EventHandler<CustomEvent<null>, T> | undefined;
+      onoutrostart?: EventHandler<CustomEvent<null>, T> | undefined | null;
+      onoutroend?: EventHandler<CustomEvent<null>, T> | undefined | null;
+      onintrostart?: EventHandler<CustomEvent<null>, T> | undefined | null;
+      onintroend?: EventHandler<CustomEvent<null>, T> | undefined | null;
 
       // Message Events
-      onmessage?: MessageEventHandler<T> | undefined;
-      onmessageerror?: MessageEventHandler<T> | undefined;
+      onmessage?: MessageEventHandler<T> | undefined | null;
+      onmessageerror?: MessageEventHandler<T> | undefined | null;
 
       // Global Events
-      oncancel?: EventHandler<Event, T> | undefined;
-      onclose?: EventHandler<Event, T> | undefined;
-      onfullscreenchange?: EventHandler<Event, T> | undefined;
-      onfullscreenerror?: EventHandler<Event, T> | undefined;
+      oncancel?: EventHandler<Event, T> | undefined | null;
+      onclose?: EventHandler<Event, T> | undefined | null;
+      onfullscreenchange?: EventHandler<Event, T> | undefined | null;
+      onfullscreenerror?: EventHandler<Event, T> | undefined | null;
     }
 
     // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
     interface AriaAttributes {
         /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
-        'aria-activedescendant'?: string | undefined;
+        'aria-activedescendant'?: string | undefined | null;
         /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
-        'aria-atomic'?: boolean | 'false' | 'true' | undefined;
+        'aria-atomic'?: boolean | 'false' | 'true' | undefined | null;
         /**
          * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
          * presented if they are made.
          */
-        'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both' | undefined;
+        'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both' | undefined | null;
         /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
-        'aria-busy'?: boolean | 'false' | 'true' | undefined;
+        'aria-busy'?: boolean | 'false' | 'true' | undefined | null;
         /**
          * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
          * @see aria-pressed @see aria-selected.
          */
-        'aria-checked'?: boolean | 'false' | 'mixed' | 'true' | undefined;
+        'aria-checked'?: boolean | 'false' | 'mixed' | 'true' | undefined | null;
         /**
          * Defines the total number of columns in a table, grid, or treegrid.
          * @see aria-colindex.
          */
-        'aria-colcount'?: number | undefined;
+        'aria-colcount'?: number | undefined | null;
         /**
          * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
          * @see aria-colcount @see aria-colspan.
          */
-        'aria-colindex'?: number | undefined;
+        'aria-colindex'?: number | undefined | null;
         /**
          * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
          * @see aria-colindex @see aria-rowspan.
          */
-        'aria-colspan'?: number | undefined;
+        'aria-colspan'?: number | undefined | null;
         /**
          * Identifies the element (or elements) whose contents or presence are controlled by the current element.
          * @see aria-owns.
          */
-        'aria-controls'?: string | undefined;
+        'aria-controls'?: string | undefined | null;
         /** Indicates the element that represents the current item within a container or set of related elements. */
-        'aria-current'?: boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time' | undefined;
+        'aria-current'?: boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time' | undefined | null;
         /**
          * Identifies the element (or elements) that describes the object.
          * @see aria-labelledby
          */
-        'aria-describedby'?: string | undefined;
+        'aria-describedby'?: string | undefined | null;
         /**
          * Identifies the element that provides a detailed, extended description for the object.
          * @see aria-describedby.
          */
-        'aria-details'?: string | undefined;
+        'aria-details'?: string | undefined | null;
         /**
          * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
          * @see aria-hidden @see aria-readonly.
          */
-        'aria-disabled'?: boolean | 'false' | 'true' | undefined;
+        'aria-disabled'?: boolean | 'false' | 'true' | undefined | null;
         /**
          * Indicates what functions can be performed when a dragged object is released on the drop target.
          * @deprecated in ARIA 1.1
          */
-        'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined;
+        'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined | null;
         /**
          * Identifies the element that provides an error message for the object.
          * @see aria-invalid @see aria-describedby.
          */
-        'aria-errormessage'?: string | undefined;
+        'aria-errormessage'?: string | undefined | null;
         /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
-        'aria-expanded'?: boolean | 'false' | 'true' | undefined;
+        'aria-expanded'?: boolean | 'false' | 'true' | undefined | null;
         /**
          * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
          * allows assistive technology to override the general default of reading in document source order.
          */
-        'aria-flowto'?: string | undefined;
+        'aria-flowto'?: string | undefined | null;
         /**
          * Indicates an element's "grabbed" state in a drag-and-drop operation.
          * @deprecated in ARIA 1.1
          */
-        'aria-grabbed'?: boolean | 'false' | 'true' | undefined;
+        'aria-grabbed'?: boolean | 'false' | 'true' | undefined | null;
         /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
-        'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | undefined;
+        'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | undefined | null;
         /**
          * Indicates whether the element is exposed to an accessibility API.
          * @see aria-disabled.
          */
-        'aria-hidden'?: boolean | 'false' | 'true' | undefined;
+        'aria-hidden'?: boolean | 'false' | 'true' | undefined | null;
         /**
          * Indicates the entered value does not conform to the format expected by the application.
          * @see aria-errormessage.
          */
-        'aria-invalid'?: boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined;
+        'aria-invalid'?: boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined | null;
         /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
-        'aria-keyshortcuts'?: string | undefined;
+        'aria-keyshortcuts'?: string | undefined | null;
         /**
          * Defines a string value that labels the current element.
          * @see aria-labelledby.
          */
-        'aria-label'?: string | undefined;
+        'aria-label'?: string | undefined | null;
         /**
          * Identifies the element (or elements) that labels the current element.
          * @see aria-describedby.
          */
-        'aria-labelledby'?: string | undefined;
+        'aria-labelledby'?: string | undefined | null;
         /** Defines the hierarchical level of an element within a structure. */
-        'aria-level'?: number | undefined;
+        'aria-level'?: number | undefined | null;
         /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
-        'aria-live'?: 'off' | 'assertive' | 'polite' | undefined;
+        'aria-live'?: 'off' | 'assertive' | 'polite' | undefined | null;
         /** Indicates whether an element is modal when displayed. */
-        'aria-modal'?: boolean | 'false' | 'true' | undefined;
+        'aria-modal'?: boolean | 'false' | 'true' | undefined | null;
         /** Indicates whether a text box accepts multiple lines of input or only a single line. */
-        'aria-multiline'?: boolean | 'false' | 'true' | undefined;
+        'aria-multiline'?: boolean | 'false' | 'true' | undefined | null;
         /** Indicates that the user may select more than one item from the current selectable descendants. */
-        'aria-multiselectable'?: boolean | 'false' | 'true' | undefined;
+        'aria-multiselectable'?: boolean | 'false' | 'true' | undefined | null;
         /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
-        'aria-orientation'?: 'horizontal' | 'vertical' | undefined;
+        'aria-orientation'?: 'horizontal' | 'vertical' | undefined | null;
         /**
          * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
          * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
          * @see aria-controls.
          */
-        'aria-owns'?: string | undefined;
+        'aria-owns'?: string | undefined | null;
         /**
          * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
          * A hint could be a sample value or a brief description of the expected format.
          */
-        'aria-placeholder'?: string | undefined;
+        'aria-placeholder'?: string | undefined | null;
         /**
          * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
          * @see aria-setsize.
          */
-        'aria-posinset'?: number | undefined;
+        'aria-posinset'?: number | undefined | null;
         /**
          * Indicates the current "pressed" state of toggle buttons.
          * @see aria-checked @see aria-selected.
          */
-        'aria-pressed'?: boolean | 'false' | 'mixed' | 'true' | undefined;
+        'aria-pressed'?: boolean | 'false' | 'mixed' | 'true' | undefined | null;
         /**
          * Indicates that the element is not editable, but is otherwise operable.
          * @see aria-disabled.
          */
-        'aria-readonly'?: boolean | 'false' | 'true' | undefined;
+        'aria-readonly'?: boolean | 'false' | 'true' | undefined | null;
         /**
          * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
          * @see aria-atomic.
          */
-        'aria-relevant'?: 'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' | undefined;
+        'aria-relevant'?: 'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' | undefined | null;
         /** Indicates that user input is required on the element before a form may be submitted. */
-        'aria-required'?: boolean | 'false' | 'true' | undefined;
+        'aria-required'?: boolean | 'false' | 'true' | undefined | null;
         /** Defines a human-readable, author-localized description for the role of an element. */
-        'aria-roledescription'?: string | undefined;
+        'aria-roledescription'?: string | undefined | null;
         /**
          * Defines the total number of rows in a table, grid, or treegrid.
          * @see aria-rowindex.
          */
-        'aria-rowcount'?: number | undefined;
+        'aria-rowcount'?: number | undefined | null;
         /**
          * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
          * @see aria-rowcount @see aria-rowspan.
          */
-        'aria-rowindex'?: number | undefined;
+        'aria-rowindex'?: number | undefined | null;
         /**
          * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
          * @see aria-rowindex @see aria-colspan.
          */
-        'aria-rowspan'?: number | undefined;
+        'aria-rowspan'?: number | undefined | null;
         /**
          * Indicates the current "selected" state of various widgets.
          * @see aria-checked @see aria-pressed.
          */
-        'aria-selected'?: boolean | 'false' | 'true' | undefined;
+        'aria-selected'?: boolean | 'false' | 'true' | undefined | null;
         /**
          * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
          * @see aria-posinset.
          */
-        'aria-setsize'?: number | undefined;
+        'aria-setsize'?: number | undefined | null;
         /** Indicates if items in a table or grid are sorted in ascending or descending order. */
-        'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other' | undefined;
+        'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other' | undefined | null;
         /** Defines the maximum allowed value for a range widget. */
-        'aria-valuemax'?: number | undefined;
+        'aria-valuemax'?: number | undefined | null;
         /** Defines the minimum allowed value for a range widget. */
-        'aria-valuemin'?: number | undefined;
+        'aria-valuemin'?: number | undefined | null;
         /**
          * Defines the current value for a range widget.
          * @see aria-valuetext.
          */
-        'aria-valuenow'?: number | undefined;
+        'aria-valuenow'?: number | undefined | null;
         /** Defines the human readable text alternative of aria-valuenow for a range widget. */
-        'aria-valuetext'?: string | undefined;
+        'aria-valuetext'?: string | undefined | null;
     }
 
     interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, DOMAttributes<T> {
       // Standard HTML Attributes
-      class?: string | undefined;
-      dataset?: object | undefined; // eslint-disable-line
-      accept?: string | undefined;
-      acceptcharset?: string | undefined;
-      accesskey?: string | undefined;
-      action?: string | undefined;
-      allow?: string | undefined;
-      allowfullscreen?: boolean | undefined;
-      allowtransparency?: boolean | undefined;
-      allowpaymentrequest?: boolean | undefined;
-      alt?: string | undefined;
-      as?: string | undefined;
-      async?: boolean | undefined;
-      autocomplete?: string | undefined;
-      autofocus?: boolean | undefined;
-      autoplay?: boolean | undefined;
-      capture?: 'environment' | 'user' | boolean | undefined;
-      cellpadding?: number | string | undefined;
-      cellspacing?: number | string | undefined;
-      charset?: string | undefined;
-      challenge?: string | undefined;
-      checked?: boolean | undefined;
-      cite?: string | undefined;
-      classid?: string | undefined;
-      cols?: number | undefined;
-      colspan?: number | undefined;
-      content?: string | undefined;
-      contenteditable?: 'true' | 'false' | boolean | undefined;
+      class?: string | undefined | null;
+      dataset?: object | undefined | null; // eslint-disable-line
+      accept?: string | undefined | null;
+      acceptcharset?: string | undefined | null;
+      accesskey?: string | undefined | null;
+      action?: string | undefined | null;
+      allow?: string | undefined | null;
+      allowfullscreen?: boolean | undefined | null;
+      allowtransparency?: boolean | undefined | null;
+      allowpaymentrequest?: boolean | undefined | null;
+      alt?: string | undefined | null;
+      as?: string | undefined | null;
+      async?: boolean | undefined | null;
+      autocomplete?: string | undefined | null;
+      autofocus?: boolean | undefined | null;
+      autoplay?: boolean | undefined | null;
+      capture?: 'environment' | 'user' | boolean | undefined | null;
+      cellpadding?: number | string | undefined | null;
+      cellspacing?: number | string | undefined | null;
+      charset?: string | undefined | null;
+      challenge?: string | undefined | null;
+      checked?: boolean | undefined | null;
+      cite?: string | undefined | null;
+      classid?: string | undefined | null;
+      cols?: number | undefined | null;
+      colspan?: number | undefined | null;
+      content?: string | undefined | null;
+      contenteditable?: 'true' | 'false' | boolean | undefined | null;
 
       // Doesn't work when used as HTML attribute
       /**
        * Elements with the contenteditable attribute support innerHTML and textContent bindings.
        */
-      innerHTML?: string | undefined;
+      innerHTML?: string | undefined | null;
       // Doesn't work when used as HTML attribute
       /**
        * Elements with the contenteditable attribute support innerHTML and textContent bindings.
        */
 
-      textContent?: string | undefined;
+      textContent?: string | undefined | null;
 
-      contextmenu?: string | undefined;
-      controls?: boolean | undefined;
-      coords?: string | undefined;
-      crossorigin?: string | undefined;
-      currenttime?: number | undefined;
-      decoding?: 'async' | 'sync' | 'auto' | undefined;
-      data?: string | undefined;
-      datetime?: string | undefined;
-      default?: boolean | undefined;
-      defaultmuted?: boolean | undefined;
-      defaultplaybackrate?: number | undefined;
-      defer?: boolean | undefined;
-      dir?: string | undefined;
-      dirname?: string | undefined;
-      disabled?: boolean | undefined;
-      download?: any | undefined;
-      draggable?: boolean | 'true' | 'false' | undefined;
-      enctype?: string | undefined;
-      enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
-      for?: string | undefined;
-      form?: string | undefined;
-      formaction?: string | undefined;
-      formenctype?: string | undefined;
-      formmethod?: string | undefined;
-      formnovalidate?: boolean | undefined;
-      formtarget?: string | undefined;
-      frameborder?: number | string | undefined;
-      headers?: string | undefined;
-      height?: number | string | undefined;
-      hidden?: boolean | undefined;
-      high?: number | undefined;
-      href?: string | undefined;
-      hreflang?: string | undefined;
-      htmlfor?: string | undefined;
-      httpequiv?: string | undefined;
-      id?: string | undefined;
-      inputmode?: string | undefined;
-      integrity?: string | undefined;
-      is?: string | undefined;
-      ismap?: boolean | undefined;
-      keyparams?: string | undefined;
-      keytype?: string | undefined;
-      kind?: string | undefined;
-      label?: string | undefined;
-      lang?: string | undefined;
-      list?: string | undefined;
-      loading?: string | undefined;
-      loop?: boolean | undefined;
-      low?: number | undefined;
-      manifest?: string | undefined;
-      marginheight?: number | undefined;
-      marginwidth?: number | undefined;
-      max?: number | string | undefined;
-      maxlength?: number | undefined;
-      media?: string | undefined;
-      mediagroup?: string | undefined;
-      method?: string | undefined;
-      min?: number | string | undefined;
-      minlength?: number | undefined;
-      multiple?: boolean | undefined;
-      muted?: boolean | undefined;
-      name?: string | undefined;
-      nonce?: string | undefined;
-      novalidate?: boolean | undefined;
-      open?: boolean | undefined;
-      optimum?: number | undefined;
-      part?: string | undefined;
-      pattern?: string | undefined;
-      placeholder?: string | undefined;
-      playsinline?: boolean | undefined;
-      poster?: string | undefined;
-      preload?: string | undefined;
-      radiogroup?: string | undefined;
-      readonly?: boolean | undefined;
-      referrerpolicy?: string | undefined;
-      rel?: string | undefined;
-      required?: boolean | undefined;
-      reversed?: boolean | undefined;
-      role?: string | undefined;
-      rows?: number | undefined;
-      rowspan?: number | undefined;
-      sandbox?: string | undefined;
-      scope?: string | undefined;
-      scoped?: boolean | undefined;
-      scrolling?: string | undefined;
-      seamless?: boolean | undefined;
-      selected?: boolean | undefined;
-      shape?: string | undefined;
-      size?: number | undefined;
-      sizes?: string | undefined;
-      slot?: string | undefined;
-      span?: number | undefined;
-      spellcheck?: boolean | 'true' | 'false' | undefined;
-      src?: string | undefined;
-      srcdoc?: string | undefined;
-      srclang?: string | undefined;
-      srcset?: string | undefined;
-      start?: number | undefined;
-      step?: number | string | undefined;
-      style?: string | undefined;
-      summary?: string | undefined;
-      tabindex?: number | undefined;
-      target?: string | undefined;
-      title?: string | undefined;
-      type?: string | undefined;
-      usemap?: string | undefined;
-      value?: string | string[] | number | null | undefined;
+      contextmenu?: string | undefined | null;
+      controls?: boolean | undefined | null;
+      coords?: string | undefined | null;
+      crossorigin?: string | undefined | null;
+      currenttime?: number | undefined | null;
+      decoding?: 'async' | 'sync' | 'auto' | undefined | null;
+      data?: string | undefined | null;
+      datetime?: string | undefined | null;
+      default?: boolean | undefined | null;
+      defaultmuted?: boolean | undefined | null;
+      defaultplaybackrate?: number | undefined | null;
+      defer?: boolean | undefined | null;
+      dir?: string | undefined | null;
+      dirname?: string | undefined | null;
+      disabled?: boolean | undefined | null;
+      download?: any | undefined | null;
+      draggable?: boolean | 'true' | 'false' | undefined | null;
+      enctype?: string | undefined | null;
+      enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined | null;
+      for?: string | undefined | null;
+      form?: string | undefined | null;
+      formaction?: string | undefined | null;
+      formenctype?: string | undefined | null;
+      formmethod?: string | undefined | null;
+      formnovalidate?: boolean | undefined | null;
+      formtarget?: string | undefined | null;
+      frameborder?: number | string | undefined | null;
+      headers?: string | undefined | null;
+      height?: number | string | undefined | null;
+      hidden?: boolean | undefined | null;
+      high?: number | undefined | null;
+      href?: string | undefined | null;
+      hreflang?: string | undefined | null;
+      htmlfor?: string | undefined | null;
+      httpequiv?: string | undefined | null;
+      id?: string | undefined | null;
+      inputmode?: string | undefined | null;
+      integrity?: string | undefined | null;
+      is?: string | undefined | null;
+      ismap?: boolean | undefined | null;
+      keyparams?: string | undefined | null;
+      keytype?: string | undefined | null;
+      kind?: string | undefined | null;
+      label?: string | undefined | null;
+      lang?: string | undefined | null;
+      list?: string | undefined | null;
+      loading?: string | undefined | null;
+      loop?: boolean | undefined | null;
+      low?: number | undefined | null;
+      manifest?: string | undefined | null;
+      marginheight?: number | undefined | null;
+      marginwidth?: number | undefined | null;
+      max?: number | string | undefined | null;
+      maxlength?: number | undefined | null;
+      media?: string | undefined | null;
+      mediagroup?: string | undefined | null;
+      method?: string | undefined | null;
+      min?: number | string | undefined | null;
+      minlength?: number | undefined | null;
+      multiple?: boolean | undefined | null;
+      muted?: boolean | undefined | null;
+      name?: string | undefined | null;
+      nonce?: string | undefined | null;
+      novalidate?: boolean | undefined | null;
+      open?: boolean | undefined | null;
+      optimum?: number | undefined | null;
+      part?: string | undefined | null;
+      pattern?: string | undefined | null;
+      placeholder?: string | undefined | null;
+      playsinline?: boolean | undefined | null;
+      poster?: string | undefined | null;
+      preload?: string | undefined | null;
+      radiogroup?: string | undefined | null;
+      readonly?: boolean | undefined | null;
+      referrerpolicy?: string | undefined | null;
+      rel?: string | undefined | null;
+      required?: boolean | undefined | null;
+      reversed?: boolean | undefined | null;
+      role?: string | undefined | null;
+      rows?: number | undefined | null;
+      rowspan?: number | undefined | null;
+      sandbox?: string | undefined | null;
+      scope?: string | undefined | null;
+      scoped?: boolean | undefined | null;
+      scrolling?: string | undefined | null;
+      seamless?: boolean | undefined | null;
+      selected?: boolean | undefined | null;
+      shape?: string | undefined | null;
+      size?: number | undefined | null;
+      sizes?: string | undefined | null;
+      slot?: string | undefined | null;
+      span?: number | undefined | null;
+      spellcheck?: boolean | 'true' | 'false' | undefined | null;
+      src?: string | undefined | null;
+      srcdoc?: string | undefined | null;
+      srclang?: string | undefined | null;
+      srcset?: string | undefined | null;
+      start?: number | undefined | null;
+      step?: number | string | undefined | null;
+      style?: string | undefined | null;
+      summary?: string | undefined | null;
+      tabindex?: number | undefined | null;
+      target?: string | undefined | null;
+      title?: string | undefined | null;
+      type?: string | undefined | null;
+      usemap?: string | undefined | null;
+      value?: string | string[] | number | undefined | null;
       /**
        * a value between 0 and 1
       */
-      volume?: number | undefined;
-      width?: number | string | undefined;
-      wmode?: string | undefined;
-      wrap?: string | undefined;
+      volume?: number | undefined | null;
+      width?: number | string | undefined | null;
+      wmode?: string | undefined | null;
+      wrap?: string | undefined | null;
 
       // RDFa Attributes
-      about?: string | undefined;
-      datatype?: string | undefined;
-      inlist?: any | undefined;
-      prefix?: string | undefined;
-      property?: string | undefined;
-      resource?: string | undefined;
-      typeof?: string | undefined;
-      vocab?: string | undefined;
+      about?: string | undefined | null;
+      datatype?: string | undefined | null;
+      inlist?: any | undefined | null;
+      prefix?: string | undefined | null;
+      property?: string | undefined | null;
+      resource?: string | undefined | null;
+      typeof?: string | undefined | null;
+      vocab?: string | undefined | null;
 
       // Non-standard Attributes
-      autocapitalize?: string | undefined;
-      autocorrect?: string | undefined;
-      autosave?: string | undefined;
-      color?: string | undefined;
-      itemprop?: string | undefined;
-      itemscope?: boolean | undefined;
-      itemtype?: string | undefined;
-      itemid?: string | undefined;
-      itemref?: string | undefined;
-      results?: number | undefined;
-      security?: string | undefined;
-      unselectable?: boolean | undefined;
+      autocapitalize?: string | undefined | null;
+      autocorrect?: string | undefined | null;
+      autosave?: string | undefined | null;
+      color?: string | undefined | null;
+      itemprop?: string | undefined | null;
+      itemscope?: boolean | undefined | null;
+      itemtype?: string | undefined | null;
+      itemid?: string | undefined | null;
+      itemref?: string | undefined | null;
+      results?: number | undefined | null;
+      security?: string | undefined | null;
+      unselectable?: boolean | undefined | null;
     }
 
     // this list is "complete" in that it contains every SVG attribute
@@ -601,271 +601,271 @@ declare namespace svelte.JSX {
     //   - union of string literals
     interface SVGAttributes<T extends EventTarget> extends AriaAttributes, DOMAttributes<T> {
       // Attributes which also defined in HTMLAttributes
-      className?: string | undefined;
-      class?: string | undefined;
-      color?: string | undefined;
-      height?: number | string | undefined;
-      id?: string | undefined;
-      lang?: string | undefined;
-      max?: number | string | undefined;
-      media?: string | undefined;
-      method?: string | undefined;
-      min?: number | string | undefined;
-      name?: string | undefined;
-      style?: string | undefined;
-      target?: string | undefined;
-      type?: string | undefined;
-      width?: number | string | undefined;
+      className?: string | undefined | null;
+      class?: string | undefined | null;
+      color?: string | undefined | null;
+      height?: number | string | undefined | null;
+      id?: string | undefined | null;
+      lang?: string | undefined | null;
+      max?: number | string | undefined | null;
+      media?: string | undefined | null;
+      method?: string | undefined | null;
+      min?: number | string | undefined | null;
+      name?: string | undefined | null;
+      style?: string | undefined | null;
+      target?: string | undefined | null;
+      type?: string | undefined | null;
+      width?: number | string | undefined | null;
 
       // Other HTML properties supported by SVG elements in browsers
-      role?: string | undefined;
-      tabindex?: number | undefined;
-      crossorigin?: 'anonymous' | 'use-credentials' | '' | undefined;
+      role?: string | undefined | null;
+      tabindex?: number | undefined | null;
+      crossorigin?: 'anonymous' | 'use-credentials' | '' | undefined | null;
 
       // SVG Specific attributes
-      'accent-height'?: number | string | undefined;
-      accumulate?: 'none' | 'sum' | undefined;
-      additive?: 'replace' | 'sum' | undefined;
+      'accent-height'?: number | string | undefined | null;
+      accumulate?: 'none' | 'sum' | undefined | null;
+      additive?: 'replace' | 'sum' | undefined | null;
       'alignment-baseline'?: 'auto' | 'baseline' | 'before-edge' | 'text-before-edge' | 'middle' |
         'central' | 'after-edge' | 'text-after-edge' | 'ideographic' | 'alphabetic' | 'hanging' |
-        'mathematical' | 'inherit' | undefined;
-      allowReorder?: 'no' | 'yes' | undefined;
-      alphabetic?: number | string | undefined;
-      amplitude?: number | string | undefined;
-      'arabic-form'?: 'initial' | 'medial' | 'terminal' | 'isolated' | undefined;
-      ascent?: number | string | undefined;
-      attributeName?: string | undefined;
-      attributeType?: string | undefined;
-      autoReverse?: number | string | undefined;
-      azimuth?: number | string | undefined;
-      baseFrequency?: number | string | undefined;
-      'baseline-shift'?: number | string | undefined;
-      baseProfile?: number | string | undefined;
-      bbox?: number | string | undefined;
-      begin?: number | string | undefined;
-      bias?: number | string | undefined;
-      by?: number | string | undefined;
-      calcMode?: number | string | undefined;
-      'cap-height'?: number | string | undefined;
-      clip?: number | string | undefined;
-      'clip-path'?: string | undefined;
-      clipPathUnits?: number | string | undefined;
-      'clip-rule'?: number | string | undefined;
-      'color-interpolation'?: number | string | undefined;
-      'color-interpolation-filters'?: 'auto' | 'sRGB' | 'linearRGB' | 'inherit' | undefined;
-      'color-profile'?: number | string | undefined;
-      'color-rendering'?: number | string | undefined;
-      contentScriptType?: number | string | undefined;
-      contentStyleType?: number | string | undefined;
-      cursor?: number | string | undefined;
-      cx?: number | string | undefined;
-      cy?: number | string | undefined;
-      d?: string | undefined;
-      decelerate?: number | string | undefined;
-      descent?: number | string | undefined;
-      diffuseConstant?: number | string | undefined;
-      direction?: number | string | undefined;
-      display?: number | string | undefined;
-      divisor?: number | string | undefined;
-      'dominant-baseline'?: number | string | undefined;
-      dur?: number | string | undefined;
-      dx?: number | string | undefined;
-      dy?: number | string | undefined;
-      edgeMode?: number | string | undefined;
-      elevation?: number | string | undefined;
-      'enable-background'?: number | string | undefined;
-      end?: number | string | undefined;
-      exponent?: number | string | undefined;
-      externalResourcesRequired?: number | string | undefined;
-      fill?: string | undefined;
-      'fill-opacity'?: number | string | undefined;
-      'fill-rule'?: 'nonzero' | 'evenodd' | 'inherit' | undefined;
-      filter?: string | undefined;
-      filterRes?: number | string | undefined;
-      filterUnits?: number | string | undefined;
-      'flood-color'?: number | string | undefined;
-      'flood-opacity'?: number | string | undefined;
-      focusable?: number | string | undefined;
-      'font-family'?: string | undefined;
-      'font-size'?: number | string | undefined;
-      'font-size-adjust'?: number | string | undefined;
-      'font-stretch'?: number | string | undefined;
-      'font-style'?: number | string | undefined;
-      'font-variant'?: number | string | undefined;
-      'font-weight'?: number | string | undefined;
-      format?: number | string | undefined;
-      from?: number | string | undefined;
-      fx?: number | string | undefined;
-      fy?: number | string | undefined;
-      g1?: number | string | undefined;
-      g2?: number | string | undefined;
-      'glyph-name'?: number | string | undefined;
-      'glyph-orientation-horizontal'?: number | string | undefined;
-      'glyph-orientation-vertical'?: number | string | undefined;
-      glyphRef?: number | string | undefined;
-      gradientTransform?: string | undefined;
-      gradientUnits?: string | undefined;
-      hanging?: number | string | undefined;
-      href?: string | undefined;
-      'horiz-adv-x'?: number | string | undefined;
-      'horiz-origin-x'?: number | string | undefined;
-      ideographic?: number | string | undefined;
-      'image-rendering'?: number | string | undefined;
-      in2?: number | string | undefined;
-      in?: string | undefined;
-      intercept?: number | string | undefined;
-      k1?: number | string | undefined;
-      k2?: number | string | undefined;
-      k3?: number | string | undefined;
-      k4?: number | string | undefined;
-      k?: number | string | undefined;
-      kernelMatrix?: number | string | undefined;
-      kernelUnitLength?: number | string | undefined;
-      kerning?: number | string | undefined;
-      keyPoints?: number | string | undefined;
-      keySplines?: number | string | undefined;
-      keyTimes?: number | string | undefined;
-      lengthAdjust?: number | string | undefined;
-      'letter-spacing'?: number | string | undefined;
-      'lighting-color'?: number | string | undefined;
-      limitingConeAngle?: number | string | undefined;
-      local?: number | string | undefined;
-      'marker-end'?: string | undefined;
-      markerHeight?: number | string | undefined;
-      'marker-mid'?: string | undefined;
-      'marker-start'?: string | undefined;
-      markerUnits?: number | string | undefined;
-      markerWidth?: number | string | undefined;
-      mask?: string | undefined;
-      maskContentUnits?: number | string | undefined;
-      maskUnits?: number | string | undefined;
-      mathematical?: number | string | undefined;
-      mode?: number | string | undefined;
-      numOctaves?: number | string | undefined;
-      offset?: number | string | undefined;
-      opacity?: number | string | undefined;
-      operator?: number | string | undefined;
-      order?: number | string | undefined;
-      orient?: number | string | undefined;
-      orientation?: number | string | undefined;
-      origin?: number | string | undefined;
-      overflow?: number | string | undefined;
-      'overline-position'?: number | string | undefined;
-      'overline-thickness'?: number | string | undefined;
-      'paint-order'?: number | string | undefined;
-      'panose-1'?: number | string | undefined;
-      path?: string | undefined;
-      pathLength?: number | string | undefined;
-      patternContentUnits?: string | undefined;
-      patternTransform?: number | string | undefined;
-      patternUnits?: string | undefined;
-      'pointer-events'?: number | string | undefined;
-      points?: string | undefined;
-      pointsAtX?: number | string | undefined;
-      pointsAtY?: number | string | undefined;
-      pointsAtZ?: number | string | undefined;
-      preserveAlpha?: number | string | undefined;
-      preserveAspectRatio?: string | undefined;
-      primitiveUnits?: number | string | undefined;
-      r?: number | string | undefined;
-      radius?: number | string | undefined;
-      refX?: number | string | undefined;
-      refY?: number | string | undefined;
-      'rendering-intent'?: number | string | undefined;
-      repeatCount?: number | string | undefined;
-      repeatDur?: number | string | undefined;
-      requiredExtensions?: number | string | undefined;
-      requiredFeatures?: number | string | undefined;
-      restart?: number | string | undefined;
-      result?: string | undefined;
-      rotate?: number | string | undefined;
-      rx?: number | string | undefined;
-      ry?: number | string | undefined;
-      scale?: number | string | undefined;
-      seed?: number | string | undefined;
-      'shape-rendering'?: number | string | undefined;
-      slope?: number | string | undefined;
-      spacing?: number | string | undefined;
-      specularConstant?: number | string | undefined;
-      specularExponent?: number | string | undefined;
-      speed?: number | string | undefined;
-      spreadMethod?: string | undefined;
-      startOffset?: number | string | undefined;
-      stdDeviation?: number | string | undefined;
-      stemh?: number | string | undefined;
-      stemv?: number | string | undefined;
-      stitchTiles?: number | string | undefined;
-      'stop-color'?: string | undefined;
-      'stop-opacity'?: number | string | undefined;
-      'strikethrough-position'?: number | string | undefined;
-      'strikethrough-thickness'?: number | string | undefined;
-      string?: number | string | undefined;
-      stroke?: string | undefined;
-      'stroke-dasharray'?: string | number | undefined;
-      'stroke-dashoffset'?: string | number | undefined;
-      'stroke-linecap'?: 'butt' | 'round' | 'square' | 'inherit' | undefined;
-      'stroke-linejoin'?: 'miter' | 'round' | 'bevel' | 'inherit' | undefined;
-      'stroke-miterlimit'?: string | undefined;
-      'stroke-opacity'?: number | string | undefined;
-      'stroke-width'?: number | string | undefined;
-      surfaceScale?: number | string | undefined;
-      systemLanguage?: number | string | undefined;
-      tableValues?: number | string | undefined;
-      targetX?: number | string | undefined;
-      targetY?: number | string | undefined;
-      'text-anchor'?: string | undefined;
-      'text-decoration'?: number | string | undefined;
-      textLength?: number | string | undefined;
-      'text-rendering'?: number | string | undefined;
-      to?: number | string | undefined;
-      transform?: string | undefined;
-      u1?: number | string | undefined;
-      u2?: number | string | undefined;
-      'underline-position'?: number | string | undefined;
-      'underline-thickness'?: number | string | undefined;
-      unicode?: number | string | undefined;
-      'unicode-bidi'?: number | string | undefined;
-      'unicode-range'?: number | string | undefined;
-      'units-per-em'?: number | string | undefined;
-      'v-alphabetic'?: number | string | undefined;
-      values?: string | undefined;
-      'vector-effect'?: number | string | undefined;
-      version?: string | undefined;
-      'vert-adv-y'?: number | string | undefined;
-      'vert-origin-x'?: number | string | undefined;
-      'vert-origin-y'?: number | string | undefined;
-      'v-hanging'?: number | string | undefined;
-      'v-ideographic'?: number | string | undefined;
-      viewBox?: string | undefined;
-      viewTarget?: number | string | undefined;
-      visibility?: number | string | undefined;
-      'v-mathematical'?: number | string | undefined;
-      widths?: number | string | undefined;
-      'word-spacing'?: number | string | undefined;
-      'writing-mode'?: number | string | undefined;
-      x1?: number | string | undefined;
-      x2?: number | string | undefined;
-      x?: number | string | undefined;
-      xChannelSelector?: string | undefined;
-      'x-height'?: number | string | undefined;
-      xlinkActuate?: string | undefined;
-      xlinkArcrole?: string | undefined;
-      xlinkHref?: string | undefined;
-      xlinkRole?: string | undefined;
-      xlinkShow?: string | undefined;
-      xlinkTitle?: string | undefined;
-      xlinkType?: string | undefined;
-      xmlBase?: string | undefined;
-      xmlLang?: string | undefined;
-      xmlns?: string | undefined;
-      xmlnsXlink?: string | undefined;
-      xmlSpace?: string | undefined;
-      y1?: number | string | undefined;
-      y2?: number | string | undefined;
-      y?: number | string | undefined;
-      yChannelSelector?: string | undefined;
-      z?: number | string | undefined;
-      zoomAndPan?: string | undefined;
+        'mathematical' | 'inherit' | undefined | null;
+      allowReorder?: 'no' | 'yes' | undefined | null;
+      alphabetic?: number | string | undefined | null;
+      amplitude?: number | string | undefined | null;
+      'arabic-form'?: 'initial' | 'medial' | 'terminal' | 'isolated' | undefined | null;
+      ascent?: number | string | undefined | null;
+      attributeName?: string | undefined | null;
+      attributeType?: string | undefined | null;
+      autoReverse?: number | string | undefined | null;
+      azimuth?: number | string | undefined | null;
+      baseFrequency?: number | string | undefined | null;
+      'baseline-shift'?: number | string | undefined | null;
+      baseProfile?: number | string | undefined | null;
+      bbox?: number | string | undefined | null;
+      begin?: number | string | undefined | null;
+      bias?: number | string | undefined | null;
+      by?: number | string | undefined | null;
+      calcMode?: number | string | undefined | null;
+      'cap-height'?: number | string | undefined | null;
+      clip?: number | string | undefined | null;
+      'clip-path'?: string | undefined | null;
+      clipPathUnits?: number | string | undefined | null;
+      'clip-rule'?: number | string | undefined | null;
+      'color-interpolation'?: number | string | undefined | null;
+      'color-interpolation-filters'?: 'auto' | 'sRGB' | 'linearRGB' | 'inherit' | undefined | null;
+      'color-profile'?: number | string | undefined | null;
+      'color-rendering'?: number | string | undefined | null;
+      contentScriptType?: number | string | undefined | null;
+      contentStyleType?: number | string | undefined | null;
+      cursor?: number | string | undefined | null;
+      cx?: number | string | undefined | null;
+      cy?: number | string | undefined | null;
+      d?: string | undefined | null;
+      decelerate?: number | string | undefined | null;
+      descent?: number | string | undefined | null;
+      diffuseConstant?: number | string | undefined | null;
+      direction?: number | string | undefined | null;
+      display?: number | string | undefined | null;
+      divisor?: number | string | undefined | null;
+      'dominant-baseline'?: number | string | undefined | null;
+      dur?: number | string | undefined | null;
+      dx?: number | string | undefined | null;
+      dy?: number | string | undefined | null;
+      edgeMode?: number | string | undefined | null;
+      elevation?: number | string | undefined | null;
+      'enable-background'?: number | string | undefined | null;
+      end?: number | string | undefined | null;
+      exponent?: number | string | undefined | null;
+      externalResourcesRequired?: number | string | undefined | null;
+      fill?: string | undefined | null;
+      'fill-opacity'?: number | string | undefined | null;
+      'fill-rule'?: 'nonzero' | 'evenodd' | 'inherit' | undefined | null;
+      filter?: string | undefined | null;
+      filterRes?: number | string | undefined | null;
+      filterUnits?: number | string | undefined | null;
+      'flood-color'?: number | string | undefined | null;
+      'flood-opacity'?: number | string | undefined | null;
+      focusable?: number | string | undefined | null;
+      'font-family'?: string | undefined | null;
+      'font-size'?: number | string | undefined | null;
+      'font-size-adjust'?: number | string | undefined | null;
+      'font-stretch'?: number | string | undefined | null;
+      'font-style'?: number | string | undefined | null;
+      'font-variant'?: number | string | undefined | null;
+      'font-weight'?: number | string | undefined | null;
+      format?: number | string | undefined | null;
+      from?: number | string | undefined | null;
+      fx?: number | string | undefined | null;
+      fy?: number | string | undefined | null;
+      g1?: number | string | undefined | null;
+      g2?: number | string | undefined | null;
+      'glyph-name'?: number | string | undefined | null;
+      'glyph-orientation-horizontal'?: number | string | undefined | null;
+      'glyph-orientation-vertical'?: number | string | undefined | null;
+      glyphRef?: number | string | undefined | null;
+      gradientTransform?: string | undefined | null;
+      gradientUnits?: string | undefined | null;
+      hanging?: number | string | undefined | null;
+      href?: string | undefined | null;
+      'horiz-adv-x'?: number | string | undefined | null;
+      'horiz-origin-x'?: number | string | undefined | null;
+      ideographic?: number | string | undefined | null;
+      'image-rendering'?: number | string | undefined | null;
+      in2?: number | string | undefined | null;
+      in?: string | undefined | null;
+      intercept?: number | string | undefined | null;
+      k1?: number | string | undefined | null;
+      k2?: number | string | undefined | null;
+      k3?: number | string | undefined | null;
+      k4?: number | string | undefined | null;
+      k?: number | string | undefined | null;
+      kernelMatrix?: number | string | undefined | null;
+      kernelUnitLength?: number | string | undefined | null;
+      kerning?: number | string | undefined | null;
+      keyPoints?: number | string | undefined | null;
+      keySplines?: number | string | undefined | null;
+      keyTimes?: number | string | undefined | null;
+      lengthAdjust?: number | string | undefined | null;
+      'letter-spacing'?: number | string | undefined | null;
+      'lighting-color'?: number | string | undefined | null;
+      limitingConeAngle?: number | string | undefined | null;
+      local?: number | string | undefined | null;
+      'marker-end'?: string | undefined | null;
+      markerHeight?: number | string | undefined | null;
+      'marker-mid'?: string | undefined | null;
+      'marker-start'?: string | undefined | null;
+      markerUnits?: number | string | undefined | null;
+      markerWidth?: number | string | undefined | null;
+      mask?: string | undefined | null;
+      maskContentUnits?: number | string | undefined | null;
+      maskUnits?: number | string | undefined | null;
+      mathematical?: number | string | undefined | null;
+      mode?: number | string | undefined | null;
+      numOctaves?: number | string | undefined | null;
+      offset?: number | string | undefined | null;
+      opacity?: number | string | undefined | null;
+      operator?: number | string | undefined | null;
+      order?: number | string | undefined | null;
+      orient?: number | string | undefined | null;
+      orientation?: number | string | undefined | null;
+      origin?: number | string | undefined | null;
+      overflow?: number | string | undefined | null;
+      'overline-position'?: number | string | undefined | null;
+      'overline-thickness'?: number | string | undefined | null;
+      'paint-order'?: number | string | undefined | null;
+      'panose-1'?: number | string | undefined | null;
+      path?: string | undefined | null;
+      pathLength?: number | string | undefined | null;
+      patternContentUnits?: string | undefined | null;
+      patternTransform?: number | string | undefined | null;
+      patternUnits?: string | undefined | null;
+      'pointer-events'?: number | string | undefined | null;
+      points?: string | undefined | null;
+      pointsAtX?: number | string | undefined | null;
+      pointsAtY?: number | string | undefined | null;
+      pointsAtZ?: number | string | undefined | null;
+      preserveAlpha?: number | string | undefined | null;
+      preserveAspectRatio?: string | undefined | null;
+      primitiveUnits?: number | string | undefined | null;
+      r?: number | string | undefined | null;
+      radius?: number | string | undefined | null;
+      refX?: number | string | undefined | null;
+      refY?: number | string | undefined | null;
+      'rendering-intent'?: number | string | undefined | null;
+      repeatCount?: number | string | undefined | null;
+      repeatDur?: number | string | undefined | null;
+      requiredExtensions?: number | string | undefined | null;
+      requiredFeatures?: number | string | undefined | null;
+      restart?: number | string | undefined | null;
+      result?: string | undefined | null;
+      rotate?: number | string | undefined | null;
+      rx?: number | string | undefined | null;
+      ry?: number | string | undefined | null;
+      scale?: number | string | undefined | null;
+      seed?: number | string | undefined | null;
+      'shape-rendering'?: number | string | undefined | null;
+      slope?: number | string | undefined | null;
+      spacing?: number | string | undefined | null;
+      specularConstant?: number | string | undefined | null;
+      specularExponent?: number | string | undefined | null;
+      speed?: number | string | undefined | null;
+      spreadMethod?: string | undefined | null;
+      startOffset?: number | string | undefined | null;
+      stdDeviation?: number | string | undefined | null;
+      stemh?: number | string | undefined | null;
+      stemv?: number | string | undefined | null;
+      stitchTiles?: number | string | undefined | null;
+      'stop-color'?: string | undefined | null;
+      'stop-opacity'?: number | string | undefined | null;
+      'strikethrough-position'?: number | string | undefined | null;
+      'strikethrough-thickness'?: number | string | undefined | null;
+      string?: number | string | undefined | null;
+      stroke?: string | undefined | null;
+      'stroke-dasharray'?: string | number | undefined | null;
+      'stroke-dashoffset'?: string | number | undefined | null;
+      'stroke-linecap'?: 'butt' | 'round' | 'square' | 'inherit' | undefined | null;
+      'stroke-linejoin'?: 'miter' | 'round' | 'bevel' | 'inherit' | undefined | null;
+      'stroke-miterlimit'?: string | undefined | null;
+      'stroke-opacity'?: number | string | undefined | null;
+      'stroke-width'?: number | string | undefined | null;
+      surfaceScale?: number | string | undefined | null;
+      systemLanguage?: number | string | undefined | null;
+      tableValues?: number | string | undefined | null;
+      targetX?: number | string | undefined | null;
+      targetY?: number | string | undefined | null;
+      'text-anchor'?: string | undefined | null;
+      'text-decoration'?: number | string | undefined | null;
+      textLength?: number | string | undefined | null;
+      'text-rendering'?: number | string | undefined | null;
+      to?: number | string | undefined | null;
+      transform?: string | undefined | null;
+      u1?: number | string | undefined | null;
+      u2?: number | string | undefined | null;
+      'underline-position'?: number | string | undefined | null;
+      'underline-thickness'?: number | string | undefined | null;
+      unicode?: number | string | undefined | null;
+      'unicode-bidi'?: number | string | undefined | null;
+      'unicode-range'?: number | string | undefined | null;
+      'units-per-em'?: number | string | undefined | null;
+      'v-alphabetic'?: number | string | undefined | null;
+      values?: string | undefined | null;
+      'vector-effect'?: number | string | undefined | null;
+      version?: string | undefined | null;
+      'vert-adv-y'?: number | string | undefined | null;
+      'vert-origin-x'?: number | string | undefined | null;
+      'vert-origin-y'?: number | string | undefined | null;
+      'v-hanging'?: number | string | undefined | null;
+      'v-ideographic'?: number | string | undefined | null;
+      viewBox?: string | undefined | null;
+      viewTarget?: number | string | undefined | null;
+      visibility?: number | string | undefined | null;
+      'v-mathematical'?: number | string | undefined | null;
+      widths?: number | string | undefined | null;
+      'word-spacing'?: number | string | undefined | null;
+      'writing-mode'?: number | string | undefined | null;
+      x1?: number | string | undefined | null;
+      x2?: number | string | undefined | null;
+      x?: number | string | undefined | null;
+      xChannelSelector?: string | undefined | null;
+      'x-height'?: number | string | undefined | null;
+      xlinkActuate?: string | undefined | null;
+      xlinkArcrole?: string | undefined | null;
+      xlinkHref?: string | undefined | null;
+      xlinkRole?: string | undefined | null;
+      xlinkShow?: string | undefined | null;
+      xlinkTitle?: string | undefined | null;
+      xlinkType?: string | undefined | null;
+      xmlBase?: string | undefined | null;
+      xmlLang?: string | undefined | null;
+      xmlns?: string | undefined | null;
+      xmlnsXlink?: string | undefined | null;
+      xmlSpace?: string | undefined | null;
+      y1?: number | string | undefined | null;
+      y2?: number | string | undefined | null;
+      y?: number | string | undefined | null;
+      yChannelSelector?: string | undefined | null;
+      z?: number | string | undefined | null;
+      zoomAndPan?: string | undefined | null;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -874,70 +874,70 @@ declare namespace svelte.JSX {
     interface SVGProps<T extends EventTarget> extends SVGAttributes<T> {}
 
     interface SvelteOptionProps extends HTMLProps<HTMLOptionElement> {
-        value?: any | undefined;
+        value?: any | undefined | null;
     }
 
     interface SvelteSelectProps extends HTMLProps<HTMLSelectElement> {
-      value?: any | undefined;
+      value?: any | undefined | null;
     }
 
     interface SvelteInputProps extends HTMLProps<HTMLInputElement> {
-      group?: any | undefined;
-      files?: FileList | null | undefined;
-      indeterminate?: boolean | undefined;
+      group?: any | undefined | null;
+      files?: FileList | undefined | null;
+      indeterminate?: boolean | undefined | null;
     }
 
     interface SvelteWindowProps  {
-      readonly innerWidth?: Window['innerWidth'] | undefined;
-      readonly innerHeight?: Window['innerHeight'] | undefined;
-      readonly outerWidth?: Window['outerWidth'] | undefined;
-      readonly outerHeight?: Window['outerHeight'] | undefined;
-      scrollX?: Window['scrollX'] | undefined;
-      scrollY?: Window['scrollY'] | undefined;
-      readonly online?: Window['navigator']['onLine'] | undefined;
+      readonly innerWidth?: Window['innerWidth'] | undefined | null;
+      readonly innerHeight?: Window['innerHeight'] | undefined | null;
+      readonly outerWidth?: Window['outerWidth'] | undefined | null;
+      readonly outerHeight?: Window['outerHeight'] | undefined | null;
+      scrollX?: Window['scrollX'] | undefined | null;
+      scrollY?: Window['scrollY'] | undefined | null;
+      readonly online?: Window['navigator']['onLine'] | undefined | null;
 
       // Transformed from on:sveltekit:xy
-      'onsveltekit:start'?: EventHandler<CustomEvent, Window> | undefined;
-      'onsveltekit:navigation-start'?: EventHandler<CustomEvent, Window> | undefined;
-      'onsveltekit:navigation-end'?: EventHandler<CustomEvent, Window> | undefined;
+      'onsveltekit:start'?: EventHandler<CustomEvent, Window> | undefined | null;
+      'onsveltekit:navigation-start'?: EventHandler<CustomEvent, Window> | undefined | null;
+      'onsveltekit:navigation-end'?: EventHandler<CustomEvent, Window> | undefined | null;
 
-      ondevicelight?: EventHandler<Event, Window> | undefined;
-      onbeforeinstallprompt?: EventHandler<Event, Window> | undefined;
-      ondeviceproximity?: EventHandler<Event, Window> | undefined;
-      onpaint?: EventHandler<Event, Window> | undefined;
-      onuserproximity?: EventHandler<Event, Window> | undefined;
-      onbeforeprint?: EventHandler<Event, Window> | undefined;
-      onafterprint?: EventHandler<Event, Window> | undefined;
-      onlanguagechange?: EventHandler<Event, Window> | undefined;
-      onorientationchange?: EventHandler<Event, Window> | undefined;
-      onmessage?: EventHandler<MessageEvent, Window> | undefined;
-      onmessageerror?: EventHandler<MessageEvent, Window> | undefined;
-      onoffline?: EventHandler<Event, Window> | undefined;
-      ononline?: EventHandler<Event, Window> | undefined;
-      onbeforeunload?: EventHandler<BeforeUnloadEvent, Window> | undefined;
-      onunload?: EventHandler<Event, Window> | undefined;
-      onstorage?: EventHandler<StorageEvent, Window> | undefined;
-      onhashchange?: EventHandler<HashChangeEvent, Window> | undefined;
-      onpagehide?: EventHandler<PageTransitionEvent, Window> | undefined;
-      onpageshow?: EventHandler<PageTransitionEvent, Window> | undefined;
-      onpopstate?: EventHandler<PopStateEvent, Window> | undefined;
-      ondevicemotion?: EventHandler<DeviceMotionEvent> | undefined;
-      ondeviceorientation?: EventHandler<DeviceOrientationEvent, Window> | undefined;
-      ondeviceorientationabsolute?: EventHandler<DeviceOrientationEvent, Window> | undefined;
-      onunhandledrejection?: EventHandler<PromiseRejectionEvent, Window> | undefined;
-      onrejectionhandled?: EventHandler<PromiseRejectionEvent, Window> | undefined;
+      ondevicelight?: EventHandler<Event, Window> | undefined | null;
+      onbeforeinstallprompt?: EventHandler<Event, Window> | undefined | null;
+      ondeviceproximity?: EventHandler<Event, Window> | undefined | null;
+      onpaint?: EventHandler<Event, Window> | undefined | null;
+      onuserproximity?: EventHandler<Event, Window> | undefined | null;
+      onbeforeprint?: EventHandler<Event, Window> | undefined | null;
+      onafterprint?: EventHandler<Event, Window> | undefined | null;
+      onlanguagechange?: EventHandler<Event, Window> | undefined | null;
+      onorientationchange?: EventHandler<Event, Window> | undefined | null;
+      onmessage?: EventHandler<MessageEvent, Window> | undefined | null;
+      onmessageerror?: EventHandler<MessageEvent, Window> | undefined | null;
+      onoffline?: EventHandler<Event, Window> | undefined | null;
+      ononline?: EventHandler<Event, Window> | undefined | null;
+      onbeforeunload?: EventHandler<BeforeUnloadEvent, Window> | undefined | null;
+      onunload?: EventHandler<Event, Window> | undefined | null;
+      onstorage?: EventHandler<StorageEvent, Window> | undefined | null;
+      onhashchange?: EventHandler<HashChangeEvent, Window> | undefined | null;
+      onpagehide?: EventHandler<PageTransitionEvent, Window> | undefined | null;
+      onpageshow?: EventHandler<PageTransitionEvent, Window> | undefined | null;
+      onpopstate?: EventHandler<PopStateEvent, Window> | undefined | null;
+      ondevicemotion?: EventHandler<DeviceMotionEvent> | undefined | null;
+      ondeviceorientation?: EventHandler<DeviceOrientationEvent, Window> | undefined | null;
+      ondeviceorientationabsolute?: EventHandler<DeviceOrientationEvent, Window> | undefined | null;
+      onunhandledrejection?: EventHandler<PromiseRejectionEvent, Window> | undefined | null;
+      onrejectionhandled?: EventHandler<PromiseRejectionEvent, Window> | undefined | null;
     }
 
     interface SapperAnchorProps {
         // transformed from sapper:noscroll so it should be camel case
-        sapperNoscroll?: true | undefined;
-        sapperPrefetch?: true | undefined;
+        sapperNoscroll?: true | undefined | null;
+        sapperPrefetch?: true | undefined | null;
     }
 
     interface SvelteKitAnchorProps {
         // transformed from sveltekit:noscroll so it should be camel case
-        sveltekitNoscroll?: true | undefined;
-        sveltekitPrefetch?: true | undefined;
+        sveltekitNoscroll?: true | undefined | null;
+        sveltekitPrefetch?: true | undefined | null;
     }
 
     interface SvelteMediaTimeRange {
@@ -946,34 +946,34 @@ declare namespace svelte.JSX {
     }
 
     interface SvelteMediaProps {
-        readonly duration?: number | undefined;
-        readonly buffered?: SvelteMediaTimeRange[] | undefined;
-        readonly played?: SvelteMediaTimeRange[] | undefined;
-        readonly seekable?: SvelteMediaTimeRange[] | undefined;
-        readonly seeking?: boolean | undefined;
-        readonly ended?: boolean | undefined;
+        readonly duration?: number | undefined | null;
+        readonly buffered?: SvelteMediaTimeRange[] | undefined | null;
+        readonly played?: SvelteMediaTimeRange[] | undefined | null;
+        readonly seekable?: SvelteMediaTimeRange[] | undefined | null;
+        readonly seeking?: boolean | undefined | null;
+        readonly ended?: boolean | undefined | null;
 
         /**
          * the current playback time in the video, in seconds
          */
-        currentTime?: number | undefined;
+        currentTime?: number | undefined | null;
         /**
          * the current playback time in the video, in seconds
          */
-        currenttime?: number | undefined;
+        currenttime?: number | undefined | null;
         // Doesn't work when used as HTML Attribute
         /**
          * how fast or slow to play the video, where 1 is 'normal'
          */
-        playbackRate?: number | undefined;
+        playbackRate?: number | undefined | null;
 
-        paused?: boolean | undefined;
+        paused?: boolean | undefined | null;
     }
 
     interface SvelteVideoProps extends SvelteMediaProps {
         // Binding only, don't need lowercase variant
-        readonly videoWidth?: number | undefined;
-        readonly videoHeight?: number | undefined;
+        readonly videoWidth?: number | undefined | null;
+        readonly videoHeight?: number | undefined | null;
     }
 
     interface IntrinsicElements {


### PR DESCRIPTION
Svelte treats undefined and null the same on these
#1285