### PR TITLE
(fix) detect invalid Svelte import paths for svelte-check

### DIFF
--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -134,7 +134,10 @@ export namespace DocumentSnapshot {
         if (!normalizedPath.endsWith('node_modules/svelte/types/runtime/ambient.d.ts')) {
             originalText = ts.sys.readFile(filePath) || '';
         }
-        if (normalizedPath.endsWith('svelte2tsx/svelte-shims.d.ts')) {
+        if (
+            normalizedPath.endsWith('svelte2tsx/svelte-shims.d.ts') ||
+            normalizedPath.endsWith('svelte-check/dist/src/svelte-shims.d.ts')
+        ) {
             // If not present, the LS uses an older version of svelte2tsx
             if (originalText.includes('// -- start svelte-ls-remove --')) {
                 originalText =


### PR DESCRIPTION
 #1448  #1468
 
Since the file is copied to the svelte-check build output. The path also needed to be considered. 