### PR TITLE
Fix language server Yarn PnP resolution crash

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -63,6 +63,7 @@
         "vscode-emmet-helper": "~2.6.0",
         "vscode-html-languageservice": "~4.1.0",
         "vscode-languageserver": "7.1.0-next.4",
+        "vscode-languageserver-protocol": "3.16.0",
         "vscode-languageserver-types": "3.16.0",
         "vscode-uri": "~3.0.0"
     }


### PR DESCRIPTION
**Summary:** The Svelte Language Server crashes while being used with [Yarn PnP VS Code support](https://yarnpkg.com/sdks/cli/default) because it [uses the package `vscode-languageserver-protocol`](https://github.com/sveltejs/language-tools/blob/cde40da02a3934ff90b78aa44d42a616fb2f18d1/packages/language-server/src/plugins/typescript/features/ImplementationProvider.ts#L1) [without declaring it in its dependencies](https://github.com/sveltejs/language-tools/blob/cde40da02a3934ff90b78aa44d42a616fb2f18d1/packages/language-server/package.json#L65). This pull request adds the package to the server's dependencies so it no longer crashes.

**Steps to reproduce:**
1. Install [VSCode](https://code.visualstudio.com/) and the [Svelte extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode)
2. Go to Settings and set the following settings:
a. `svelte.language-server.ls-path`: `.yarn/sdks/svelte-language-server/bin/server.js`
b. `svelte.trace.server`: `verbose`
3. Clone the [PoC](https://github.com/NoelTautges/svelte-language-server-pnp)
4. Open the PoC folder in VS Code
5. Open `App.svelte`
6. View the following error message in Output > Svelte:
```
[snip]\svelte-language-server-pnp-crash\.pnp.cjs:11508
    throw firstError;
    ^

Error: svelte-language-server tried to access vscode-languageserver-protocol, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: vscode-languageserver-protocol
Required by: svelte-language-server@npm:0.14.16 (via [snip]\svelte-language-server-pnp-crash\.yarn\cache\svelte-language-server-npm-0.14.16-ad271df40a-4826ff5df6.zip\node_modules\svelte-language-server\dist\src\plugins\typescript\features\)

Require stack:
- [snip]\svelte-language-server-pnp-crash\.yarn\cache\svelte-language-server-npm-0.14.16-ad271df40a-4826ff5df6.zip\node_modules\svelte-language-server\dist\src\plugins\typescript\features\ImplementationProvider.js
- [snip]\svelte-language-server-pnp-crash\.yarn\cache\svelte-language-server-npm-0.14.16-ad271df40a-4826ff5df6.zip\node_modules\svelte-language-server\dist\src\plugins\typescript\TypeScriptPlugin.js
- [snip]\svelte-language-server-pnp-crash\.yarn\cache\svelte-language-server-npm-0.14.16-ad271df40a-4826ff5df6.zip\node_modules\svelte-language-server\dist\src\plugins\index.js
- [snip]\svelte-language-server-pnp-crash\.yarn\cache\svelte-language-server-npm-0.14.16-ad271df40a-4826ff5df6.zip\node_modules\svelte-language-server\dist\src\server.js
- [snip]\svelte-language-server-pnp-crash\.yarn\cache\svelte-language-server-npm-0.14.16-ad271df40a-4826ff5df6.zip\node_modules\svelte-language-server\bin\server.js
- [snip]\svelte-language-server-pnp-crash\.pnp.cjs
    at Function.external_module_.Module._resolveFilename ([snip]\svelte-language-server-pnp-crash\.pnp.cjs:11507:55)
    at Function.external_module_.Module._load ([snip]\svelte-language-server-pnp-crash\.pnp.cjs:11306:48)
    at Module.require (internal/modules/cjs/loader.js:1006:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> ([snip]\svelte-language-server-pnp-crash\.yarn\cache\svelte-language-server-npm-0.14.16-ad271df40a-4826ff5df6.zip\node_modules\svelte-language-server\dist\src\plugins\typescript\features\ImplementationProvider.js:4:42)
    at Module._compile (internal/modules/cjs/loader.js:1125:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1155:10)
    at Module.load (internal/modules/cjs/loader.js:982:32)
    at Function.external_module_.Module._load ([snip]\svelte-language-server-pnp-crash\.pnp.cjs:11356:14)
    at Module.require (internal/modules/cjs/loader.js:1006:19)
[Error - 8:19:27 PM] Connection to server got closed. Server will not be restarted.
```
7. Run `yarn remove` and `yarn link [path to built language-server]`
8. Restart VS Code and open `App.svelte` again
9. View no error messages
10. Unset the settings above

**Temporary workaround:** Add the following lines to [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc#packageExtensions):
```yml
packageExtensions:
  svelte-language-server@*:
    dependencies:
      vscode-languageserver-protocol: "*"
```

**Notes:**
- The `vscode-languageserver-protocol` version added is the same as `vscode-languageserver-types` so they can be updated togther.

Thank you for your time! Let me know if you need more information.