### PR TITLE
Expose svelte2tsx component documentation

### DIFF
--- a/packages/svelte2tsx/index.d.ts
+++ b/packages/svelte2tsx/index.d.ts
@@ -3,11 +3,24 @@ export interface SvelteCompiledToTsx {
     map: import("magic-string").SourceMap;
     exportedNames: IExportedNames;
     events: ComponentEvents;
+    componentDocumentation: string;
+    slots: Map<string, Map<string, string>>;
+    generics: {
+        definitions: string;
+        references: string;
+    };
 }
 
-export interface IExportedNames {
-    has(name: string): boolean;
-}
+export type IExportedNames = Map<
+    string,
+    {
+        isLet: boolean;
+        type?: string;
+        identifierText?: string;
+        required?: boolean;
+        doc?: string;
+    }
+>;
 
 export interface ComponentEvents {
     getAll(): { name: string; type: string; doc?: string }[];
@@ -51,16 +64,16 @@ export function svelte2tsx(
         /**
          * Takes effect when using the new 'ts' mode. Default 'svelteHTML'.
          * Tells svelte2tsx from which namespace some specific functions to use.
-         * 
+         *
          * Example: 'svelteHTML' -> svelteHTML.createElement<..>(..)
-         * 
+         *
          * A namespace needs to implement the following functions:
          * - `createElement(str: string, validAttributes: ..): Element`
          * - `mapElementTag<Key extends keyof YourElements>(str: Key): YourElements[Key]`
          */
         typingsNamespace?: string;
         /**
-         * The accessor option from svelte config. 
+         * The accessor option from svelte config.
          * Would be overridden by the same config in the svelte:option element if exist
          * see https://svelte.dev/docs#svelte_compile for more info
          */

--- a/packages/svelte2tsx/src/svelte2tsx/index.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/index.ts
@@ -451,7 +451,13 @@ declare function __sveltets_1_createSvelteComponentTyped<Props, Events, Slots>(
             code: str.toString(),
             map: str.generateMap({ hires: true, source: options?.filename }),
             exportedNames: exportedNames.getExportsMap(),
-            events: events.createAPI()
+            events: events.createAPI(),
+            componentDocumentation: componentDocumentation.getFormatted(),
+            slots,
+            generics: {
+                definition: generics.toDefinitionString(),
+                references: generics.toReferencesString()
+            }
         };
     }
 }


### PR DESCRIPTION
No currently available tool is able to generate **complete** component documentation from svelte file. There are many attempts listed here https://github.com/sveltejs/kit/issues/1979#issuecomment-1014259443. With this change it will be possible to access documentation of component and use `svelte2tsx` as a _docgen_ tool.