### PR TITLE
(fix) sourcemap reference locations when the definition is in a ts file

### DIFF
--- a/packages/typescript-plugin/src/language-service/find-references.ts
+++ b/packages/typescript-plugin/src/language-service/find-references.ts
@@ -24,7 +24,10 @@ function _decorateFindReferences(
             ?.map((reference) => {
                 const snapshot = snapshotManager.get(reference.definition.fileName);
                 if (!isSvelteFilePath(reference.definition.fileName) || !snapshot) {
-                    return reference;
+                    return {
+                        ...reference,
+                        references: mapReferences(reference.references, snapshotManager, logger)
+                    };
                 }
 
                 const textSpan = snapshot.getOriginalTextSpan(reference.definition.textSpan);


### PR DESCRIPTION
#1480 this mainly happened with object members. because they won't be aliased when imported. We should still sourcemap the reference location. 