### PR TITLE
(feat) Support svelte project files in typescript plugin

### DIFF
--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -36,7 +36,7 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
             logger.log(info.config);
         }
 
-        // This called the ConfiguredProject.getParsedCommandLine
+        // This call the ConfiguredProject.getParsedCommandLine
         // where it'll try to load the cached version of the parsedCommandLine
         const parsedCommandLine = info.languageServiceHost.getParsedCommandLine?.(
             getConfigPathForProject(info.project)

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -45,16 +45,6 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
         logger.log('svelteOptions:', svelteOptions);
 
         logger.log(parsedCommandLine?.wildcardDirectories);
-        const watcher = watchDirectoryForNewSvelteFiles(
-            parsedCommandLine,
-            info,
-            modules.typescript,
-            configManager
-        );
-
-        if (parsedCommandLine) {
-            updateProjectSvelteFiles(modules.typescript, info.project, parsedCommandLine);
-        }
 
         const snapshotManager = new SvelteSnapshotManager(
             modules.typescript,
@@ -63,6 +53,18 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
             logger,
             configManager
         );
+
+        const watcher = watchDirectoryForNewSvelteFiles(
+            parsedCommandLine,
+            info,
+            modules.typescript,
+            configManager,
+            snapshotManager
+        );
+
+        if (parsedCommandLine) {
+            updateProjectSvelteFiles(modules.typescript, info.project, parsedCommandLine);
+        }
 
         patchModuleLoader(
             logger,

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -44,8 +44,7 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
 
         const svelteOptions = parsedCommandLine?.raw?.svelteOptions || { namespace: 'svelteHTML' };
         logger.log('svelteOptions:', svelteOptions);
-
-        logger.log(parsedCommandLine?.wildcardDirectories);
+        logger.debug(parsedCommandLine?.wildcardDirectories);
 
         const snapshotManager = new SvelteSnapshotManager(
             modules.typescript,

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -54,7 +54,7 @@ function createProxyHandler(configManager: ConfigManager): ProxyHandler<ts.Langu
                 return true;
             }
 
-            if (!configManager.getConfig().enable) {
+            if (!configManager.getConfig().enable || p === 'dispose') {
                 return target[p as keyof ts.LanguageService];
             }
 

--- a/packages/typescript-plugin/src/project-svelte-files.ts
+++ b/packages/typescript-plugin/src/project-svelte-files.ts
@@ -1,140 +1,178 @@
 import type ts from 'typescript/lib/tsserverlibrary';
-import { ConfigManager } from './config-manager';
+import { ConfigManager, Configuration } from './config-manager';
 import { SvelteSnapshotManager } from './svelte-snapshots';
-import { isSvelteFilePath } from './utils';
-
-const projectSvelteFilesMap = new Map<string, string[]>();
+import { getConfigPathForProject, isSvelteFilePath } from './utils';
 
 export interface TsFilesSpec {
     include?: readonly string[];
     exclude?: readonly string[];
 }
 
-export function updateProjectSvelteFiles(
-    typescript: typeof ts,
-    project: ts.server.Project,
-    parsedCommandLine: ts.ParsedCommandLine
-) {
-    const files = readProjectSvelteFilesFromFs(typescript, project, parsedCommandLine.raw);
+export class ProjectSvelteFilesManager {
+    private files: Set<string> | undefined;
+    private directoryWatchers: Set<ts.FileWatcher> | undefined;
 
-    projectSvelteFilesMap.set(project.getProjectName(), files);
-}
+    private static instances = new Map<string, ProjectSvelteFilesManager>();
 
-function readProjectSvelteFilesFromFs(
-    typescript: typeof ts,
-    project: ts.server.Project,
-    fileSpec: TsFilesSpec
-) {
-    const { include, exclude } = fileSpec;
-
-    if (include?.length === 0) {
-        return [];
+    static getInstance(projectName: string) {
+        return this.instances.get(projectName);
     }
 
-    return typescript.sys
-        .readDirectory(
-            project.getCurrentDirectory() || process.cwd(),
-            ['.svelte'],
-            exclude,
-            include
-        )
-        .map(typescript.sys.resolvePath);
-}
-
-export function watchDirectoryForNewSvelteFiles(
-    parsedCommandLine: ts.ParsedCommandLine | undefined,
-    info: ts.server.PluginCreateInfo,
-    typescript: typeof ts,
-    configManager: ConfigManager,
-    snapshotManager: SvelteSnapshotManager
-) {
-    let watchers: ts.FileWatcher[] = [];
-    let watcherCreated = false;
-
-    if (configManager.getConfig().enable) {
-        watchers = setupWatcher(parsedCommandLine, info, typescript, snapshotManager);
-
-        watcherCreated = true;
-    }
-
-    configManager.onConfigurationChanged((config) => {
-        if (config.enable) {
-            if (!watcherCreated) {
-                watchers = setupWatcher(parsedCommandLine, info, typescript, snapshotManager);
-            }
-        } else {
-            dispose();
-            watcherCreated = false;
+    constructor(
+        private readonly typescript: typeof ts,
+        private readonly project: ts.server.Project,
+        private readonly serverHost: ts.server.ServerHost,
+        private readonly snapshotManager: SvelteSnapshotManager,
+        private parsedCommandLine: ts.ParsedCommandLine,
+        configManager: ConfigManager
+    ) {
+        if (configManager.getConfig().enable) {
+            this.setupWatchers();
         }
-    });
 
-    return {
-        dispose
-    };
-
-    function dispose() {
-        watchers.forEach((watcher) => watcher.close());
-    }
-}
-
-function setupWatcher(
-    parsedCommandLine: ts.ParsedCommandLine | undefined,
-    info: ts.server.PluginCreateInfo,
-    typescript: typeof ts,
-    snapshotManager: SvelteSnapshotManager
-) {
-    if (!parsedCommandLine?.wildcardDirectories) {
-        return [];
+        configManager.onConfigurationChanged(this.onConfigChanged.bind(this));
+        this.updateProjectSvelteFiles();
+        ProjectSvelteFilesManager.instances.set(project.getProjectName(), this);
     }
 
-    const watchers: ts.FileWatcher[] = [];
-    for (const directory in parsedCommandLine.wildcardDirectories) {
-        if (
-            !Object.prototype.hasOwnProperty.call(parsedCommandLine.wildcardDirectories, directory)
-        ) {
-            continue;
-        }
-        const watchDirectoryFlags = parsedCommandLine.wildcardDirectories[directory];
-
-        const watcher = info.serverHost.watchDirectory(
-            directory,
-            (fileName) => {
-                if (!isSvelteFilePath(fileName)) {
-                    return;
-                }
-
-                const projectName = info.project.getProjectName();
-                const fileNamesBefore = projectSvelteFilesMap.get(projectName);
-                updateProjectSvelteFiles(typescript, info.project, parsedCommandLine);
-                const fileNamesAfter = projectSvelteFilesMap.get(projectName);
-                const newFiles =
-                    (fileNamesBefore
-                        ? fileNamesAfter?.filter((fileName) => !fileNamesBefore.includes(fileName))
-                        : fileNamesAfter) ?? [];
-
-                for (const newFile of newFiles) {
-                    snapshotManager.create(newFile);
-                    const snapshot = info.project.projectService.getScriptInfoForNormalizedPath(
-                        typescript.server.toNormalizedPath(newFile)
-                    );
-
-                    if (snapshot) {
-                        info.project.addRoot(snapshot);
-                    }
-                }
-
-                info.project.markAsDirty();
-            },
-            watchDirectoryFlags === typescript.WatchDirectoryFlags.Recursive,
-            parsedCommandLine.watchOptions
+    updateProjectConfig(serviceHost: ts.LanguageServiceHost) {
+        const parsedCommandLine = serviceHost.getParsedCommandLine?.(
+            getConfigPathForProject(this.project)
         );
 
-        watchers.push(watcher);
+        if (!parsedCommandLine) {
+            return;
+        }
+
+        this.parsedCommandLine = parsedCommandLine;
+        this.updateProjectSvelteFiles();
+        this.disposeWatcher();
+        this.setupWatchers();
     }
 
-    return watchers;
-}
+    getFiles() {
+        return this.files ? Array.from(this.files) : [];
+    }
 
-export function getProjectSvelteFiles(project: ts.server.Project) {
-    return projectSvelteFilesMap.get(project.getProjectName());
+    /**
+     * Create directory watcher for include and exclude
+     * The watcher in tsserver doesn't support svelte file
+     * It won't add new created svelte file to root
+     */
+    private setupWatchers() {
+        if (!this.directoryWatchers) {
+            this.directoryWatchers = new Set();
+        }
+
+        for (const directory in this.parsedCommandLine.wildcardDirectories) {
+            if (
+                !Object.prototype.hasOwnProperty.call(
+                    this.parsedCommandLine.wildcardDirectories,
+                    directory
+                )
+            ) {
+                continue;
+            }
+
+            const watchDirectoryFlags = this.parsedCommandLine.wildcardDirectories[directory];
+            const watcher = this.serverHost.watchDirectory(
+                directory,
+                this.watcherCallback.bind(this),
+                watchDirectoryFlags === this.typescript.WatchDirectoryFlags.Recursive,
+                this.parsedCommandLine.watchOptions
+            );
+
+            this.directoryWatchers.add(watcher);
+        }
+    }
+
+    private watcherCallback(fileName: string) {
+        if (!isSvelteFilePath(fileName)) {
+            return;
+        }
+
+        this.updateProjectSvelteFiles();
+    }
+
+    private updateProjectSvelteFiles() {
+        const fileNamesAfter = this.readProjectSvelteFilesFromFs();
+        const filesBefore = this.files;
+        const newFiles = filesBefore
+            ? fileNamesAfter.filter((fileName) => !filesBefore.has(fileName))
+            : fileNamesAfter;
+
+        if (!this.files) {
+            this.files = new Set();
+        }
+
+        for (const newFile of newFiles) {
+            this.addFileToProject(newFile);
+            this.files?.add(newFile);
+        }
+    }
+
+    private addFileToProject(newFile: string) {
+        this.snapshotManager.create(newFile);
+        const snapshot = this.project.projectService.getScriptInfo(newFile);
+
+        if (snapshot) {
+            this.project.addRoot(snapshot);
+        }
+    }
+
+    private readProjectSvelteFilesFromFs() {
+        const fileSpec: TsFilesSpec = this.parsedCommandLine.raw;
+        const { include, exclude } = fileSpec;
+
+        if (include?.length === 0) {
+            return [];
+        }
+
+        return this.typescript.sys
+            .readDirectory(
+                this.project.getCurrentDirectory() || process.cwd(),
+                ['.svelte'],
+                exclude,
+                include
+            )
+            .map(this.typescript.server.toNormalizedPath);
+    }
+
+    private onConfigChanged(config: Configuration) {
+        if (config.enable) {
+            if (!this.directoryWatchers) {
+                this.setupWatchers();
+            }
+
+            this.updateProjectSvelteFiles();
+        } else {
+            this.disposeWatcher();
+
+            this.files?.forEach((file) => this.removeFileFromProject(file));
+            this.files = undefined;
+        }
+    }
+
+    private removeFileFromProject(file: string) {
+        const info = this.project.getScriptInfo(file);
+
+        if (info) {
+            this.project.removeFile(info, true, true);
+        }
+    }
+
+    private disposeWatcher() {
+        if (!this.directoryWatchers) {
+            return;
+        }
+
+        this.directoryWatchers.forEach((watcher) => watcher.close());
+        this.directoryWatchers = undefined;
+    }
+
+    dispose() {
+        this.disposeWatcher();
+
+        ProjectSvelteFilesManager.instances.delete(this.project.getProjectName());
+    }
 }

--- a/packages/typescript-plugin/src/project-svelte-files.ts
+++ b/packages/typescript-plugin/src/project-svelte-files.ts
@@ -1,0 +1,119 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+import { ConfigManager } from './config-manager';
+
+const projectSvelteFilesMap = new Map<string, string[]>();
+
+export interface TsFilesSpec {
+    include?: readonly string[];
+    exclude?: readonly string[];
+}
+
+export function updateProjectSvelteFiles(
+    typescript: typeof ts,
+    project: ts.server.Project,
+    parsedCommandLine: ts.ParsedCommandLine
+) {
+    const files = readProjectSvelteFilesFromFs(typescript, project, parsedCommandLine.raw);
+
+    projectSvelteFilesMap.set(project.getProjectName(), files);
+}
+
+function readProjectSvelteFilesFromFs(
+    typescript: typeof ts,
+    project: ts.server.Project,
+    fileSpec: TsFilesSpec
+) {
+    const { include, exclude } = fileSpec;
+
+    if (include?.length === 0) {
+        return [];
+    }
+
+    return typescript.sys
+        .readDirectory(
+            project.getCurrentDirectory() || process.cwd(),
+            ['.svelte'],
+            exclude,
+            include
+        )
+        .map(typescript.sys.resolvePath);
+}
+
+export function watchDirectoryForNewSvelteFiles(
+    parsedCommandLine: ts.ParsedCommandLine | undefined,
+    info: ts.server.PluginCreateInfo,
+    typescript: typeof ts,
+    configManager: ConfigManager
+) {
+    let watchers: ts.FileWatcher[] = [];
+    let watcherCreated = false;
+
+    if (configManager.getConfig().enable) {
+        watchers = setupWatcher(parsedCommandLine, info, typescript);
+
+        watcherCreated = true;
+    }
+
+    configManager.onConfigurationChanged((config) => {
+        if (config.enable) {
+            if (!watcherCreated) {
+                watchers = setupWatcher(parsedCommandLine, info, typescript);
+            }
+        } else {
+            dispose();
+            watcherCreated = false;
+        }
+    });
+
+    return {
+        dispose
+    };
+
+    function dispose() {
+        watchers.forEach((watcher) => watcher.close());
+    }
+}
+
+function setupWatcher(
+    parsedCommandLine: ts.ParsedCommandLine | undefined,
+    info: ts.server.PluginCreateInfo,
+    typescript: typeof ts
+) {
+    if (!parsedCommandLine?.wildcardDirectories) {
+        return [];
+    }
+
+    const watchers: ts.FileWatcher[] = [];
+    for (const directory in parsedCommandLine.wildcardDirectories) {
+        if (
+            Object.prototype.hasOwnProperty.call(parsedCommandLine.wildcardDirectories, directory)
+        ) {
+            continue;
+        }
+        const watchDirectoryFlags = parsedCommandLine.wildcardDirectories[directory];
+
+        const watcher = info.serverHost.watchDirectory(
+            directory,
+            () => {
+                const projectName = info.project.getProjectName();
+                const fileAmount = projectSvelteFilesMap.get(projectName)?.length;
+                updateProjectSvelteFiles(typescript, info.project, parsedCommandLine);
+                const fileAmountAfter = projectSvelteFilesMap.get(projectName)?.length;
+
+                if (fileAmount !== fileAmountAfter) {
+                    info.project.updateGraph();
+                }
+            },
+            watchDirectoryFlags === typescript.WatchDirectoryFlags.Recursive,
+            parsedCommandLine.watchOptions
+        );
+
+        watchers.push(watcher);
+    }
+
+    return watchers;
+}
+
+export function getProjectSvelteFiles(project: ts.server.Project) {
+    return projectSvelteFilesMap.get(project.getProjectName());
+}

--- a/packages/typescript-plugin/src/project-svelte-files.ts
+++ b/packages/typescript-plugin/src/project-svelte-files.ts
@@ -107,7 +107,7 @@ export class ProjectSvelteFilesManager {
 
         for (const newFile of newFiles) {
             this.addFileToProject(newFile);
-            this.files?.add(newFile);
+            this.files.add(newFile);
         }
     }
 

--- a/packages/typescript-plugin/src/project-svelte-files.ts
+++ b/packages/typescript-plugin/src/project-svelte-files.ts
@@ -145,12 +145,13 @@ export class ProjectSvelteFilesManager {
             }
 
             this.updateProjectSvelteFiles();
-        } else {
-            this.disposeWatcher();
-
-            this.files?.forEach((file) => this.removeFileFromProject(file));
-            this.files = undefined;
+            return;
         }
+
+        this.disposeWatcher();
+
+        this.files?.forEach((file) => this.removeFileFromProject(file));
+        this.files = undefined;
     }
 
     private removeFileFromProject(file: string) {

--- a/packages/typescript-plugin/src/project-svelte-files.ts
+++ b/packages/typescript-plugin/src/project-svelte-files.ts
@@ -1,5 +1,6 @@
 import type ts from 'typescript/lib/tsserverlibrary';
 import { ConfigManager } from './config-manager';
+import { isSvelteFilePath } from './utils';
 
 const projectSvelteFilesMap = new Map<string, string[]>();
 
@@ -94,7 +95,11 @@ function setupWatcher(
 
         const watcher = info.serverHost.watchDirectory(
             directory,
-            () => {
+            (fileName) => {
+                if (!isSvelteFilePath(fileName)) {
+                    return;
+                }
+
                 const projectName = info.project.getProjectName();
                 const fileAmount = projectSvelteFilesMap.get(projectName)?.length;
                 updateProjectSvelteFiles(typescript, info.project, parsedCommandLine);

--- a/packages/typescript-plugin/src/project-svelte-files.ts
+++ b/packages/typescript-plugin/src/project-svelte-files.ts
@@ -86,7 +86,7 @@ function setupWatcher(
     const watchers: ts.FileWatcher[] = [];
     for (const directory in parsedCommandLine.wildcardDirectories) {
         if (
-            Object.prototype.hasOwnProperty.call(parsedCommandLine.wildcardDirectories, directory)
+            !Object.prototype.hasOwnProperty.call(parsedCommandLine.wildcardDirectories, directory)
         ) {
             continue;
         }

--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -9,7 +9,6 @@ export class SvelteSnapshot {
     private scriptInfo?: ts.server.ScriptInfo;
     private lineOffsets?: number[];
     private convertInternalCodePositions = false;
-    private scriptInfoPatched = false;
 
     constructor(
         private typescript: typeof ts,
@@ -119,7 +118,6 @@ export class SvelteSnapshot {
         // };
 
         this.scriptInfo = scriptInfo;
-        this.scriptInfoPatched = true;
         this.log('patched scriptInfo');
     }
 

--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -86,8 +86,8 @@ export class SvelteSnapshot {
     }
 
     setAndPatchScriptInfo(scriptInfo: ts.server.ScriptInfo) {
-        // @ts-expect-error
-        scriptInfo.scriptKind = this.typescript.ScriptKind.TSX;
+        // // @ts-expect-error
+        // scriptInfo.scriptKind = this.typescript.ScriptKind.TSX;
 
         const positionToLineOffset = scriptInfo.positionToLineOffset.bind(scriptInfo);
         scriptInfo.positionToLineOffset = (position) => {

--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -69,25 +69,9 @@ export class SvelteSnapshot {
         return originalOffset;
     }
 
-    ensurePatchScriptInfo(projectService: ts.server.ProjectService) {
-        if (this.scriptInfoPatched) {
-            return;
-        }
-
-        const scriptInfo = projectService.getScriptInfo(this.fileName);
-
-        if (scriptInfo) {
-            this.setAndPatchScriptInfo(scriptInfo);
-        }
-
-        this.scriptInfoPatched = true;
-
-        return;
-    }
-
     setAndPatchScriptInfo(scriptInfo: ts.server.ScriptInfo) {
-        // // @ts-expect-error
-        // scriptInfo.scriptKind = this.typescript.ScriptKind.TSX;
+        // @ts-expect-error
+        scriptInfo.scriptKind = this.typescript.ScriptKind.TSX;
 
         const positionToLineOffset = scriptInfo.positionToLineOffset.bind(scriptInfo);
         scriptInfo.positionToLineOffset = (position) => {
@@ -259,13 +243,7 @@ export class SvelteSnapshotManager {
     }
 
     get(fileName: string) {
-        const result = this.snapshots.get(fileName);
-
-        if (result) {
-            result.ensurePatchScriptInfo(this.projectService);
-        }
-
-        return result;
+        return this.snapshots.get(fileName);
     }
 
     create(fileName: string): SvelteSnapshot | undefined {

--- a/packages/typescript-plugin/src/utils.ts
+++ b/packages/typescript-plugin/src/utils.ts
@@ -1,3 +1,5 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+
 export function isSvelteFilePath(filePath: string) {
     return filePath.endsWith('.svelte');
 }
@@ -63,4 +65,11 @@ export function replaceDeep<T extends Record<string, any>>(
         }
         return _obj;
     }
+}
+
+export function getConfigPathForProject(project: ts.server.Project) {
+    return (
+        (project as ts.server.ConfiguredProject).canonicalConfigFilePath ??
+        (project.getCompilerOptions() as any).configFilePath
+    );
 }


### PR DESCRIPTION
#1195. Tried various solutions and end up similarly as we update the project js/ts files in the svelte language server. 

The `extraFileExtensions` parameter in `parseJsonConfigFileContent` do work but it's less performant. I did find a way to configure the tsserver to accept extra file extensions while parsing config and updating project files. But that method will restart the project and load the plugin again. Meaning an infinite loop until it throws an error. 

Implementation wise, First, we read the directory matching the include, exclude add those files to the typescript server project. And set up a directory watcher base with the watching option in the parsed command line. When there's svelte files update, update the files again. 

The reason why we need to manually add it to the typescript server project is that for reason typescript only add the initial external files to the root. A newly created file won't. Meaning it will never be updated. 