### PR TITLE
(fix) better ensureComponent check

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -271,17 +271,18 @@ function enhanceIfNecessary(diagnostic: Diagnostic): Diagnostic {
     if (
         diagnostic.code === DiagnosticCode.CANNOT_BE_USED_AS_JSX_COMPONENT ||
         (diagnostic.code === DiagnosticCode.TYPE_X_NOT_ASSIGNABLE_TO_TYPE_Y &&
-            diagnostic.message.includes('Svelte2TsxComponent'))
+            diagnostic.message.includes('ConstructorOfATypedSvelteComponent'))
     ) {
         return {
             ...diagnostic,
             message:
-                'Type definitions are missing for this Svelte Component. ' +
+                diagnostic.message +
+                '\n\nPossible causes:\n' +
+                '- You use the instance type of a component where you should use the constructor type\n' +
+                '- Type definitions are missing for this Svelte Component. ' +
                 'If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n' +
                 '  import type { SvelteComponentTyped } from "svelte";\n' +
-                '  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}\n\n' +
-                'Underlying error:\n' +
-                diagnostic.message
+                '  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}'
         };
     }
 

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expected.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expected.json
@@ -1,13 +1,57 @@
 [
     {
         "range": {
-            "start": { "line": 25, "character": 1 },
-            "end": { "line": 25, "character": 11 }
+            "start": { "line": 36, "character": 1 },
+            "end": { "line": 36, "character": 11 }
         },
         "severity": 1,
         "source": "ts",
-        "message": "Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}\n\nUnderlying error:\n'DoesntWork' cannot be used as a JSX component.\n  Its instance type 'DoesntWork' is not a valid JSX element.\n    Property '$$prop_def' is missing in type 'DoesntWork' but required in type 'ElementClass'.",
+        "message": "'DoesntWork' cannot be used as a JSX component.\n  Its instance type 'DoesntWork' is not a valid JSX element.\n    Property '$$prop_def' is missing in type 'DoesntWork' but required in type 'ElementClass'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
         "code": 2786,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 40, "character": 0 },
+            "end": { "line": 40, "character": 49 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Element does not support attributes because type definitions are missing for this Svelte Component or element cannot be used as such.\n\nUnderlying error:\nJSX element class does not support attributes because it does not have a '$$prop_def' property.",
+        "code": 2607,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 40, "character": 1 },
+            "end": { "line": 40, "character": 11 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "'DoesntWork' cannot be used as a JSX component.\n  Its instance type 'DoesntWork' is not a valid JSX element.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
+        "code": 2786,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 40, "character": 48 },
+            "end": { "line": 40, "character": 48 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Property '$$slot_def' does not exist on type 'DoesntWork'.",
+        "code": 2339,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 40, "character": 24 },
+            "end": { "line": 42, "character": 12 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Property '$on' does not exist on type 'DoesntWork'.",
+        "code": 2339,
         "tags": []
     }
 ]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expectedv2.json
@@ -1,12 +1,45 @@
 [
     {
         "range": {
-            "start": { "line": 25, "character": 1 },
-            "end": { "line": 25, "character": 11 }
+            "start": { "line": 36, "character": 1 },
+            "end": { "line": 36, "character": 11 }
         },
         "severity": 1,
         "source": "ts",
-        "message": "Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}\n\nUnderlying error:\nArgument of type 'typeof DoesntWork' is not assignable to parameter of type 'new (args: { target: any; props?: any; }) => Svelte2TsxComponent<any, {}, any>'.\n  Type 'DoesntWork' is missing the following properties from type 'Svelte2TsxComponent<any, {}, any>': $$prop_def, $$events_def, $$slot_def, $on, and 5 more.",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n  Type 'DoesntWork' is missing the following properties from type 'ATypedSvelteComponent': $$prop_def, $$events_def, $$slot_def, $on\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
+        "code": 2345,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 37, "character": 24 },
+            "end": { "line": 37, "character": 34 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
+        "code": 2345,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 40, "character": 1 },
+            "end": { "line": 40, "character": 11 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
+        "code": 2345,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 43, "character": 24 },
+            "end": { "line": 43, "character": 34 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
         "code": 2345,
         "tags": []
     }

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/input.svelte
@@ -12,6 +12,11 @@
             };
         }
     > {}
+    class Works3 extends SvelteComponentTyped<
+        any,
+        { [evt: string]: CustomEvent<any> },
+        never
+    > {}
     class DoesntWork {}
 </script>
 
@@ -21,6 +26,21 @@
 <Works2 hi="hi" on:click={e => console.log(e.movementX)} let:foo>
     {foo.toLocaleLowerCase()}
 </Works2>
+<Works3 />
+<svelte:component this={Works} />
+<svelte:component this={Works2}  hi="hi" on:click={e => console.log(e.movementX)} let:foo>
+    {foo.toLocaleLowerCase()}
+</svelte:component>
+<svelte:component this={Works3} />
 
 <!-- invalid -->
 <DoesntWork />
+<svelte:component this={DoesntWork} />
+
+<!-- invalid, no additional errors for new transformation (everything else is any) -->
+<DoesntWork foo="bar" on:click={() => ''} let:etc>
+    {etc}
+</DoesntWork>
+<svelte:component this={DoesntWork} foo="bar" on:click={() => ''} let:etc>
+    {etc}
+</svelte:component>

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -50,7 +50,7 @@
         }
     },
     "contributes": {
-        "typescriptServerPlugins-disabled": [
+        "typescriptServerPlugins": [
             {
                 "name": "typescript-svelte-plugin",
                 "enableForWorkspaceTypeScriptVersions": true

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -50,7 +50,7 @@
         }
     },
     "contributes": {
-        "typescriptServerPlugins": [
+        "typescriptServerPlugins-disabled": [
             {
                 "name": "typescript-svelte-plugin",
                 "enableForWorkspaceTypeScriptVersions": true

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -256,6 +256,39 @@ declare function __sveltets_2_ensureTransition(transitionCall: __sveltets_2_Svel
 declare function __sveltets_2_ensureType<T>(type: AConstructorTypeOf<T>, el: T): {};
 declare function __sveltets_2_ensureType<T1, T2>(type1: AConstructorTypeOf<T1>, type2: AConstructorTypeOf<T2>, el: T1 | T2): {};
 
-declare function __sveltets_2_ensureComponent<T extends new (args: {target: any, props?: any}) => Svelte2TsxComponent<any, {}, any>>(type: T): T extends never ? Svelte2TsxComponent<any, any, any> : T;
+// The following is necessary because there are two clashing errors that can't be solved at the same time
+// when using Svelte2TsxComponent, more precisely the event typings in
+// __sveltets_2_ensureComponent<T extends new (..) => Svelte2TsxComponent<any,||any||<-this,any>>(type: T): T;
+// If we type it as "any", we have an error when using sth like {a: CustomEvent<any>}
+// If we type it as "{}", we have an error when using sth like {[evt: string]: CustomEvent<any>}
+// If we type it as "unknown", we get all kinds of follow up errors which we want to avoid
+// Therefore introduce two more base classes just for this case.
+/**
+ * Ambient type only used for intellisense, DO NOT USE IN YOUR PROJECT
+ */
+declare type ATypedSvelteComponent = {
+    /**
+     * @internal This is for type checking capabilities only
+     * and does not exist at runtime. Don't use this property.
+     */
+    $$prop_def: any;
+    /**
+     * @internal This is for type checking capabilities only
+     * and does not exist at runtime. Don't use this property.
+     */
+    $$events_def: any;
+    /**
+     * @internal This is for type checking capabilities only
+     * and does not exist at runtime. Don't use this property.
+     */
+    $$slot_def: any;
+
+    $on(event: string, handler: (e: any) => any): () => void;
+}
+/**
+ * Ambient type only used for intellisense, DO NOT USE IN YOUR PROJECT
+ */
+declare type ConstructorOfATypedSvelteComponent = new (args: {target: any, props?: any}) => ATypedSvelteComponent
+declare function __sveltets_2_ensureComponent<T extends ConstructorOfATypedSvelteComponent>(type: T): T;
 
 declare function __sveltets_2_ensureArray<T extends ArrayLike<unknown>>(array: T): T extends ArrayLike<infer U> ? U[] : any[];


### PR DESCRIPTION
#1352

@jasonlyu123 I wasn't able to come up with a better way to solve both "events" cases described in the shims file. What do you think about the way this is handled now? What I like about it is that there's now a more descriptive error message for the new transformation because it prints out the type in the message.