### PR TITLE
Add special "conservative" highlighting for `style` attribute values

### DIFF
--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
@@ -319,11 +319,83 @@ repository:
     endCaptures:
       1: { name: punctuation.definition.block.end.svelte }
 
+  # -------
+  #  STYLE
+
+  # Specifically matches the `style=''` attribute.
+  style-attribute:
+    begin: (style)
+    beginCaptures: { 1: { name: entity.other.attribute-name.svelte } }
+    end: (?=\s*+[^=\s])
+    name: 'meta.attribute.$1.svelte'
+    patterns:
+    - begin: '='
+      beginCaptures: { 0: { name: punctuation.separator.key-value.svelte } }
+      end: (?<=[^\s=])(?!\s*=)|(?=/?>)
+      patterns:
+      - include: '#style-value'
+      - include: '#attributes-value'
+
+  # Embedded CSS in a style attribute.
+  # Does not include the actual CSS grammar. A simplified one is used instead.
+  style-value:
+    begin: (['"])
+    end: \1
+    beginCaptures: { 0: { name: punctuation.definition.string.begin.svelte } }
+    endCaptures:   { 0: { name: punctuation.definition.string.end.svelte } }
+    contentName: source.css
+    patterns:
+    - include: '#interpolation'
+    - include: '#style-css-expression'
+
+  style-css-expression:
+    patterns:
+    # Matches declaration properties.
+    - match: ([a-zA-Z0-9_-]+)\s*(:)
+      captures:
+        1: { name: support.type.property-name.css }
+        2: { name: punctuation.separator.key-value.css }
+    # Matches functions, e.g. `var()`.
+    - begin: (\w[^\s:'"()]*?)(\()
+      end: \)
+      beginCaptures:
+        1: { name: entity.name.function.css }
+        2: { name: punctuation.section.function.begin.bracket.round.css }
+      endCaptures: { 0: { name: punctuation.section.function.end.bracket.round.css } }
+      patterns: [ include: '#style-css-expression' ]
+    # Matches quoted strings.
+    - begin: (['"])
+      end: \1
+      beginCaptures: { 0: { name: punctuation.definition.string.begin.css } }
+      endCaptures:   { 0: { name: punctuation.definition.string.end.css } }
+      name: string.quoted.svelte
+      patterns: [ include: '#interpolation' ]
+    # Matches hex colors.
+    - match: '#[0-9a-fA-F]+'
+      name: constant.other.color.rgb-value.hex.css
+    # Matches numbers + optional unit suffix.
+    - match: (?<![\w\d-])[+-]?[0-9.][0-9._]*[\w%]{,4}(?!=[\w\d-])
+      name: constant.numeric.decimal.css
+    # Matches unit suffixes.
+    - match: cm|mm|Q|in|pc|pt|px|em|ex|ch|rem|lh|vw|vh|vmin|vmax
+      name: constant.numeric.decimal.css
+    # Matches CSS variables (excluding ones in declaration property names)
+    - match: --[a-zA-Z_-][a-zA-Z0-9_-]*
+      name: variable.css
+    # Matches various punctuation and operators.
+    - { match: '[+*/-]', name: keyword.operator.css }
+    - { match: ',',      name: punctuation.seperator.css }
+    - { match: ';',      name: punctuation.terminator.rule.css }
+    # Matches every other string of characters that looks like an identifier or value.
+    - match: '[a-zA-Z_-][a-zA-Z0-9_-]*'
+      name: support.constant.property-value.css
+
   # ------------
   #  ATTRIBUTES
 
   attributes:
     patterns:
+    - include: '#style-attribute'
     - include: '#attributes-directives'
     - include: '#attributes-keyvalue'
     - include: '#attributes-interpolated'

--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
@@ -339,24 +339,36 @@ repository:
   # Matches attribute keyvalues. (and boolean attributes as well)
   # e.g. `class="my-class"`
   attributes-keyvalue:
-    begin: ([_$[:alpha:]][_\-$[:alnum:]]*)
-    beginCaptures: { 1: { name: entity.other.attribute-name.svelte } }
+    begin: ((?:--)?[_$[:alpha:]][_\-$[:alnum:]]*)
+    beginCaptures:
+      0:
+        patterns:
+        # Matches if the key is a `--css-variable` attribute.
+        - match: --.*
+          name: support.type.property-name.svelte
+        # Matches everything else.
+        - match: .*
+          name: entity.other.attribute-name.svelte
     end: (?=\s*+[^=\s])
     name: 'meta.attribute.$1.svelte'
-    patterns: [ include: '#attributes-value' ]
+    patterns:
+    - begin: '='
+      beginCaptures: { 0: { name: punctuation.separator.key-value.svelte } }
+      end: (?<=[^\s=])(?!\s*=)|(?=/?>)
+      patterns: [include: '#attributes-value']
 
-  # The value part of attribute keyvalues. e.g. `="my-class"` in `class="my-class"`
+  # The value part of attribute keyvalues. e.g. `"my-class"` in `class="my-class"`
   attributes-value:
-    begin: '='
-    beginCaptures: { 0: { name: punctuation.separator.key-value.svelte } }
-    end: (?<=[^\s=])(?!\s*=)|(?=/?>)
     patterns:
     # No quotes - just an interpolation expression.
     - include: '#interpolation'
     # Units, meaning digit characters and an optional unit string. e.g. `15px`
-    - match: ([0-9._]+[\w]{,4})(?=\s|/?>)
-      name: constant.numeric.decimal.svelte
-      patterns: [ include: '#interpolation' ]
+    - match: (?:(['"])([0-9._]+[\w%]{,4})(\1))|(?:([0-9._]+[\w%]{,4})(?=\s|/?>))
+      captures:
+        1: { name: punctuation.definition.string.begin.svelte }
+        2: { name: constant.numeric.decimal.svelte }
+        3: { name: punctuation.definition.string.end.svelte }
+        4: { name: constant.numeric.decimal.svelte }
     # Unquoted strings.
     - match: ([^\s"'=<>`/]|/(?!>))+
       name: string.unquoted.svelte
@@ -365,7 +377,7 @@ repository:
     - begin: (['"])
       end: \1
       beginCaptures: { 0: { name: punctuation.definition.string.begin.svelte } }
-      endCaptures: { 0: { name: punctuation.definition.string.end.svelte } }
+      endCaptures:   { 0: { name: punctuation.definition.string.end.svelte } }
       name: string.quoted.svelte
       patterns: [ include: '#interpolation' ]
 
@@ -419,7 +431,10 @@ repository:
     end: (?=\s*+[^=\s])
     name: meta.directive.$1.svelte
     patterns:
-    - include: '#attributes-value'
+    - begin: '='
+      beginCaptures: { 0: { name: punctuation.separator.key-value.svelte } }
+      end: (?<=[^\s=])(?!\s*=)|(?=/?>)
+      patterns: [include: '#attributes-value']
 
   # ------
   #  TAGS

--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
@@ -363,12 +363,9 @@ repository:
     # No quotes - just an interpolation expression.
     - include: '#interpolation'
     # Units, meaning digit characters and an optional unit string. e.g. `15px`
-    - match: (?:(['"])([0-9._]+[\w%]{,4})(\1))|(?:([0-9._]+[\w%]{,4})(?=\s|/?>))
-      captures:
-        1: { name: punctuation.definition.string.begin.svelte }
-        2: { name: constant.numeric.decimal.svelte }
-        3: { name: punctuation.definition.string.end.svelte }
-        4: { name: constant.numeric.decimal.svelte }
+    - match: ([0-9._]+[\w]{,4})(?=\s|/?>)
+      name: constant.numeric.decimal.svelte
+      patterns: [ include: '#interpolation' ]
     # Unquoted strings.
     - match: ([^\s"'=<>`/]|/(?!>))+
       name: string.unquoted.svelte


### PR DESCRIPTION
Was part of my old PR. Quoting myself:

> This adds a form of syntax highlighting inside of CSS style attributes as requested by https://github.com/sveltejs/language-tools/issues/381. This also adds a slight "fix" to attribute value number strings, which allows them to be quoted (pictures below).
>
> Syntax highlighting is done "conservatively", as in the actual `source.css` grammar **is not included.** Instead, I wrote an "adequate" grammar, which should look fairly similar to how CSS normally looks in themes and is plenty good enough for Svelte's purposes. The primary reason I did it this way was to avoid any 'break-out' bugs. This addition, therefore, should actually avoid those bugs - however, because we don't really have a good test suite yet, I haven't been able to test this thoroughly.
>
> What is actually highlighted in the grammar is very minimal - selectors, media blocks, etc. are not handled because, afaik, they won't ever appear in a style string. Additionally, the highlighting won't actually "check" for valid expressions (forgetting a semi-colon) because it doesn't parse the CSS using begin-end blocks. It uses `match` pretty much exclusively except for functions and strings.
>
> Due to the lack of a test suite, I'd recommend caution when merging this - I can't see how my additions can go _too_ wrong, but I don't know for sure. Textmate grammar definitions are cursed.
>
> One issue I do know of is that any themes that specifically handle `source.css` may highlight interpolated Svelte expressions slightly wrong - e.g. in my theme, CSS variables are red, so Svelte variables become red inside the interpolated expression. This is a tradeoff, as I'd have to make things either very messy or complex to fix this. This isn't too common in themes.
>
> Some screenshots:
>
> My theme
> ![image](https://user-images.githubusercontent.com/34875062/110504198-28b2a200-80ba-11eb-97e8-e61218986fbb.png)
>
> Dark+
> ![image](https://user-images.githubusercontent.com/34875062/110504248-3700be00-80ba-11eb-953b-967d454afea5.png)
>
> Light+
> ![image](https://user-images.githubusercontent.com/34875062/110504284-3ff18f80-80ba-11eb-8772-cdf8c2c380a5.png)

This extends/requires #1315. That PR should be merged first, or this one merged and that one closed.