### PR TITLE
(fix) $store++/$store-- return type

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/nodes/Stores.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/Stores.ts
@@ -49,7 +49,7 @@ export function handleStore(node: Node, parent: Node, str: MagicString): void {
             str.overwrite(
                 parent.start,
                 parent.end,
-                `${storename}.set( $${storename} ${simpleOperator} 1)`
+                `(${storename}.set( $${storename} ${simpleOperator} 1), $${storename})`
             );
         } else {
             console.warn(

--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -152,7 +152,7 @@ export function processInstanceScriptContent(
                 str.overwrite(
                     parent.getStart() + astOffset,
                     parent.end + astOffset,
-                    `${storename}.set( $${storename} ${simpleOperator} 1)`
+                    `(${storename}.set( $${storename} ${simpleOperator} 1), $${storename})`
                 );
                 return;
             } else {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
@@ -5,14 +5,14 @@ function render() {
 
   
   const count = writable(0)/*Ωignore_startΩ*/;let $count = __sveltets_1_store_get(count);/*Ωignore_endΩ*/;
-  const handler1 = () => count.set( $count + 1)
-  const handler2 = () => count.set( $count - 1)
+  const handler1 = () => (count.set( $count + 1), $count)
+  const handler2 = () => (count.set( $count - 1), $count)
 ;
 () => (<>
 
-<button onclick={() => count.set( $count + 1)}>add</button>
-<button onclick={() => count.set( $count - 1)}>subtract</button>
-<button onclick={() => count.set( $count + 1)}>add</button></>);
+<button onclick={() => (count.set( $count + 1), $count)}>add</button>
+<button onclick={() => (count.set( $count - 1), $count)}>subtract</button>
+<button onclick={() => (count.set( $count + 1), $count)}>add</button></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expectedv2.ts
@@ -5,14 +5,14 @@ function render() {
 
   
   const count = writable(0)/*Ωignore_startΩ*/;let $count = __sveltets_1_store_get(count);/*Ωignore_endΩ*/;
-  const handler1 = () => count.set( $count + 1)
-  const handler2 = () => count.set( $count - 1)
+  const handler1 = () => (count.set( $count + 1), $count)
+  const handler2 = () => (count.set( $count - 1), $count)
 ;
 async () => {
 
- { svelteHTML.createElement("button", {  "onclick":() => count.set( $count + 1),});  }
- { svelteHTML.createElement("button", {  "onclick":() => count.set( $count - 1),});  }
- { svelteHTML.createElement("button", {  "onclick":() => count.set( $count + 1),});  }};
+ { svelteHTML.createElement("button", {  "onclick":() => (count.set( $count + 1), $count),});  }
+ { svelteHTML.createElement("button", {  "onclick":() => (count.set( $count - 1), $count),});  }
+ { svelteHTML.createElement("button", {  "onclick":() => (count.set( $count + 1), $count),});  }};
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {


### PR DESCRIPTION
#1382

This feels like a safe change, but paranoid me feels like this syntax could maybe clash in some situations with other code? I didn't come up with a situation where that's actually true, though - @jasonlyu123 can you think of a situation where the resulting code might be syntactically invalid?