### PR TITLE
(fix) no error for component typedef with event

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expected.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expected.json
@@ -1,8 +1,8 @@
 [
     {
         "range": {
-            "start": { "line": 13, "character": 1 },
-            "end": { "line": 13, "character": 11 }
+            "start": { "line": 25, "character": 1 },
+            "end": { "line": 25, "character": 11 }
         },
         "severity": 1,
         "source": "ts",

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expectedv2.json
@@ -1,12 +1,12 @@
 [
     {
         "range": {
-            "start": { "line": 13, "character": 1 },
-            "end": { "line": 13, "character": 11 }
+            "start": { "line": 25, "character": 1 },
+            "end": { "line": 25, "character": 11 }
         },
         "severity": 1,
         "source": "ts",
-        "message": "Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}\n\nUnderlying error:\nArgument of type 'typeof DoesntWork' is not assignable to parameter of type 'new (args: { target: any; props?: any; }) => Svelte2TsxComponent<any, any, any>'.\n  Type 'DoesntWork' is missing the following properties from type 'Svelte2TsxComponent<any, any, any>': $$prop_def, $$events_def, $$slot_def, $on, and 5 more.",
+        "message": "Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}\n\nUnderlying error:\nArgument of type 'typeof DoesntWork' is not assignable to parameter of type 'new (args: { target: any; props?: any; }) => Svelte2TsxComponent<any, {}, any>'.\n  Type 'DoesntWork' is missing the following properties from type 'Svelte2TsxComponent<any, {}, any>': $$prop_def, $$events_def, $$slot_def, $on, and 5 more.",
         "code": 2345,
         "tags": []
     }

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/input.svelte
@@ -3,12 +3,24 @@
     import Imported from './imported.svelte';
 
     class Works extends SvelteComponentTyped<any, any, any> {}
+    class Works2 extends SvelteComponentTyped<
+        { hi: string },
+        { click: MouseEvent },
+        {
+            default: {
+                foo: string;
+            };
+        }
+    > {}
     class DoesntWork {}
 </script>
 
 <!-- valid -->
 <Works />
 <Imported />
+<Works2 hi="hi" on:click={e => console.log(e.movementX)} let:foo>
+    {foo.toLocaleLowerCase()}
+</Works2>
 
 <!-- invalid -->
 <DoesntWork />

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -256,6 +256,6 @@ declare function __sveltets_2_ensureTransition(transitionCall: __sveltets_2_Svel
 declare function __sveltets_2_ensureType<T>(type: AConstructorTypeOf<T>, el: T): {};
 declare function __sveltets_2_ensureType<T1, T2>(type1: AConstructorTypeOf<T1>, type2: AConstructorTypeOf<T2>, el: T1 | T2): {};
 
-declare function __sveltets_2_ensureComponent<T extends new (args: {target: any, props?: any}) => Svelte2TsxComponent<any, any, any>>(type: T): T extends never ? Svelte2TsxComponent<any, any, any> : T;
+declare function __sveltets_2_ensureComponent<T extends new (args: {target: any, props?: any}) => Svelte2TsxComponent<any, {}, any>>(type: T): T extends never ? Svelte2TsxComponent<any, any, any> : T;
 
 declare function __sveltets_2_ensureArray<T extends ArrayLike<unknown>>(array: T): T extends ArrayLike<infer U> ? U[] : any[];


### PR DESCRIPTION
For the new transformation. Currently, it would show an error with a component having events in the typedef. For example: 
```ts
class Component extends SvelteComponentTyped<{}, { click: MouseEvent }, {}>{}
```