### PR TITLE
(feat) Add support for svelte-jsx.d.ts and svelte-native-jsx.d.ts to emitDts

### DIFF
--- a/packages/svelte2tsx/src/emitDts.ts
+++ b/packages/svelte2tsx/src/emitDts.ts
@@ -5,6 +5,8 @@ import { svelte2tsx } from './svelte2tsx';
 export interface EmitDtsConfig {
     declarationDir: string;
     svelteShimsPath: string;
+    svelteJsxPath?: string;
+    svelteNativeJsxPath?: string;
     libRoot?: string;
 }
 
@@ -72,6 +74,14 @@ function loadTsconfig(config: EmitDtsConfig, svelteMap: SvelteMap) {
     // Add ambient functions so TS knows how to resolve its invocations in the
     // code output of svelte2tsx.
     filenames.push(config.svelteShimsPath);
+    // Add the svelte.JSX namespace so TS can resolve users' references to it
+    if (config.svelteJsxPath) {
+        filenames.push(config.svelteJsxPath);
+    }
+    // Add the svelteNative.JSX namespace so TS can resolve users' references to it
+    if (config.svelteNativeJsxPath) {
+        filenames.push(config.svelteNativeJsxPath);
+    }
 
     return {
         options: {

--- a/packages/svelte2tsx/test/emitDts/index.ts
+++ b/packages/svelte2tsx/test/emitDts/index.ts
@@ -17,6 +17,8 @@ async function testEmitDts(sample: string) {
         await emitDts({
             declarationDir: 'package',
             svelteShimsPath: require.resolve(join(process.cwd(), 'svelte-shims.d.ts')),
+            svelteJsxPath: require.resolve(join(process.cwd(), 'svelte-jsx.d.ts')),
+            svelteNativeJsxPath: require.resolve(join(process.cwd(), 'svelte-native-jsx.d.ts')),
             ...config,
             libRoot: config.libRoot ? join(cwd, config.libRoot) : cwd
         });


### PR DESCRIPTION
The svelte.JSX namespace, and in particular the svelte.JSX.HTMLAttributes interface, is used by several component libraries. But SvelteKit's package command will fail for components that use them because these definitions are missing. See kit#3783