### PR TITLE
(perf) cache fileExists resolutions

### DIFF
--- a/packages/language-server/src/lib/documents/Document.ts
+++ b/packages/language-server/src/lib/documents/Document.ts
@@ -17,6 +17,11 @@ export class Document extends WritableDocument {
     configPromise: Promise<SvelteConfig | undefined>;
     config?: SvelteConfig;
     html!: HTMLDocument;
+    /**
+     * Compute and cache directly because of performance reasons
+     * and it will be called anyway.
+     */
+    private path = urlToPath(this.url);
 
     constructor(public url: string, public content: string) {
         super();
@@ -77,7 +82,7 @@ export class Document extends WritableDocument {
      * Returns the file path if the url scheme is file
      */
     getFilePath(): string | null {
-        return urlToPath(this.url);
+        return this.path;
     }
 
     /**

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -90,9 +90,14 @@ export function createSvelteModuleLoader(
         fileExists: svelteSys.fileExists,
         readFile: svelteSys.readFile,
         readDirectory: svelteSys.readDirectory,
-        deleteFromModuleCache: (path: string) => moduleCache.delete(path),
-        deleteUnresolvedResolutionsFromCache: (path: string) =>
-            moduleCache.deleteUnresolvedResolutionsFromCache(path),
+        deleteFromModuleCache: (path: string) => {
+            svelteSys.deleteFromCache(path);
+            moduleCache.delete(path);
+        },
+        deleteUnresolvedResolutionsFromCache: (path: string) => {
+            svelteSys.deleteFromCache(path);
+            moduleCache.deleteUnresolvedResolutionsFromCache(path);
+        },
         resolveModuleNames
     };
 

--- a/packages/language-server/src/plugins/typescript/svelte-sys.ts
+++ b/packages/language-server/src/plugins/typescript/svelte-sys.ts
@@ -6,7 +6,7 @@ import { ensureRealSvelteFilePath, isVirtualSvelteFilePath, toRealSvelteFilePath
  * This should only be accessed by TS svelte module resolution.
  */
 export function createSvelteSys(getSnapshot: (fileName: string) => DocumentSnapshot) {
-    let fileExistsCache = new Map<string, boolean>();
+    const fileExistsCache = new Map<string, boolean>();
 
     const svelteSys: ts.System & { deleteFromCache: (path: string) => void } = {
         ...ts.sys,


### PR DESCRIPTION
This makes getCompletions perform many times faster, the bigger the project the more it benefits from this cache.

I noticed that there's a lot of time spent in `fileExists` during analyzing whether or not #1192 does make any difference. I then also found that TypeScript does something similar for its watcher at https://github.com/microsoft/TypeScript/blob/1298f498f4cde7fa53cbf050ebfeefdf85c848ec/src/compiler/watchUtilities.ts#L42 , and that `ts.sys.fileExists` does not cache anything, so we need to do it ourselves.

Should help #1130 and #1139

I also found out during that that we are likely not properly removing Svelte snapshots when its file is deleted. I'll try this out later on.

Another possible speed-up I found was [this method in completions](https://github.com/sveltejs/language-tools/blob/master/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts#L269), according to the perf analysis some time is spent in that area in total, probably due to source mapping. We could speed that up in this case because the textEdit ranges are probably all the same, so we can create a cache there. Update: I was wrong, textEdit is rarely filled especially when it's about global completions. But I found that we can compute `path` once only because `pathToUrl` is not that fast either.

@jasonlyu123 thoughts?