### PR TITLE
add basic types for svelte:component

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom" />
 
+type FalsyType = false | '' | 0 | null | undefined
+
 declare namespace svelteHTML {
 
   // Every namespace eligible for use needs to implement the following two functions
@@ -290,6 +292,7 @@ declare namespace svelteHTML {
     // Svelte specific
     sveltewindow: HTMLProps<Window> & SvelteWindowProps;
     sveltebody: HTMLProps<HTMLElement>;
+    sveltecomponent: { this: object | FalsyType, [name: string]: any };
     sveltefragment: { slot?: string; };
     svelteoptions: { [name: string]: any };
     sveltehead: { [name: string]: any };
@@ -1444,6 +1447,7 @@ declare namespace svelte.JSX {
       // Svelte specific
       sveltewindow: HTMLProps<Window> & SvelteWindowProps;
       sveltebody: HTMLProps<HTMLElement>;
+      sveltecomponent: { this: object | FalsyType, [name: string]: any };
       sveltefragment: { slot?: string; };
       svelteoptions: { [name: string]: any };
       sveltehead: { [name: string]: any };


### PR DESCRIPTION
This PR adds basic types for the `<svelte:component />` element

Currently you won't get a TypeScript error if you forget to set the `this` prop.
With this PR an error is shown if `this` is missing.

I could not find out what the type of a real SvelteComponent is so I just used the `object` type which represents the component as closest without adding an additional type.