### PR TITLE
(feat) better hover info for html attributes

### DIFF
--- a/packages/language-server/src/lib/documents/Document.ts
+++ b/packages/language-server/src/lib/documents/Document.ts
@@ -4,6 +4,7 @@ import { extractScriptTags, extractStyleTag, extractTemplateTag, TagInformation 
 import { parseHtml } from './parseHtml';
 import { SvelteConfig, configLoader } from './configLoader';
 import { HTMLDocument } from 'vscode-html-languageservice';
+import { Range } from 'vscode-languageserver';
 
 /**
  * Represents a text document contains a svelte component.
@@ -64,7 +65,10 @@ export class Document extends WritableDocument {
     /**
      * Get text content
      */
-    getText(): string {
+    getText(range?: Range): string {
+        if (range) {
+            return this.content.substring(this.offsetAt(range.start), this.offsetAt(range.end));
+        }
         return this.content;
     }
 

--- a/packages/language-server/src/lib/documents/DocumentBase.ts
+++ b/packages/language-server/src/lib/documents/DocumentBase.ts
@@ -1,4 +1,4 @@
-import { Position, TextDocument } from 'vscode-languageserver';
+import { Position, Range, TextDocument } from 'vscode-languageserver';
 import { getLineOffsets, offsetAt, positionAt } from './utils';
 
 /**
@@ -8,7 +8,7 @@ export abstract class ReadableDocument implements TextDocument {
     /**
      * Get the text content of the document
      */
-    abstract getText(): string;
+    abstract getText(range?: Range): string;
 
     /**
      * Returns the url of the document


### PR DESCRIPTION
Use the HTML hover info instead of the TS hover info. This requires the document's getText-method to support the optional range parameter