### PR TITLE
(feat) detect invalid Svelte import paths

### DIFF
--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -144,9 +144,15 @@ export namespace DocumentSnapshot {
             originalText = ts.sys.readFile(filePath) || '';
         }
         if (normalizedPath.endsWith('svelte2tsx/svelte-shims.d.ts')) {
-            originalText =
-                originalText.substring(0, originalText.indexOf('// -- start svelte-ls-remove --')) +
-                originalText.substring(originalText.indexOf('// -- end svelte-ls-remove --'));
+            // If not present, the LS uses an older version of svelte2tsx
+            if (originalText.includes('// -- start svelte-ls-remove --')) {
+                originalText =
+                    originalText.substring(
+                        0,
+                        originalText.indexOf('// -- start svelte-ls-remove --')
+                    ) +
+                    originalText.substring(originalText.indexOf('// -- end svelte-ls-remove --'));
+            }
         }
 
         return new JSOrTSDocumentSnapshot(INITIAL_VERSION, filePath, originalText);

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -131,7 +131,24 @@ export namespace DocumentSnapshot {
      * @param options options that apply in case it's a svelte file
      */
     export function fromNonSvelteFilePath(filePath: string) {
-        const originalText = ts.sys.readFile(filePath) ?? '';
+        let originalText = '';
+
+        // The following (very hacky) code makes sure that the ambient module definitions
+        // that tell TS "every import ending with .svelte is a valid module" are removed.
+        // They exist in svelte2tsx and svelte to make sure that people don't
+        // get errors in their TS files when importing Svelte files and not using our TS plugin.
+        // If someone wants to get back the behavior they can add an ambient module definition
+        // on their own.
+        const normalizedPath = filePath.replace(/\\/g, '/');
+        if (!normalizedPath.endsWith('node_modules/svelte/types/runtime/ambient.d.ts')) {
+            originalText = ts.sys.readFile(filePath) || '';
+        }
+        if (normalizedPath.endsWith('svelte2tsx/svelte-shims.d.ts')) {
+            originalText =
+                originalText.substring(0, originalText.indexOf('// -- start svelte-ls-remove --')) +
+                originalText.substring(originalText.indexOf('// -- end svelte-ls-remove --'));
+        }
+
         return new JSOrTSDocumentSnapshot(INITIAL_VERSION, filePath, originalText);
     }
 

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$$props-usage/expected.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$$props-usage/expected.json
@@ -1,6 +1,9 @@
 [
     {
-        "range": { "start": { "line": 9, "character": 7 }, "end": { "line": 9, "character": 16 } },
+        "range": {
+            "start": { "line": 10, "character": 7 },
+            "end": { "line": 10, "character": 16 }
+        },
         "severity": 1,
         "source": "ts",
         "message": "Type 'boolean' is not assignable to type 'string'.",
@@ -9,8 +12,8 @@
     },
     {
         "range": {
-            "start": { "line": 10, "character": 43 },
-            "end": { "line": 10, "character": 54 }
+            "start": { "line": 11, "character": 43 },
+            "end": { "line": 11, "character": 54 }
         },
         "severity": 1,
         "source": "ts",
@@ -19,7 +22,7 @@
         "tags": []
     },
     {
-        "range": { "start": { "line": 11, "character": 1 }, "end": { "line": 11, "character": 6 } },
+        "range": { "start": { "line": 12, "character": 1 }, "end": { "line": 12, "character": 6 } },
         "severity": 1,
         "source": "ts",
         "message": "Type '{}' is not assignable to type 'IntrinsicAttributes & { exported1: string; exported2?: string | undefined; }'.\n  Property 'exported1' is missing in type '{}' but required in type '{ exported1: string; exported2?: string | undefined; }'.",

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$$props-usage/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$$props-usage/expectedv2.json
@@ -1,6 +1,9 @@
 [
     {
-        "range": { "start": { "line": 9, "character": 7 }, "end": { "line": 9, "character": 16 } },
+        "range": {
+            "start": { "line": 10, "character": 7 },
+            "end": { "line": 10, "character": 16 }
+        },
         "severity": 1,
         "source": "ts",
         "message": "Type 'boolean' is not assignable to type 'string'.",
@@ -9,8 +12,8 @@
     },
     {
         "range": {
-            "start": { "line": 10, "character": 43 },
-            "end": { "line": 10, "character": 61 }
+            "start": { "line": 11, "character": 43 },
+            "end": { "line": 11, "character": 61 }
         },
         "severity": 1,
         "source": "ts",
@@ -19,7 +22,7 @@
         "tags": []
     },
     {
-        "range": { "start": { "line": 11, "character": 1 }, "end": { "line": 11, "character": 6 } },
+        "range": { "start": { "line": 12, "character": 1 }, "end": { "line": 12, "character": 6 } },
         "severity": 1,
         "source": "ts",
         "message": "Property 'exported1' is missing in type '{}' but required in type '{ exported1: string; exported2?: string | undefined; }'.",

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$$props-usage/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$$props-usage/input.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import Props from '../$$props-valid/input.svelte';
+    // @ts-expect-error
     import PropsInvalid3 from './$$props-invalid3.svelte';
 </script>
 

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/invalid-import/expected.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/invalid-import/expected.json
@@ -1,0 +1,10 @@
+[
+    {
+        "range": { "start": { "line": 1, "character": 28 }, "end": { "line": 1, "character": 51 } },
+        "severity": 1,
+        "source": "ts",
+        "message": "Cannot find module './doesnt-exist.svelte' or its corresponding type declarations.",
+        "code": 2307,
+        "tags": []
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/invalid-import/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/invalid-import/expectedv2.json
@@ -1,0 +1,10 @@
+[
+    {
+        "range": { "start": { "line": 1, "character": 28 }, "end": { "line": 1, "character": 51 } },
+        "severity": 1,
+        "source": "ts",
+        "message": "Cannot find module './doesnt-exist.svelte' or its corresponding type declarations.",
+        "code": 2307,
+        "tags": []
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/invalid-import/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/invalid-import/input.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import InvalidImport from './doesnt-exist.svelte';
+  import ValidImport from './valid-import.svelte';
+
+  InvalidImport;ValidImport;
+</script>

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -3,9 +3,11 @@
 // are loaded and their declarations conflict each other
 // See https://github.com/sveltejs/language-tools/issues/1059 for an example bug that stems from it
 
+// -- start svelte-ls-remove --
 declare module '*.svelte' {
     export default Svelte2TsxComponent
 }
+// -- end svelte-ls-remove --
 
 declare class Svelte2TsxComponent<
     Props extends {} = {},

--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -291,6 +291,9 @@ export class SvelteSnapshotManager {
                 return '';
             } else if (normalizedPath.endsWith('svelte2tsx/svelte-shims.d.ts')) {
                 let originalText = readFile(path) || '';
+                if (!originalText.includes('// -- start svelte-ls-remove --')) {
+                    return originalText; // uses an older version of svelte2tsx
+                }
                 originalText =
                     originalText.substring(
                         0,


### PR DESCRIPTION
Detect that an import of a .svelte file is pointing to a non-existent file by removing the ambient module definitions in svelte and svelte2tsx from the eyes of TS.

If you want the old behavior back, add a `ambient.d.ts` file (or similar; you can add it to `app.d.ts` in a SvelteKit project for example) with the following:
```ts
declare module "*.svelte";
```

#1444

@jasonlyu123 please tell me if this too hacky or actually a good idea 😅 