### PR TITLE
(feat) make it possible to pass additional file paths to emitDts

### DIFF
--- a/packages/svelte2tsx/index.d.ts
+++ b/packages/svelte2tsx/index.d.ts
@@ -79,6 +79,11 @@ export interface EmitDtsConfig {
      */
     svelteShimsPath: string;
     /**
+     * Additional file paths that need to be present when doing the dts emit.
+     * Example: `[require.resolve('svelte2tsx/svelte-jsx.d.ts')]` for the Svelte HTML ambient type definitions
+     */
+    additionalPaths?: string[];
+    /**
      * If you want to emit types only for part of your project,
      * then set this to the folder for which the types should be emitted.
      * Most of the time you don't need this. For SvelteKit, this is for example

--- a/packages/svelte2tsx/src/emitDts.ts
+++ b/packages/svelte2tsx/src/emitDts.ts
@@ -5,6 +5,7 @@ import { svelte2tsx } from './svelte2tsx';
 export interface EmitDtsConfig {
     declarationDir: string;
     svelteShimsPath: string;
+    additionalPaths?: string[];
     libRoot?: string;
 }
 
@@ -72,6 +73,7 @@ function loadTsconfig(config: EmitDtsConfig, svelteMap: SvelteMap) {
     // Add ambient functions so TS knows how to resolve its invocations in the
     // code output of svelte2tsx.
     filenames.push(config.svelteShimsPath);
+    filenames.push(...(config.additionalPaths || []));
 
     return {
         options: {


### PR DESCRIPTION
Needed when someone uses the svelte.JSX typings.
Closes #1405

Other possibilities:
- type this as `string` like in #1405 -> decided against that because it's not flexible enough for other use cases
- use `require.resolve` for this to get the `d.ts` file -> decided against that because people might use this in other environments than HTML (Svelte Native) and they couldn't pass their file in then
