### PR TITLE
(chore) add debugger config for ts plugin

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,10 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/packages/svelte-vscode/dist/**/*.js"],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "npm: watch",
+            "env": {
+                "TSS_DEBUG": "5859"
+            }
         },
         {
             "type": "node",
@@ -51,6 +54,14 @@
                 "${workspaceRoot}/packages/language-server/dist/**/*.js",
                 "${workspaceRoot}/packages/svelte2tsx/index.js"
             ],
+            "skipFiles": ["<node_internals>/**"]
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach debugger to typescript plugin",
+            "port": 5859,
+            "outFiles": ["${workspaceRoot}/packages/typescript-plugin/dist/**/*.js"],
             "skipFiles": ["<node_internals>/**"]
         }
     ]

--- a/packages/typescript-plugin/.npmignore
+++ b/packages/typescript-plugin/.npmignore
@@ -4,3 +4,4 @@ tsconfig.json
 .gitignore
 internal.md
 dist/tsconfig.tsbuildinfo
+dist/**/*.map

--- a/packages/typescript-plugin/tsconfig.json
+++ b/packages/typescript-plugin/tsconfig.json
@@ -6,7 +6,7 @@
         "strict": true,
         "declaration": true,
         "outDir": "dist",
-        "sourceMap": false,
+        "sourceMap": true,
         "composite": true
     },
     "include": ["./src/**/*"],


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/wiki/Debugging-Language-Service-in-VS-Code#debugging-tsserver-server-side

added an environment variable for the tsserver to launch with inspector enabled when we launch extension for debugging. So we can attach a debugger like what we did for language-server. Do we want to keep the sourcemap in the published plugin? If not, we might need to create another tsconfig to distinguish. 