### PR TITLE
(fix) relax value typings

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -557,7 +557,7 @@ declare namespace svelte.JSX {
       title?: string | undefined | null;
       type?: string | undefined | null;
       usemap?: string | undefined | null;
-      value?: string | string[] | number | undefined | null;
+      value?: any | undefined | null;
       /**
        * a value between 0 and 1
       */
@@ -873,14 +873,6 @@ declare namespace svelte.JSX {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface SVGProps<T extends EventTarget> extends SVGAttributes<T> {}
 
-    interface SvelteOptionProps extends HTMLProps<HTMLOptionElement> {
-        value?: any | undefined | null;
-    }
-
-    interface SvelteSelectProps extends HTMLProps<HTMLSelectElement> {
-      value?: any | undefined | null;
-    }
-
     interface SvelteInputProps extends HTMLProps<HTMLInputElement> {
       group?: any | undefined | null;
       files?: FileList | undefined | null;
@@ -1052,7 +1044,7 @@ declare namespace svelte.JSX {
       object: HTMLProps<HTMLObjectElement>;
       ol: HTMLProps<HTMLOListElement>;
       optgroup: HTMLProps<HTMLOptGroupElement>;
-      option: SvelteOptionProps;
+      option: HTMLProps<HTMLOptionElement>;
       output: HTMLProps<HTMLElement>;
       p: HTMLProps<HTMLParagraphElement>;
       param: HTMLProps<HTMLParamElement>;
@@ -1067,7 +1059,7 @@ declare namespace svelte.JSX {
       samp: HTMLProps<HTMLElement>;
       script: HTMLProps<HTMLElement>;
       section: HTMLProps<HTMLElement>;
-      select: SvelteSelectProps;
+      select: HTMLProps<HTMLSelectElement>;
       small: HTMLProps<HTMLElement>;
       source: HTMLProps<HTMLSourceElement>;
       span: HTMLProps<HTMLSpanElement>;


### PR DESCRIPTION
A radio group value can be anything, so we need to relax the type
#1297