### PR TITLE
(fix) svg attributes and casing

### DIFF
--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -141,7 +141,9 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
                     return false;
                 }
                 if (label[0] === '"' && label[label.length - 1] === '"') {
-                    if (htmlCompletions.has(label.slice(1, -1))) {
+                    // this will result in a wrong completion regardless, remove the quotes
+                    item.label = item.label.slice(1, -1);
+                    if (htmlCompletions.has(item.label)) {
                         // "aria-label" -> aria-label -> exists in html completions
                         return false;
                     }

--- a/packages/language-server/src/plugins/typescript/features/SemanticTokensProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/SemanticTokensProvider.ts
@@ -77,7 +77,7 @@ export class SemanticTokensProviderImpl implements SemanticTokensProvider {
                 continue;
             }
 
-            const [line, character, length, start] = originalPosition;
+            const [line, character, length] = originalPosition;
 
             // remove identifiers whose start and end mapped to the same location,
             // like the svelte2tsx inserted render function,

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
@@ -110,10 +110,7 @@ export function handleAttribute(
         addAttribute([[attr.value[0].start, attr.value[0].end]]);
         return;
     } else {
-        let name =
-            element instanceof Element && attr.value === true
-                ? transformAttributeCase(attr.name)
-                : attr.name;
+        let name = element instanceof Element ? transformAttributeCase(attr.name) : attr.name;
         // surround with quotes because dashes or other invalid property characters could be part of the name
         // Overwrite first char with "+char because TS will squiggle the whole "prop" including quotes when something is wrong
         if (name !== attr.name) {

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
@@ -110,7 +110,10 @@ export function handleAttribute(
         addAttribute([[attr.value[0].start, attr.value[0].end]]);
         return;
     } else {
-        let name = element instanceof Element ? transformAttributeCase(attr.name) : attr.name;
+        let name =
+            element instanceof Element && parent.type === 'Element'
+                ? transformAttributeCase(attr.name)
+                : attr.name;
         // surround with quotes because dashes or other invalid property characters could be part of the name
         // Overwrite first char with "+char because TS will squiggle the whole "prop" including quotes when something is wrong
         if (name !== attr.name) {

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -68,7 +68,10 @@ declare namespace svelteHTML {
   interface AriaAttributes extends svelte.JSX.AriaAttributes {}
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface HTMLAttributes<T extends EventTarget> extends svelte.JSX.HTMLAttributes<T> {
+  interface HTMLAttributes<T extends EventTarget> extends svelte.JSX.HTMLAttributes<T> {}
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface SVGAttributes<T extends EventTarget> extends svelte.JSX.SVGAttributes<T> {
     'xlink:actuate'?: string | undefined;
     'xlink:arcrole'?: string | undefined;
     'xlink:href'?: string | undefined;
@@ -82,9 +85,6 @@ declare namespace svelteHTML {
     'xmlns'?: string | undefined;
     'xmlns:xlink'?: string | undefined;
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface SVGAttributes<T extends EventTarget> extends svelte.JSX.SVGAttributes<T> {}
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface HTMLProps<T extends EventTarget> extends HTMLAttributes<T> {}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-element/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-element/expectedv2.js
@@ -1,3 +1,3 @@
  { svelteHTML.createElement("div", {"contenteditable":true,}); }
  { svelteHTML.createElement("div", { contentEditable,}); }
- { svelteHTML.createElement("div", { "contentEditable":contenteditable,}); }
+ { svelteHTML.createElement("div", { "contenteditable":contenteditable,}); }


### PR DESCRIPTION
- move "xml:.." attributes into svg attributes interface
- remove quotes from attribute completions
- lowercase attributes when they are case insensitive

#1352