### PR TITLE
(fix) no TS/JS completions in html text

### DIFF
--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -1,4 +1,6 @@
 import { RawSourceMap, SourceMapConsumer } from 'source-map';
+import { walk } from 'svelte/compiler';
+import { TemplateNode } from 'svelte/types/compiler/interfaces';
 import { svelte2tsx, IExportedNames } from 'svelte2tsx';
 import ts from 'typescript';
 import { Position, Range, TextDocumentContentChangeEvent } from 'vscode-languageserver';
@@ -15,6 +17,7 @@ import {
 } from '../../lib/documents';
 import { pathToUrl } from '../../utils';
 import { ConsumerDocumentMapper } from './DocumentMapper';
+import { SvelteNode } from './svelte-ast-utils';
 import {
     getScriptKindFromAttributes,
     getScriptKindFromFileName,
@@ -89,7 +92,7 @@ export namespace DocumentSnapshot {
      * @param options options that apply to the svelte document
      */
     export function fromDocument(document: Document, options: SvelteSnapshotOptions) {
-        const { tsxMap, text, exportedNames, parserError, nrPrependedLines, scriptKind } =
+        const { tsxMap, htmlAst, text, exportedNames, parserError, nrPrependedLines, scriptKind } =
             preprocessSvelteFile(document, options);
 
         return new SvelteDocumentSnapshot(
@@ -99,7 +102,8 @@ export namespace DocumentSnapshot {
             text,
             nrPrependedLines,
             exportedNames,
-            tsxMap
+            tsxMap,
+            htmlAst
         );
     }
 
@@ -156,6 +160,7 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
     let nrPrependedLines = 0;
     let text = document.getText();
     let exportedNames: IExportedNames = { has: () => false };
+    let htmlAst: TemplateNode | undefined;
 
     const scriptKind = [
         getScriptKindFromAttributes(document.scriptInfo?.attributes ?? {}),
@@ -185,6 +190,9 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
         text = tsx.code;
         tsxMap = tsx.map;
         exportedNames = tsx.exportedNames;
+        // We know it's there, it's not part of the public API so people don't start using it
+        htmlAst = (tsx as any).htmlAst;
+
         if (tsxMap) {
             tsxMap.sources = [document.uri];
 
@@ -218,6 +226,7 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
         tsxMap,
         text,
         exportedNames,
+        htmlAst,
         parserError,
         nrPrependedLines,
         scriptKind
@@ -239,7 +248,8 @@ export class SvelteDocumentSnapshot implements DocumentSnapshot {
         private readonly text: string,
         private readonly nrPrependedLines: number,
         private readonly exportedNames: IExportedNames,
-        private readonly tsxMap?: RawSourceMap
+        private readonly tsxMap?: RawSourceMap,
+        private readonly htmlAst?: TemplateNode
     ) {}
 
     get filePath() {
@@ -273,6 +283,38 @@ export class SvelteDocumentSnapshot implements DocumentSnapshot {
 
     hasProp(name: string): boolean {
         return this.exportedNames.has(name);
+    }
+
+    svelteNodeAt(postionOrOffset: number | Position): SvelteNode | null {
+        if (!this.htmlAst) {
+            return null;
+        }
+        const offset =
+            typeof postionOrOffset === 'number'
+                ? postionOrOffset
+                : this.parent.offsetAt(postionOrOffset);
+
+        let foundNode: SvelteNode | null = null;
+        walk(this.htmlAst, {
+            enter: function (node) {
+                // In case the offset is at a point where a node ends and a new one begins,
+                // the node where the code ends is used. If this introduces problems, introduce
+                // an affinity parameter to prefer the node where it ends/starts.
+                if ((node as SvelteNode).start > offset || (node as SvelteNode).end < offset) {
+                    this.skip();
+                    return;
+                }
+                let parent = foundNode;
+                // Spread so the "parent" property isn't added to the original ast,
+                // causing an infinite loop
+                foundNode = { ...node } as SvelteNode;
+                if (parent) {
+                    foundNode.parent = parent;
+                }
+            }
+        });
+
+        return foundNode;
     }
 
     async getFragment() {

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -296,7 +296,7 @@ export class SvelteDocumentSnapshot implements DocumentSnapshot {
 
         let foundNode: SvelteNode | null = null;
         walk(this.htmlAst, {
-            enter: function (node) {
+            enter(node) {
                 // In case the offset is at a point where a node ends and a new one begins,
                 // the node where the code ends is used. If this introduces problems, introduce
                 // an affinity parameter to prefer the node where it ends/starts.
@@ -304,7 +304,7 @@ export class SvelteDocumentSnapshot implements DocumentSnapshot {
                     this.skip();
                     return;
                 }
-                let parent = foundNode;
+                const parent = foundNode;
                 // Spread so the "parent" property isn't added to the original ast,
                 // causing an infinite loop
                 foundNode = { ...node } as SvelteNode;

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -72,7 +72,6 @@ import {
     convertToLocationRange,
     getScriptKindFromFileName,
     isInScript,
-    rangeToTextSpan,
     symbolKindFromString
 } from './utils';
 
@@ -178,15 +177,12 @@ export class TypeScriptPlugin
         collectSymbols(navTree, undefined, (symbol) => symbols.push(symbol));
 
         const topContainerName = symbols[0].name;
-        const sourceFile = lang.getProgram()!.getSourceFile(tsDoc.filePath)!;
         const result: SymbolInformation[] = [];
 
         for (let symbol of symbols.slice(1)) {
             if (symbol.containerName === topContainerName) {
                 symbol.containerName = 'script';
             }
-
-            const generatedRange = symbol.location.range;
 
             symbol = mapSymbolInformationToOriginal(fragment, symbol);
 

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -64,16 +64,10 @@ import { SemanticTokensProviderImpl } from './features/SemanticTokensProvider';
 import { SignatureHelpProviderImpl } from './features/SignatureHelpProvider';
 import { TypeDefinitionProviderImpl } from './features/TypeDefinitionProvider';
 import { UpdateImportsProviderImpl } from './features/UpdateImportsProvider';
-import {
-    findNodeAtSpan,
-    isComponentProp,
-    isHTMLAttributeName,
-    isHTMLAttributeShorthand,
-    isNoTextSpanInGeneratedCode,
-    SnapshotFragmentMap
-} from './features/utils';
+import { isNoTextSpanInGeneratedCode, SnapshotFragmentMap } from './features/utils';
 import { LSAndTSDocResolver } from './LSAndTSDocResolver';
 import { ignoredBuildDirectories } from './SnapshotManager';
+import { isAttributeName, isAttributeShorthand, isEventHandler } from './svelte-ast-utils';
 import {
     convertToLocationRange,
     getScriptKindFromFileName,
@@ -217,17 +211,10 @@ export class TypeScriptPlugin
                     // This is the "props" of a generated component constructor
                     continue;
                 }
-                const node = findNodeAtSpan(
-                    sourceFile,
-                    rangeToTextSpan(generatedRange, fragment),
-                    (node): node is ts.ShorthandPropertyAssignment | ts.PropertyAssignment =>
-                        ts.isPropertyAssignment(node) || ts.isShorthandPropertyAssignment(node)
-                );
+                const node = tsDoc.svelteNodeAt(symbol.location.range.start);
                 if (
-                    node &&
-                    (isComponentProp(node.name) ||
-                        isHTMLAttributeName(node.name) ||
-                        isHTMLAttributeShorthand(node.name))
+                    (node && (isAttributeName(node) || isAttributeShorthand(node))) ||
+                    isEventHandler(node)
                 ) {
                     // This is a html or component property, they are not treated as a new symbol
                     // in JSX and so we do the same for the new transformation.

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -146,7 +146,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             // Cursor is somewhere in regular HTML text
             (svelteNode?.type === 'Text' &&
                 ['Element', 'InlineComponent', 'Fragment', 'SlotTemplate'].includes(
-                    svelteNode.parent?.type!
+                    svelteNode.parent?.type as any
                 )) ||
             // Cursor is at <div>|</div> in which case there's no TextNode inbetween
             document.getText().substring(originalOffset - 1, originalOffset + 2) === '></'

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -17,11 +17,11 @@ import {
     findNodeAtSpan,
     isReactiveStatement,
     isInReactiveStatement,
-    gatherIdentifiers,
-    isHTMLAttributeName
+    gatherIdentifiers
 } from './utils';
 import { not, flatten, passMap, regexIndexOf, swapRangeStartEndIfNecessary } from '../../../utils';
 import { LSConfigManager } from '../../../ls-config';
+import { isAttributeName, isEventHandler } from '../svelte-ast-utils';
 
 enum DiagnosticCode {
     MODIFIERS_CANNOT_APPEAR_HERE = 1184, // "Modifiers cannot appear here."
@@ -84,8 +84,7 @@ export class DiagnosticsProviderImpl implements DiagnosticsProvider {
         ];
         diagnostics = diagnostics
             .filter(isNotGenerated(tsDoc.getText(0, tsDoc.getLength())))
-            .filter(not(isUnusedReactiveStatementLabel))
-            .filter(isNoFalsePositive1(this.configManager.getConfig().svelte.useNewTransformation));
+            .filter(not(isUnusedReactiveStatementLabel));
         diagnostics = resolveNoopsInReactiveStatements(lang, diagnostics);
 
         return diagnostics
@@ -105,7 +104,13 @@ export class DiagnosticsProviderImpl implements DiagnosticsProvider {
                 )
             )
             .filter(hasNoNegativeLines)
-            .filter(isNoFalsePositive2(document, tsDoc))
+            .filter(
+                isNoFalsePositive(
+                    this.configManager.getConfig().svelte.useNewTransformation,
+                    document,
+                    tsDoc
+                )
+            )
             .map(enhanceIfNecessary)
             .map(swapDiagRangeStartEndIfNecessary);
     }
@@ -184,26 +189,6 @@ function copyDiagnosticAndChangeNode(diagnostic: ts.Diagnostic) {
     });
 }
 
-function isNoFalsePositive1(useNewTransformation: boolean) {
-    if (!useNewTransformation) {
-        return () => true;
-    }
-
-    return (diagnostic: ts.Diagnostic) => {
-        if (
-            ![
-                DiagnosticCode.MULTIPLE_PROPS_SAME_NAME,
-                DiagnosticCode.DUPLICATE_IDENTIFIER
-            ].includes(diagnostic.code)
-        ) {
-            return true;
-        }
-
-        const node = findDiagnosticNode(diagnostic);
-        return !node || !isHTMLAttributeName(node);
-    };
-}
-
 /**
  * In some rare cases mapping of diagnostics does not work and produces negative lines.
  * We filter out these diagnostics with negative lines because else the LSP
@@ -213,11 +198,27 @@ function hasNoNegativeLines(diagnostic: Diagnostic): boolean {
     return diagnostic.range.start.line >= 0 && diagnostic.range.end.line >= 0;
 }
 
-function isNoFalsePositive2(document: Document, tsDoc: SvelteDocumentSnapshot) {
+function isNoFalsePositive(
+    useNewTransformation: boolean,
+    document: Document,
+    tsDoc: SvelteDocumentSnapshot
+) {
     const text = document.getText();
     const usesPug = document.getLanguageAttribute('template') === 'pug';
 
     return (diagnostic: Diagnostic) => {
+        if (
+            useNewTransformation &&
+            [DiagnosticCode.MULTIPLE_PROPS_SAME_NAME, DiagnosticCode.DUPLICATE_IDENTIFIER].includes(
+                diagnostic.code as number
+            )
+        ) {
+            const node = tsDoc.svelteNodeAt(diagnostic.range.start);
+            if (isAttributeName(node, 'Element') || isEventHandler(node, 'Element')) {
+                return false;
+            }
+        }
+
         return (
             isNoJsxCannotHaveMultipleAttrsError(diagnostic) &&
             isNoUsedBeforeAssigned(diagnostic, text, tsDoc) &&

--- a/packages/language-server/src/plugins/typescript/features/RenameProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/RenameProvider.ts
@@ -23,10 +23,10 @@ import {
     isAfterSvelte2TsxPropsReturn,
     isNoTextSpanInGeneratedCode,
     SnapshotFragmentMap,
-    findContainingNode,
-    isHTMLAttributeName
+    findContainingNode
 } from './utils';
 import { LSConfigManager } from '../../../ls-config';
+import { isAttributeName, isEventHandler } from '../svelte-ast-utils';
 
 export class RenameProviderImpl implements RenameProvider {
     constructor(
@@ -165,14 +165,12 @@ export class RenameProviderImpl implements RenameProvider {
             return null;
         }
 
+        const svelteNode = tsDoc.svelteNodeAt(originalPosition);
         if (
             this.configManager.getConfig().svelte.useNewTransformation &&
             (isInHTMLTagRange(doc.html, doc.offsetAt(originalPosition)) ||
-                !!findContainingNode(
-                    lang.getProgram()!.getSourceFile(tsDoc.filePath)!,
-                    { start: generatedOffset, length: 0 },
-                    isHTMLAttributeName
-                ))
+                isAttributeName(svelteNode, 'Element') ||
+                isEventHandler(svelteNode, 'Element'))
         ) {
             return null;
         }

--- a/packages/language-server/src/plugins/typescript/features/utils.ts
+++ b/packages/language-server/src/plugins/typescript/features/utils.ts
@@ -79,11 +79,13 @@ export function isComponentAtPosition(
  * Checks if this a section that should be completely ignored
  * because it's purely generated.
  */
-export function isInGeneratedCode(text: string, start: number, end: number) {
+export function isInGeneratedCode(text: string, start: number, end: number = start) {
     const lastStart = text.lastIndexOf('/*Ωignore_startΩ*/', start);
     const lastEnd = text.lastIndexOf('/*Ωignore_endΩ*/', start);
     const nextEnd = text.indexOf('/*Ωignore_endΩ*/', end);
-    return lastStart > lastEnd && lastStart < nextEnd;
+    // if lastEnd === nextEnd, this means that the str was found at the index
+    // up to which is searched for it
+    return (lastStart > lastEnd || lastEnd === nextEnd) && lastStart < nextEnd;
 }
 
 /**
@@ -277,54 +279,3 @@ function gatherDescendants<T extends ts.Node>(
 }
 
 export const gatherIdentifiers = (node: ts.Node) => gatherDescendants(node, ts.isIdentifier);
-
-/**
- * Returns when given node represents an HTML Attribute. Example:
- * The `class` in `<div class=".."`.
- * Transformed code is `svelte.createElement("div", {"class": ".."})`.
- * Note: This method returns `false` for shorthands like `svelte.createElement("div", {shorthand})`.
- * Only applies when `useNewTransformation` is `true`!
- */
-export const isHTMLAttributeName = nodeAndParentsSatisfyRespectivePredicates(
-    (node) => ts.isPropertyAssignment(node.parent) && node.parent.name === node,
-    Boolean,
-    ts.isObjectLiteralExpression,
-    (parent) =>
-        ts.isCallExpression(parent) &&
-        ts.isPropertyAccessExpression(parent.expression) &&
-        ts.isIdentifier(parent.expression.name) &&
-        parent.expression.name.text === 'createElement'
-);
-
-/**
- * Returns when given node represents an HTML Attribute shorthand. Example:
- * The `{foo}` in `<div {foo}`.
- * Transformed code is `svelte.createElement("div", {foo})`.
- * Only applies when `useNewTransformation` is `true`!
- */
-export const isHTMLAttributeShorthand = nodeAndParentsSatisfyRespectivePredicates(
-    ts.isIdentifier,
-    ts.isShorthandPropertyAssignment,
-    ts.isObjectLiteralExpression,
-    (parent) =>
-        ts.isCallExpression(parent) &&
-        ts.isPropertyAccessExpression(parent.expression) &&
-        ts.isIdentifier(parent.expression.name) &&
-        parent.expression.name.text === 'createElement'
-);
-
-/**
- * Returns `true` if node is a component prop (for both the property name and shorthands).
- * Example: the `foo` in `new Component({target:.., props: {foo: bar}})`
- */
-export const isComponentProp = nodeAndParentsSatisfyRespectivePredicates(
-    (node) =>
-        ts.isShorthandPropertyAssignment(node.parent) ||
-        (ts.isPropertyAssignment(node.parent) && node.parent.name === node),
-    Boolean,
-    ts.isObjectLiteralExpression,
-    (node) =>
-        ts.isPropertyAssignment(node) && ts.isIdentifier(node.name) && node.name.text === 'props',
-    ts.isObjectLiteralExpression,
-    ts.isNewExpression
-);

--- a/packages/language-server/src/plugins/typescript/svelte-ast-utils.ts
+++ b/packages/language-server/src/plugins/typescript/svelte-ast-utils.ts
@@ -1,0 +1,64 @@
+export interface SvelteNode {
+    start: number;
+    end: number;
+    type: string;
+    parent?: SvelteNode;
+}
+
+/**
+ * Returns when given node represents an HTML Attribute.
+ * Example: The `class` in `<div class=".."`.
+ * Note: This method returns `false` for shorthands like `<div {foo}`.
+ */
+export function isAttributeName(
+    node: SvelteNode | null | undefined,
+    only?: 'Element' | 'InlineComponent'
+): boolean {
+    return !!node && node.type === 'Attribute' && (!only || node.parent?.type === only);
+}
+
+/**
+ * Returns when given node represents an HTML element.
+ * Example: The `div` in `<div class=".."`.
+ * Note: This method returns `false` for shorthands like `<div {foo}`.
+ */
+export function isHTMLElement(
+    node: SvelteNode | null | undefined,
+    only?: 'Element' | 'InlineComponent'
+): boolean {
+    return !!node && node.type === 'Attribute' && (!only || node.parent?.type === only);
+}
+
+/**
+ * Returns when given node represents an HTML Attribute shorthand or is inside one.
+ * Example: The `{foo}` in `<div {foo}`
+ */
+export function isAttributeShorthand(
+    node: SvelteNode | null | undefined,
+    only?: 'Element' | 'InlineComponent'
+): boolean {
+    if (!node) {
+        return false;
+    }
+    do {
+        // We could get the expression, or the shorthand, or the attribute
+        // Be pragmatic and just go upwards until we can't anymore
+        if (isAttributeName(node, only)) {
+            console.log('yay');
+            return true;
+        }
+        node = node.parent!;
+    } while (node);
+    return false;
+}
+
+/**
+ * Returns when given node represents an HTML Attribute shorthand or is inside one.
+ * Example: The `on:click={foo}` in `<div on:click={foo}`
+ */
+export function isEventHandler(
+    node: SvelteNode | null | undefined,
+    only?: 'Element' | 'InlineComponent'
+) {
+    return !!node && node.type === 'EventHandler' && (!only || node.parent?.type === only);
+}

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1233,6 +1233,34 @@ function test(useNewTransformation: boolean) {
             );
         });
 
+        it('shouldnt do completions in text', async () => {
+            const { completionProvider, document } = setup('importcompletions-text.svelte');
+
+            await expectNoCompletions(4, 1);
+            await expectNoCompletions(5, 5);
+            await expectNoCompletions(5, 6);
+            await expectNoCompletions(6, 0);
+            await expectNoCompletions(6, 1);
+            await expectNoCompletions(7, 5);
+            await expectNoCompletions(8, 7);
+            await expectNoCompletions(8, 8);
+            await expectNoCompletions(9, 0);
+            await expectNoCompletions(9, 1);
+            await expectNoCompletions(10, 6);
+
+            async function expectNoCompletions(line: number, char: number) {
+                const completions = await completionProvider.getCompletions(
+                    document,
+                    Position.create(line, char)
+                );
+                assert.strictEqual(
+                    completions,
+                    null,
+                    `expected no completions for ${line},${char}`
+                );
+            }
+        });
+
         // Hacky, but it works. Needed due to testing both new and old transformation
         after(() => {
             __resetCache();

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/importcompletions-text.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/importcompletions-text.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  let abc = "";
+</script>
+
+a
+<div>a
+a</div>
+<div></div>
+<Comp>a
+a</Comp>
+<Comp></Comp>

--- a/packages/svelte2tsx/src/svelte2tsx/index.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/index.ts
@@ -22,8 +22,13 @@ import { ScopeStack } from './utils/Scope';
 import { Generics } from './nodes/Generics';
 import { addComponentExport } from './addComponentExport';
 import { createRenderFunction } from './createRenderFunction';
+import { TemplateNode } from 'svelte/types/compiler/interfaces';
 
 type TemplateProcessResult = {
+    /**
+     * The HTML part of the Svelte AST.
+     */
+    htmlAst: TemplateNode;
     uses$$props: boolean;
     uses$$restProps: boolean;
     uses$$slots: boolean;
@@ -280,6 +285,7 @@ function processSvelteTemplate(
     const resolvedStores = stores.resolveStores();
 
     return {
+        htmlAst: htmlxAst,
         moduleScriptTag,
         scriptTag,
         slots: slotHandler.getSlotDef(),
@@ -315,6 +321,7 @@ export function svelte2tsx(
     const str = new MagicString(svelte);
     // process the htmlx as a svelte template
     let {
+        htmlAst,
         moduleScriptTag,
         scriptTag,
         slots,
@@ -451,7 +458,9 @@ declare function __sveltets_1_createSvelteComponentTyped<Props, Events, Slots>(
             code: str.toString(),
             map: str.generateMap({ hires: true, source: options?.filename }),
             exportedNames: exportedNames.getExportsMap(),
-            events: events.createAPI()
+            events: events.createAPI(),
+            // not part of the public API so people don't start using it
+            htmlAst
         };
     }
 }


### PR DESCRIPTION
#1352
This makes use of the Svelte AST that is now returned from svelte2tsx (privately, do not use this elsewhere!) by checking if the AST node at the given position is of type text. This also helped refactor some other checks into something less hacky

@jasonlyu123 what do think of this approach, using the Svelte AST more in the language server?