### PR TITLE
Add highlighting for `@const` tags

### DIFF
--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
@@ -214,7 +214,8 @@ repository:
          { match: each|key,          name: keyword.control.svelte             },
          { match: await|then|catch,  name: keyword.control.flow.svelte        },
          { match: html,              name: keyword.other.svelte               },
-         { match: debug,             name: keyword.other.debugger.svelte      }]}
+         { match: debug,             name: keyword.other.debugger.svelte      },
+         { match: const,             name: storage.type.svelte                }]}
 
   # Scopes special tag _block start nodes_ depending on what type they are, such as `#if` or `#await` blocks.
   special-tags-modes:
@@ -224,6 +225,19 @@ repository:
       end: (?=})
       name: meta.embedded.expression.svelte source.ts
       patterns: [ include: source.ts ]
+
+    # Const.
+    - begin: (?<=const.*?)\G
+      end: (?=})
+      patterns:
+      # Variable.
+      - begin: \G\s*([_$[:alpha:]][_$[:alnum:]]+)\s*
+        end: (?=\=)
+        beginCaptures: { 1: { name: variable.other.constant.svelte } }
+      # Expression (starting with "=").
+      - begin: (?=\=)
+        end: (?=})
+        patterns: [ include: source.ts#variable-initializer ]
 
     # Each.
     - begin: (?<=each.*?)\G


### PR DESCRIPTION
Helps with #1067

Due to me trying to make this as reliable as possible, the actual TS highlighting begins at the `=` character. Trying to get TS to highlight `const` itself probably would open up a bunch of edge cases.

![image](https://user-images.githubusercontent.com/34875062/148306696-9ecaf02a-ae10-45de-a633-0131d2511d11.png)
