### PR TITLE
(feat) auto-create page endpoints

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -102,6 +102,16 @@
                     "default": "off",
                     "description": "Traces the communication between VS Code and the Svelte Language Server."
                 },
+                "svelte.kit.createEndpoints": {
+                    "type": "string",
+                    "enum": [
+                        "Ask",
+                        "Always",
+                        "Never"
+                    ],
+                    "default": "Ask",
+                    "description": "Creates a corresponding endpoint when creating a new Svelte page file"
+                },
                 "svelte.plugin.typescript.enable": {
                     "type": "boolean",
                     "default": true,

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -102,16 +102,6 @@
                     "default": "off",
                     "description": "Traces the communication between VS Code and the Svelte Language Server."
                 },
-                "svelte.kit.createEndpoints": {
-                    "type": "string",
-                    "enum": [
-                        "Ask",
-                        "Always",
-                        "Never"
-                    ],
-                    "default": "Ask",
-                    "description": "Creates a corresponding endpoint when creating a new Svelte page file"
-                },
                 "svelte.plugin.typescript.enable": {
                     "type": "boolean",
                     "default": true,
@@ -544,6 +534,10 @@
             {
                 "command": "svelte.extractComponent",
                 "title": "Svelte: Extract Component"
+            },
+            {
+                "command": "svelte.kit.createPageEndpoint",
+                "title": "SvelteKit: Create endpoint for page"
             }
         ],
         "menus": {
@@ -565,6 +559,12 @@
                     "command": "svelte.extractComponent",
                     "when": "editorLangId == svelte",
                     "group": "1_modification"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "command": "svelte.kit.createPageEndpoint",
+                    "when": "resourceExtname == .svelte"
                 }
             ]
         },

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -28,6 +28,7 @@ import { LanguageClient, ServerOptions, TransportKind } from 'vscode-languagecli
 import CompiledCodeContentProvider from './CompiledCodeContentProvider';
 import { activateTagClosing } from './html/autoClose';
 import { EMPTY_ELEMENTS } from './html/htmlEmptyTagsShared';
+import { addPageEndpointsPrompt } from './sveltekit';
 import { TsPlugin } from './tsplugin';
 
 namespace TagCloseRequest {
@@ -228,6 +229,8 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
     addCompilePreviewCommand(getLS, context);
 
     addExtracComponentCommand(getLS, context);
+
+    addPageEndpointsPrompt();
 
     languages.setLanguageConfiguration('svelte', {
         indentationRules: {

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -28,7 +28,7 @@ import { LanguageClient, ServerOptions, TransportKind } from 'vscode-languagecli
 import CompiledCodeContentProvider from './CompiledCodeContentProvider';
 import { activateTagClosing } from './html/autoClose';
 import { EMPTY_ELEMENTS } from './html/htmlEmptyTagsShared';
-import { addPageEndpointsPrompt } from './sveltekit';
+import { addPageEndpointsCommand } from './sveltekit';
 import { TsPlugin } from './tsplugin';
 
 namespace TagCloseRequest {
@@ -230,7 +230,7 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
 
     addExtracComponentCommand(getLS, context);
 
-    addPageEndpointsPrompt();
+    addPageEndpointsCommand(context);
 
     languages.setLanguageConfiguration('svelte', {
         indentationRules: {

--- a/packages/svelte-vscode/src/sveltekit.ts
+++ b/packages/svelte-vscode/src/sveltekit.ts
@@ -1,113 +1,56 @@
 // SvelteKit related features go here
 
-import { TextDecoder } from 'util';
-import { Position, Uri, window, workspace, WorkspaceEdit } from 'vscode';
+import { commands, ExtensionContext, Position, Uri, workspace, WorkspaceEdit } from 'vscode';
 
-enum Option {
-    Yes = 'Yes',
-    No = 'No',
-    Always = 'Always',
-    Never = 'Never'
-}
-
-const routesPath = '/src/routes'; // TODO can be configured, read svelte.config.js https://kit.svelte.dev/docs/configuration
-
-export function addPageEndpointsPrompt() {
-    workspace.onDidCreateFiles(async (e) => {
-        const option = workspace.getConfiguration('svelte.kit').get<string>('createEndpoints');
-        if (option === Option.Never) {
-            return;
-        }
-        // The signature says multiple files can be created at once, but we only care about the
-        // "single file created by user through UI" case. This makes the follow-up code easier.
-        const file = e.files[0];
-        if (!file.path.includes(routesPath) || !file.path.endsWith('.svelte')) {
-            return;
-        }
-
-        // Find out if this is actually a SvelteKit project
-        try {
-            const packageJson = await workspace.fs.readFile(
-                Uri.file(file.path.split(routesPath)[0] + '/package.json')
+export function addPageEndpointsCommand(context: ExtensionContext) {
+    context.subscriptions.push(
+        commands.registerTextEditorCommand('svelte.kit.createPageEndpoint', async (editor) => {
+            const file = editor.document.uri;
+            // Traverse the file tree up until the workspace root to check if it's a TS project or not
+            const workspaceFolder = workspace.workspaceFolders?.find((folder) =>
+                file.path.startsWith(folder.uri.path)
             );
-            const packageJsonContent = JSON.parse(new TextDecoder().decode(packageJson));
-            if (
-                !packageJsonContent.dependencies['@sveltejs/kit'] &&
-                !packageJsonContent.devDependencies['@sveltejs/kit']
-            ) {
-                return;
+            let isTsProject = false;
+            let path = file.path;
+            while (!isTsProject && workspaceFolder && path.startsWith(workspaceFolder.uri.path)) {
+                const parts = path.split('/');
+                parts.pop();
+                path = parts.join('/');
+                try {
+                    await workspace.fs.stat(Uri.file(path + '/tsconfig.json'));
+                    isTsProject = true;
+                } catch (e) {
+                    // continue
+                }
             }
-        } catch (e) {
-            return;
-        }
 
-        if (option === Option.Always) {
-            createPageEndpoint(file);
-            return;
-        }
-
-        const item = await window.showQuickPick(
-            [
-                { label: Option.Yes, detail: 'Create an endpoint for the page you just created' },
-                { label: Option.No, detail: 'Do nothing' },
-                {
-                    label: Option.Always,
-                    detail: 'Always automatically create an endpoint for the page you just created'
-                },
-                { label: Option.Never, detail: 'Do not ask again' }
-            ],
-            {
-                placeHolder: 'Create corresponding page endpoint?',
-                canPickMany: false
-            }
-        );
-        switch (item?.label) {
-            case Option.Always:
-                workspace.getConfiguration('svelte.kit').update('createEndpoints', Option.Always);
-                createPageEndpoint(file);
-                break;
-            case Option.Never:
-                workspace.getConfiguration('svelte.kit').update('createEndpoints', Option.Never);
-                break;
-            case Option.Yes:
-                createPageEndpoint(file);
-                break;
-        }
-    });
-}
-
-async function createPageEndpoint(file: Uri) {
-    const edit = new WorkspaceEdit();
-
-    let isTsProject = true;
-    try {
-        await workspace.fs.stat(Uri.file(file.path.split(routesPath)[0] + '/tsconfig.json'));
-    } catch (e) {
-        isTsProject = false;
-    }
-
-    const uri = Uri.file(file.path.slice(0, -'.svelte'.length) + (isTsProject ? '.ts' : '.js'));
-    edit.createFile(uri, {
-        overwrite: false,
-        ignoreIfExists: true
-    });
-    const fileName = file.path.split('/').pop()!.slice(0, -'.svelte'.length);
-    edit.insert(
-        uri,
-        new Position(0, 0),
-        isTsProject
-            ? `import type { RequestHandler } from './${fileName}.d';
+            // Create page endpoint file
+            const edit = new WorkspaceEdit();
+            const uri = Uri.file(
+                file.path.slice(0, -'.svelte'.length) + (isTsProject ? '.ts' : '.js')
+            );
+            edit.createFile(uri, {
+                overwrite: false,
+                ignoreIfExists: true
+            });
+            const fileName = file.path.split('/').pop()!.slice(0, -'.svelte'.length);
+            edit.insert(
+                uri,
+                new Position(0, 0),
+                isTsProject
+                    ? `import type { RequestHandler } from './${fileName}.d';
 
 export const get: RequestHandler = async () => {
 
 }
 `
-            : `/** @type {import('./${fileName}').RequestHandler} */
+                    : `/** @type {import('./${fileName}').RequestHandler} */
 export async function get() {
 
 }
 `
+            );
+            workspace.applyEdit(edit);
+        })
     );
-
-    workspace.applyEdit(edit);
 }

--- a/packages/svelte-vscode/src/sveltekit.ts
+++ b/packages/svelte-vscode/src/sveltekit.ts
@@ -1,0 +1,71 @@
+// SvelteKit related features go here
+
+import { Position, Uri, window, workspace, WorkspaceEdit } from 'vscode';
+
+const routesPath = '/src/routes'; // TODO can be configured, read svelte.config.js https://kit.svelte.dev/docs/configuration
+
+export function addPageEndpointsPrompt() {
+    workspace.onDidCreateFiles(async (e) => {
+        const files = e.files.filter(
+            (file) => file.path.includes(routesPath) && file.path.endsWith('.svelte')
+        );
+        if (!files.length) {
+            return;
+        }
+
+        const item = await window.showQuickPick(['Yes', 'No', 'Always', 'Never'], {
+            placeHolder: 'Create corresponding page endpoint?',
+            canPickMany: false
+        });
+        switch (item) {
+            case 'Always':
+                workspace.getConfiguration('svelte.kit').update('createEndpoints', 'Always');
+                createPageEndpoint(files);
+                break;
+            case 'Never':
+                workspace.getConfiguration('svelte.kit').update('createEndpoints', 'Never');
+                break;
+            case 'Yes':
+                createPageEndpoint(files);
+                break;
+        }
+    });
+}
+
+async function createPageEndpoint(files: Uri[]) {
+    const edit = new WorkspaceEdit();
+
+    for (const file of files) {
+        let isTsProject = true;
+        try {
+            await workspace.fs.stat(Uri.file(file.path.split(routesPath)[0] + '/tsconfig.json'));
+        } catch (e) {
+            isTsProject = false;
+        }
+
+        const uri = Uri.file(file.path.slice(0, -'.svelte'.length) + (isTsProject ? '.ts' : '.js'));
+        edit.createFile(uri, {
+            overwrite: false,
+            ignoreIfExists: true
+        });
+        const fileName = file.path.split('/').pop()!.slice(0, -'.svelte'.length);
+        edit.insert(
+            uri,
+            new Position(0, 0),
+            isTsProject
+                ? `import type { RequestHandler } from './${fileName}.d';
+
+export async function get() {
+
+}
+`
+                : `/** @type {import('./${fileName}').RequestHandler} */
+export async function get() {
+
+}
+`
+        );
+    }
+
+    workspace.applyEdit(edit);
+}


### PR DESCRIPTION
Adds a prompt that shows up when adding a new route to a SvelteKit app, which generates a corresponding page endpoint file.

TODO
- [x] find out if this is really a SvelteKit app (check package.json)
- [ ] read svelte.config.js because people can customize the routes folder (?) (maybe later, not sure how feasible this is since we need to read a JS file)
- [x] finish always/never handling

Questions:
- UX ok? Is a info window in the lower right better?
- Should the page endpoint boiler plate be customizable?
