### PR TITLE
(feat) improve Ts plugin enable config

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -50,7 +50,7 @@
         }
     },
     "contributes": {
-        "typescriptServerPlugins-disabled": [
+        "typescriptServerPlugins": [
             {
                 "name": "typescript-svelte-plugin",
                 "enableForWorkspaceTypeScriptVersions": true

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -41,7 +41,9 @@
     },
     "activationEvents": [
         "onLanguage:svelte",
-        "onCommand:svelte.restartLanguageServer"
+        "onCommand:svelte.restartLanguageServer",
+        "onLanguage:javascript",
+        "onLanguage:typescript"
     ],
     "capabilities": {
         "untrustedWorkspaces": {

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -37,6 +37,9 @@ namespace TagCloseRequest {
 }
 
 export function activate(context: ExtensionContext) {
+    // The extension is activated on TS/JS/Svelte files because else it might be too late to configure the TS plugin:
+    // If we only activate on Svelte file and the user opens a TS file first, the configuration command is issued too late.
+    // We wait until there's a Svelte file open and only then start the actual language client.
     const tsPlugin = new TsPlugin(context);
     let lsApi: { getLS(): LanguageClient } | undefined;
 

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -37,10 +37,12 @@ namespace TagCloseRequest {
 }
 
 export function activate(context: ExtensionContext) {
+    const tsPlugin = new TsPlugin(context);
     let lsApi: { getLS(): LanguageClient } | undefined;
 
     if (workspace.textDocuments.some((doc) => doc.languageId === 'svelte')) {
         lsApi = activateSvelteLanguageServer(context);
+        tsPlugin.askToEnable();
     } else {
         const onTextDocumentListener = workspace.onDidOpenTextDocument((doc) => {
             if (doc.languageId === 'svelte') {
@@ -51,12 +53,6 @@ export function activate(context: ExtensionContext) {
         });
 
         context.subscriptions.push(onTextDocumentListener);
-    }
-
-    const tsPlugin = new TsPlugin(context);
-
-    if (lsApi) {
-        tsPlugin.askToEnable();
     }
 
     // This API is considered private and only exposed for experimenting.

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -45,6 +45,7 @@ export function activate(context: ExtensionContext) {
         const onTextDocumentListener = workspace.onDidOpenTextDocument((doc) => {
             if (doc.languageId === 'svelte') {
                 lsApi = activateSvelteLanguageServer(context);
+                tsPlugin.askToEnable();
                 onTextDocumentListener.dispose();
             }
         });
@@ -52,7 +53,11 @@ export function activate(context: ExtensionContext) {
         context.subscriptions.push(onTextDocumentListener);
     }
 
-    TsPlugin.create(context);
+    const tsPlugin = new TsPlugin(context);
+
+    if (lsApi) {
+        tsPlugin.askToEnable();
+    }
 
     // This API is considered private and only exposed for experimenting.
     // Interface may change at any time. Use at your own risk!

--- a/packages/svelte-vscode/src/tsplugin.ts
+++ b/packages/svelte-vscode/src/tsplugin.ts
@@ -1,5 +1,3 @@
-// import { readFileSync, writeFileSync } from 'fs';
-// import { join } from 'path';
 import { commands, ExtensionContext, extensions, window, workspace } from 'vscode';
 
 export class TsPlugin {
@@ -31,53 +29,14 @@ export class TsPlugin {
             return;
         }
 
+        // This somewhat semi-public command configures our TypeScript plugin.
+        // The plugin itself is always present, but enabled/disabled depending on this config.
+        // It is done this way because it allows us to toggle the plugin without restarting VS Code
+        // and without having to do hacks like updating the extension's package.json.
         commands.executeCommand('_typescript.configurePlugin', 'typescript-svelte-plugin', {
             enable
         });
-
-        // const extension = extensions.getExtension('svelte.svelte-vscode');
-        // if (!extension) {
-        //     // This shouldn't be possible
-        //     return;
-        // }
-
-        // const packageJson = join(extension.extensionPath, 'package.json');
-        // const enabled = '"typescriptServerPlugins"';
-        // const disabled = '"typescriptServerPlugins-disabled"';
-        // try {
-        //     const packageText = readFileSync(packageJson, 'utf8');
-        //     if (packageText.includes(disabled) && enable) {
-        //         const newText = packageText.replace(disabled, enabled);
-        //         writeFileSync(packageJson, newText, 'utf8');
-        //         this.showReload(true);
-        //     } else if (packageText.includes(enabled) && !enable) {
-        //         const newText = packageText.replace(enabled, disabled);
-        //         writeFileSync(packageJson, newText, 'utf8');
-        //         this.showReload(false);
-        //     } else if (!packageText.includes(enabled) && !packageText.includes(disabled)) {
-        //         window.showWarningMessage('Unknown Svelte for VS Code package.json status.');
-        //     }
-        // } catch (err) {
-        //     window.showWarningMessage(
-        //         'Svelte for VS Code package.json update failed, TypeScript plugin could not be toggled.'
-        //     );
-        // }
     }
-
-    // private async showReload(enabled: boolean) {
-    //     // Restarting the TSServer via a command isn't enough, the whole VS Code window needs to reload
-    //     let message = `TypeScript Svelte Plugin ${enabled ? 'enabled' : 'disabled'}.`;
-    //     if (enabled) {
-    //         message +=
-    //             ' Note that changes of Svelte files are only noticed by TS/JS files after they are saved to disk.';
-    //     }
-    //     message += ' Please reload VS Code to restart the TS Server.';
-
-    //     const reload = await window.showInformationMessage(message, 'Reload Window');
-    //     if (reload) {
-    //         commands.executeCommand('workbench.action.reloadWindow');
-    //     }
-    // }
 
     async askToEnable() {
         const shouldAsk = workspace

--- a/packages/svelte-vscode/src/tsplugin.ts
+++ b/packages/svelte-vscode/src/tsplugin.ts
@@ -5,13 +5,8 @@ import { commands, ExtensionContext, extensions, window, workspace } from 'vscod
 export class TsPlugin {
     private enabled: boolean;
 
-    static create(context: ExtensionContext) {
-        new TsPlugin(context);
-    }
-
-    private constructor(context: ExtensionContext) {
+    constructor(context: ExtensionContext) {
         this.enabled = this.getEnabledState();
-        this.askToEnable(this.enabled);
         this.toggleTsPlugin(this.enabled);
 
         context.subscriptions.push(
@@ -84,11 +79,11 @@ export class TsPlugin {
     //     }
     // }
 
-    private async askToEnable(enabled: boolean) {
+    async askToEnable() {
         const shouldAsk = workspace
             .getConfiguration('svelte')
             .get<boolean>('ask-to-enable-ts-plugin');
-        if (enabled || !shouldAsk) {
+        if (this.enabled || !shouldAsk) {
             return;
         }
 

--- a/packages/svelte-vscode/src/tsplugin.ts
+++ b/packages/svelte-vscode/src/tsplugin.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+// import { readFileSync, writeFileSync } from 'fs';
+// import { join } from 'path';
 import { commands, ExtensionContext, extensions, window, workspace } from 'vscode';
 
 export class TsPlugin {
@@ -29,50 +29,60 @@ export class TsPlugin {
         return workspace.getConfiguration('svelte').get<boolean>('enable-ts-plugin') ?? false;
     }
 
-    private toggleTsPlugin(enable: boolean) {
-        const extension = extensions.getExtension('svelte.svelte-vscode');
+    private async toggleTsPlugin(enable: boolean) {
+        const extension = extensions.getExtension('vscode.typescript-language-features');
+
         if (!extension) {
-            // This shouldn't be possible
             return;
         }
 
-        const packageJson = join(extension.extensionPath, 'package.json');
-        const enabled = '"typescriptServerPlugins"';
-        const disabled = '"typescriptServerPlugins-disabled"';
-        try {
-            const packageText = readFileSync(packageJson, 'utf8');
-            if (packageText.includes(disabled) && enable) {
-                const newText = packageText.replace(disabled, enabled);
-                writeFileSync(packageJson, newText, 'utf8');
-                this.showReload(true);
-            } else if (packageText.includes(enabled) && !enable) {
-                const newText = packageText.replace(enabled, disabled);
-                writeFileSync(packageJson, newText, 'utf8');
-                this.showReload(false);
-            } else if (!packageText.includes(enabled) && !packageText.includes(disabled)) {
-                window.showWarningMessage('Unknown Svelte for VS Code package.json status.');
-            }
-        } catch (err) {
-            window.showWarningMessage(
-                'Svelte for VS Code package.json update failed, TypeScript plugin could not be toggled.'
-            );
-        }
+        commands.executeCommand('_typescript.configurePlugin', 'typescript-svelte-plugin', {
+            enable
+        });
+
+        // const extension = extensions.getExtension('svelte.svelte-vscode');
+        // if (!extension) {
+        //     // This shouldn't be possible
+        //     return;
+        // }
+
+        // const packageJson = join(extension.extensionPath, 'package.json');
+        // const enabled = '"typescriptServerPlugins"';
+        // const disabled = '"typescriptServerPlugins-disabled"';
+        // try {
+        //     const packageText = readFileSync(packageJson, 'utf8');
+        //     if (packageText.includes(disabled) && enable) {
+        //         const newText = packageText.replace(disabled, enabled);
+        //         writeFileSync(packageJson, newText, 'utf8');
+        //         this.showReload(true);
+        //     } else if (packageText.includes(enabled) && !enable) {
+        //         const newText = packageText.replace(enabled, disabled);
+        //         writeFileSync(packageJson, newText, 'utf8');
+        //         this.showReload(false);
+        //     } else if (!packageText.includes(enabled) && !packageText.includes(disabled)) {
+        //         window.showWarningMessage('Unknown Svelte for VS Code package.json status.');
+        //     }
+        // } catch (err) {
+        //     window.showWarningMessage(
+        //         'Svelte for VS Code package.json update failed, TypeScript plugin could not be toggled.'
+        //     );
+        // }
     }
 
-    private async showReload(enabled: boolean) {
-        // Restarting the TSServer via a command isn't enough, the whole VS Code window needs to reload
-        let message = `TypeScript Svelte Plugin ${enabled ? 'enabled' : 'disabled'}.`;
-        if (enabled) {
-            message +=
-                ' Note that changes of Svelte files are only noticed by TS/JS files after they are saved to disk.';
-        }
-        message += ' Please reload VS Code to restart the TS Server.';
+    // private async showReload(enabled: boolean) {
+    //     // Restarting the TSServer via a command isn't enough, the whole VS Code window needs to reload
+    //     let message = `TypeScript Svelte Plugin ${enabled ? 'enabled' : 'disabled'}.`;
+    //     if (enabled) {
+    //         message +=
+    //             ' Note that changes of Svelte files are only noticed by TS/JS files after they are saved to disk.';
+    //     }
+    //     message += ' Please reload VS Code to restart the TS Server.';
 
-        const reload = await window.showInformationMessage(message, 'Reload Window');
-        if (reload) {
-            commands.executeCommand('workbench.action.reloadWindow');
-        }
-    }
+    //     const reload = await window.showInformationMessage(message, 'Reload Window');
+    //     if (reload) {
+    //         commands.executeCommand('workbench.action.reloadWindow');
+    //     }
+    // }
 
     private async askToEnable(enabled: boolean) {
         const shouldAsk = workspace

--- a/packages/typescript-plugin/internal.md
+++ b/packages/typescript-plugin/internal.md
@@ -16,6 +16,8 @@ The last step is to enhance the language service. For that, we patch the desired
 
 Along the way, we need to patch some internal methods, which is brittly and hacky, but to our knowledge there currently is no other way.
 
+To make it work with the VS Code extension we need to provide the plugin within `contributes.typescriptServerPlugins`. That way the plugin is always loaded. To enable/disable it, we use a semi-public command that tells TypeScript to configure the plugin. That configuration then tells this plugin whether or not it is enabled.
+
 ## Limitations
 
 Currently, changes to Svelte files are only recognized after they are saved to disk. That could be changed by adding `"languages": ["svelte"]` to the plugin provide options. The huge disadvantage is that diagnostics, rename etc within Svelte files no longer stay in the control of the language-server, instead TS/JS starts interacting with Svelte files on a much deeper level, which would mean patching many more undocumented/private methods, and having less control of the situation overall.

--- a/packages/typescript-plugin/src/config-manager.ts
+++ b/packages/typescript-plugin/src/config-manager.ts
@@ -21,7 +21,7 @@ export class ConfigManager {
             ...this.config,
             ...config
         };
-        this.emitter.emit(configurationEventName);
+        this.emitter.emit(configurationEventName, config);
     }
 
     getConfig() {

--- a/packages/typescript-plugin/src/config-manager.ts
+++ b/packages/typescript-plugin/src/config-manager.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from 'events';
+
+const configurationEventName = 'configuration-changed';
+
+export interface Configuration {
+    enable: false;
+}
+
+export class ConfigManager {
+    private emitter = new EventEmitter();
+    private config: Configuration = {
+        enable: false
+    };
+
+    onConfigurationChanged(listener: (config: Configuration) => void) {
+        this.emitter.on(configurationEventName, listener);
+    }
+
+    updateConfigFromPluginConfig(config: Configuration) {
+        this.config = {
+            ...this.config,
+            ...config
+        };
+        this.emitter.emit(configurationEventName);
+    }
+
+    getConfig() {
+        return this.config;
+    }
+}

--- a/packages/typescript-plugin/src/config-manager.ts
+++ b/packages/typescript-plugin/src/config-manager.ts
@@ -3,13 +3,13 @@ import { EventEmitter } from 'events';
 const configurationEventName = 'configuration-changed';
 
 export interface Configuration {
-    enable: false;
+    enable: boolean;
 }
 
 export class ConfigManager {
     private emitter = new EventEmitter();
     private config: Configuration = {
-        enable: false
+        enable: true
     };
 
     onConfigurationChanged(listener: (config: Configuration) => void) {

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -49,6 +49,7 @@ function init(modules: { typescript: typeof ts }) {
         );
 
         configManager.onConfigurationChanged(() => {
+            // enabling/disabling the plugin means TS has to recompute stuff
             info.languageService.cleanupSemanticCache();
             info.project.markAsDirty();
         });

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -4,8 +4,11 @@ import { Logger } from './logger';
 import { patchModuleLoader } from './module-loader';
 import { SvelteSnapshotManager } from './svelte-snapshots';
 import type ts from 'typescript/lib/tsserverlibrary';
+import { ConfigManager, Configuration } from './config-manager';
 
 function init(modules: { typescript: typeof ts }) {
+    const configManager = new ConfigManager();
+
     function create(info: ts.server.PluginCreateInfo) {
         const logger = new Logger(info.project.projectService.logger);
         if (!isSvelteProject(info.project.getCompilerOptions())) {
@@ -13,7 +16,14 @@ function init(modules: { typescript: typeof ts }) {
             return info.languageService;
         }
 
-        logger.log('Starting Svelte plugin');
+        configManager.updateConfigFromPluginConfig(info.config);
+        if (configManager.getConfig().enable) {
+            logger.log('Starting Svelte plugin');
+        } else {
+            logger.log('Svelte plugin disabled');
+            logger.log(info.config);
+        }
+
         // If someone knows a better/more performant way to get svelteOptions,
         // please tell us :)
         const svelteOptions = info.languageServiceHost.getParsedCommandLine?.(
@@ -25,7 +35,8 @@ function init(modules: { typescript: typeof ts }) {
             modules.typescript,
             info.project.projectService,
             svelteOptions,
-            logger
+            logger,
+            configManager
         );
 
         patchModuleLoader(
@@ -33,9 +44,21 @@ function init(modules: { typescript: typeof ts }) {
             snapshotManager,
             modules.typescript,
             info.languageServiceHost,
-            info.project
+            info.project,
+            configManager
         );
-        return decorateLanguageService(info.languageService, snapshotManager, logger);
+
+        configManager.onConfigurationChanged(() => {
+            info.languageService.cleanupSemanticCache();
+            info.project.markAsDirty();
+        });
+
+        return decorateLanguageService(
+            info.languageService,
+            snapshotManager,
+            logger,
+            configManager
+        );
     }
 
     function getExternalFiles(project: ts.server.ConfiguredProject) {
@@ -66,7 +89,11 @@ function init(modules: { typescript: typeof ts }) {
         }
     }
 
-    return { create, getExternalFiles };
+    function onConfigurationChanged(config: Configuration) {
+        configManager.updateConfigFromPluginConfig(config);
+    }
+
+    return { create, getExternalFiles, onConfigurationChanged };
 }
 
 export = init;

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -16,10 +16,10 @@ export function decorateLanguageService(
     logger: Logger,
     configManager: ConfigManager
 ) {
+    // Decorate using a proxy so we can dynamically enable/disable method
+    // patches depending on the enabled state of our config
     const proxy = new Proxy(ls, createProxyHandler(configManager));
-
     decorateLanguageServiceInner(proxy, snapshotManager, logger);
-
     return proxy;
 }
 

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -1,4 +1,5 @@
 import type ts from 'typescript/lib/tsserverlibrary';
+import { ConfigManager } from '../config-manager';
 import { Logger } from '../logger';
 import { SvelteSnapshotManager } from '../svelte-snapshots';
 import { isSvelteFilePath } from '../utils';
@@ -12,6 +13,19 @@ import { decorateRename } from './rename';
 export function decorateLanguageService(
     ls: ts.LanguageService,
     snapshotManager: SvelteSnapshotManager,
+    logger: Logger,
+    configManager: ConfigManager
+) {
+    const proxy = new Proxy(ls, createProxyHandler(configManager));
+
+    decorateLanguageServiceInner(proxy, snapshotManager, logger);
+
+    return proxy;
+}
+
+function decorateLanguageServiceInner(
+    ls: ts.LanguageService,
+    snapshotManager: SvelteSnapshotManager,
     logger: Logger
 ): ts.LanguageService {
     patchLineColumnOffset(ls, snapshotManager);
@@ -22,6 +36,27 @@ export function decorateLanguageService(
     decorateGetDefinition(ls, snapshotManager, logger);
     decorateGetImplementation(ls, snapshotManager, logger);
     return ls;
+}
+
+function createProxyHandler(configManager: ConfigManager): ProxyHandler<ts.LanguageService> {
+    const decorated: Partial<ts.LanguageService> = {};
+
+    return {
+        get(target, p) {
+            if (!configManager.getConfig().enable) {
+                return target[p as keyof ts.LanguageService];
+            }
+
+            return (
+                decorated[p as keyof ts.LanguageService] ?? target[p as keyof ts.LanguageService]
+            );
+        },
+        set(_, p, value) {
+            decorated[p as keyof ts.LanguageService] = value;
+
+            return true;
+        }
+    };
 }
 
 function patchLineColumnOffset(ls: ts.LanguageService, snapshotManager: SvelteSnapshotManager) {

--- a/packages/typescript-plugin/src/module-loader.ts
+++ b/packages/typescript-plugin/src/module-loader.ts
@@ -1,4 +1,5 @@
 import type ts from 'typescript/lib/tsserverlibrary';
+import { ConfigManager } from './config-manager';
 import { Logger } from './logger';
 import { SvelteSnapshotManager } from './svelte-snapshots';
 import { createSvelteSys } from './svelte-sys';
@@ -39,6 +40,10 @@ class ModuleResolutionCache {
         });
     }
 
+    clear() {
+        this.cache.clear();
+    }
+
     private getKey(moduleName: string, containingFile: string) {
         return containingFile + ':::' + ensureRealSvelteFilePath(moduleName);
     }
@@ -58,7 +63,8 @@ export function patchModuleLoader(
     snapshotManager: SvelteSnapshotManager,
     typescript: typeof ts,
     lsHost: ts.LanguageServiceHost,
-    project: ts.server.Project
+    project: ts.server.Project,
+    configManager: ConfigManager
 ): void {
     const svelteSys = createSvelteSys(logger);
     const moduleCache = new ModuleResolutionCache();
@@ -72,6 +78,10 @@ export function patchModuleLoader(
         moduleCache.delete(info.fileName);
         return origRemoveFile(info, fileExists, detachFromProject);
     };
+
+    configManager.onConfigurationChanged(() => {
+        moduleCache.clear();
+    });
 
     function resolveModuleNames(
         moduleNames: string[],
@@ -93,6 +103,10 @@ export function patchModuleLoader(
                 redirectedReference,
                 compilerOptions
             ) || Array.from<undefined>(Array(moduleNames.length));
+
+        if (!configManager.getConfig().enable) {
+            return resolved;
+        }
 
         return resolved.map((moduleName, idx) => {
             const fileName = moduleNames[idx];

--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -1,5 +1,6 @@
 import { svelte2tsx } from 'svelte2tsx';
 import type ts from 'typescript/lib/tsserverlibrary';
+import { ConfigManager } from './config-manager';
 import { Logger } from './logger';
 import { SourceMapper } from './source-mapper';
 import { isNoTextSpanInGeneratedCode, isSvelteFilePath } from './utils';
@@ -233,7 +234,8 @@ export class SvelteSnapshotManager {
         private typescript: typeof ts,
         private projectService: ts.server.ProjectService,
         private svelteOptions: { namespace: string },
-        private logger: Logger
+        private logger: Logger,
+        private configManager: ConfigManager
     ) {
         this.patchProjectServiceReadFile();
     }
@@ -278,7 +280,7 @@ export class SvelteSnapshotManager {
     private patchProjectServiceReadFile() {
         const readFile = this.projectService.host.readFile;
         this.projectService.host.readFile = (path: string) => {
-            if (isSvelteFilePath(path)) {
+            if (isSvelteFilePath(path) && this.configManager.getConfig().enable) {
                 this.logger.debug('Read Svelte file:', path);
                 const svelteCode = readFile(path) || '';
                 try {


### PR DESCRIPTION
https://github.com/sveltejs/language-tools/issues/1358. Based on the tslint plugin method. 

The way it works is the svelte extension sends a command to ts extension and then to the tsserver. So it only works when the svelte extension is activated. To achieve that we needed the extension to be started on javascript and typescript files too. While only activating the language server until a svelte file is opened for better performance. 

On the typescript plugin side. There's a new ConfigManager as a config getter. And provide an event for config update so we can clear the cache after the toggle. I changed to use a Proxy while decorating the language service, so it can be easier to toggle it with the enable config. Or we could change to pass config manager to every function that decorates language service methods.

@dummdidumm what do think about this approach? Also, do we still want to send a message when we enable the plugin? 