### PR TITLE
Handle @const tag

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx/index.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/index.ts
@@ -12,6 +12,7 @@ import { handleBinding } from './nodes/binding';
 import { handleClassDirective } from './nodes/class-directive';
 import { handleComment } from './nodes/comment';
 import { handleComponent } from './nodes/component';
+import { handleConstTag } from './nodes/const';
 import { handleDebug } from './nodes/debug';
 import { handleEach } from './nodes/each';
 import { handleElement } from './nodes/element';
@@ -95,6 +96,9 @@ export function convertHtmlxToJsx(
                         break;
                     case 'RawMustacheTag':
                         handleRawHtml(htmlx, str, node);
+                        break;
+                    case 'ConstTag':
+                        handleConstTag(htmlx, str, node);
                         break;
                     case 'DebugTag':
                         handleDebug(htmlx, str, node);

--- a/packages/svelte2tsx/src/htmlxtojsx/nodes/const.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx/nodes/const.ts
@@ -1,0 +1,10 @@
+import MagicString from 'magic-string';
+import { BaseNode } from '../../interfaces';
+
+/**
+ * {@const ...}   --->   {const ...}
+ */
+export function handleConstTag(htmlx: string, str: MagicString, rawBlock: BaseNode): void {
+    const tokenStart = htmlx.indexOf('@const', rawBlock.start);
+    str.remove(tokenStart, tokenStart + '@'.length);
+}


### PR DESCRIPTION
This WIP PR adds support for the new `@const` tag to the language server and related tools.

[X] - Transform the @const tag in svelte2tsx
[ ] - Tests for svelte2tsx changes
[ ] - Add const to hover info in language server

Fixes #1330 