### PR TITLE
feat(svelte2tsx): add controlslist attribute to types

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -581,6 +581,7 @@ declare namespace svelte.JSX {
       autocorrect?: string | undefined | null;
       autosave?: string | undefined | null;
       color?: string | undefined | null;
+      controlslist?: "nodownload" | "nofullscreen" | "noremoteplayback"; 
       itemprop?: string | undefined | null;
       itemscope?: boolean | undefined | null;
       itemtype?: string | undefined | null;

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -581,7 +581,7 @@ declare namespace svelte.JSX {
       autocorrect?: string | undefined | null;
       autosave?: string | undefined | null;
       color?: string | undefined | null;
-      controlslist?: "nodownload" | "nofullscreen" | "noremoteplayback"; 
+      controlslist?: "nodownload" | "nofullscreen" | "noplaybackrate" | "noremoteplayback";
       itemprop?: string | undefined | null;
       itemscope?: boolean | undefined | null;
       itemtype?: string | undefined | null;

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -581,7 +581,7 @@ declare namespace svelte.JSX {
       autocorrect?: string | undefined | null;
       autosave?: string | undefined | null;
       color?: string | undefined | null;
-      controlslist?: "nodownload" | "nofullscreen" | "noplaybackrate" | "noremoteplayback";
+      controlslist?: 'nodownload' | 'nofullscreen' | 'noplaybackrate' | 'noremoteplayback';
       itemprop?: string | undefined | null;
       itemscope?: boolean | undefined | null;
       itemtype?: string | undefined | null;


### PR DESCRIPTION
This isn't currently a standard attribute, there is some opposition to it from webkit but it is shipped in latest edge and chrome. I have also added the 4th attribute option, added in that PR (`noplaybackrate`) as this has shipped in chrome/edge.

Related:
- [whatwg discussion](https://github.com/whatwg/html/pull/6715)
- [Chrome Platform Status](https://chromestatus.com/feature/5092414224072704)