### PR TITLE
(perf) avoid duplicate patching in the ts plugin

### DIFF
--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import { dirname, resolve } from 'path';
-import { decorateLanguageService } from './language-service';
+import { decorateLanguageService, isPatched } from './language-service';
 import { Logger } from './logger';
 import { patchModuleLoader } from './module-loader';
 import { SvelteSnapshotManager } from './svelte-snapshots';
@@ -13,6 +13,11 @@ function init(modules: { typescript: typeof ts }) {
         const logger = new Logger(info.project.projectService.logger);
         if (!isSvelteProject(info.project.getCompilerOptions())) {
             logger.log('Detected that this is not a Svelte project, abort patching TypeScript');
+            return info.languageService;
+        }
+
+        if (isPatched(info.languageService)) {
+            logger.log('Already patched');
             return info.languageService;
         }
 

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -10,6 +10,12 @@ import { decorateFindReferences } from './find-references';
 import { decorateGetImplementation } from './implementation';
 import { decorateRename } from './rename';
 
+const sveltePluginPatchSymbol = Symbol('sveltePluginPatchSymbol');
+
+export function isPatched(ls: ts.LanguageService) {
+    return (ls as any)[sveltePluginPatchSymbol] === true;
+}
+
 export function decorateLanguageService(
     ls: ts.LanguageService,
     snapshotManager: SvelteSnapshotManager,
@@ -43,6 +49,10 @@ function createProxyHandler(configManager: ConfigManager): ProxyHandler<ts.Langu
 
     return {
         get(target, p) {
+            if (p === sveltePluginPatchSymbol) {
+                return true;
+            }
+
             if (!configManager.getConfig().enable) {
                 return target[p as keyof ts.LanguageService];
             }

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -49,6 +49,7 @@ function createProxyHandler(configManager: ConfigManager): ProxyHandler<ts.Langu
 
     return {
         get(target, p) {
+            // always return patch symbol whether the plugin is enabled or not
             if (p === sveltePluginPatchSymbol) {
                 return true;
             }


### PR DESCRIPTION
Found this while debugging the ts plugin. When the tsconfig.json is updated. tsserver would reload the project and it would cause the plugin to be loaded again.