### PR TITLE
(chore) bumps typescript to 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "prettier --check . && eslint \"packages/**/*.{ts,js}\""
     },
     "dependencies": {
-        "typescript": "^4.6.2"
+        "typescript": "^4.7.2"
     },
     "devDependencies": {
         "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.2.0",

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -50,7 +50,7 @@ import {
 } from '../interfaces';
 import { CodeActionsProviderImpl } from './features/CodeActionsProvider';
 import {
-    CompletionEntryWithIdentifer,
+    CompletionEntryWithIdentifier,
     CompletionsProviderImpl
 } from './features/CompletionProvider';
 import { DiagnosticsProviderImpl } from './features/DiagnosticsProvider';
@@ -91,7 +91,7 @@ export class TypeScriptPlugin
         ImplementationProvider,
         TypeDefinitionProvider,
         OnWatchFileChanges,
-        CompletionsProvider<CompletionEntryWithIdentifer>,
+        CompletionsProvider<CompletionEntryWithIdentifier>,
         UpdateTsOrJsFile
 {
     __name = 'ts';
@@ -273,7 +273,7 @@ export class TypeScriptPlugin
         position: Position,
         completionContext?: CompletionContext,
         cancellationToken?: CancellationToken
-    ): Promise<AppCompletionList<CompletionEntryWithIdentifer> | null> {
+    ): Promise<AppCompletionList<CompletionEntryWithIdentifier> | null> {
         if (!this.featureEnabled('completions')) {
             return null;
         }
@@ -303,9 +303,9 @@ export class TypeScriptPlugin
 
     async resolveCompletion(
         document: Document,
-        completionItem: AppCompletionItem<CompletionEntryWithIdentifer>,
+        completionItem: AppCompletionItem<CompletionEntryWithIdentifier>,
         cancellationToken?: CancellationToken
-    ): Promise<AppCompletionItem<CompletionEntryWithIdentifer>> {
+    ): Promise<AppCompletionItem<CompletionEntryWithIdentifier>> {
         return this.completionProvider.resolveCompletion(
             document,
             completionItem,

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -142,10 +142,10 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                             mapRangeToOriginal(fragment, convertRange(fragment, edit.span))
                         );
 
-                        return this.fixIndentationOfImports(TextEdit.replace(
-                            range,
-                            edit.newText
-                        ), document);
+                        return this.fixIndentationOfImports(
+                            TextEdit.replace(range, edit.newText),
+                            document
+                        );
                     })
                 );
             })
@@ -177,7 +177,9 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
             return edit;
         }
 
-        const fixedNewText = modifyLines(edit.newText, (line, idx) => (idx === 0 || !line ? line : leadingChars + line));
+        const fixedNewText = modifyLines(edit.newText, (line, idx) =>
+            idx === 0 || !line ? line : leadingChars + line
+        );
 
         if (range.end.character > 0) {
             const endLine = getLineAtPosition(range.start, document.getText());

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -39,7 +39,7 @@ import {
 import { getJsDocTemplateCompletion } from './getJsDocTemplateCompletion';
 import { getComponentAtPosition, isPartOfImportStatement } from './utils';
 
-export interface CompletionEntryWithIdentifer extends ts.CompletionEntry, TextDocumentIdentifier {
+export interface CompletionEntryWithIdentifier extends ts.CompletionEntry, TextDocumentIdentifier {
     position: Position;
 }
 
@@ -48,10 +48,10 @@ type validTriggerCharacter = '.' | '"' | "'" | '`' | '/' | '@' | '<' | '#';
 type LastCompletion = {
     key: string;
     position: Position;
-    completionList: AppCompletionList<CompletionEntryWithIdentifer> | null;
+    completionList: AppCompletionList<CompletionEntryWithIdentifier> | null;
 };
 
-export class CompletionsProviderImpl implements CompletionsProvider<CompletionEntryWithIdentifer> {
+export class CompletionsProviderImpl implements CompletionsProvider<CompletionEntryWithIdentifier> {
     constructor(
         private readonly lsAndTsDocResolver: LSAndTSDocResolver,
         private readonly configManager: LSConfigManager
@@ -79,7 +79,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         position: Position,
         completionContext?: CompletionContext,
         cancellationToken?: CancellationToken
-    ): Promise<AppCompletionList<CompletionEntryWithIdentifer> | null> {
+    ): Promise<AppCompletionList<CompletionEntryWithIdentifier> | null> {
         if (isInTag(position, document.styleInfo)) {
             return null;
         }
@@ -251,7 +251,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         tsDoc: SvelteDocumentSnapshot,
         originalPosition: Position,
         wordRange: { start: number; end: number }
-    ): Array<AppCompletionItem<CompletionEntryWithIdentifer>> {
+    ): Array<AppCompletionItem<CompletionEntryWithIdentifier>> {
         const componentInfo = getComponentAtPosition(lang, doc, tsDoc, originalPosition);
         if (!componentInfo) {
             return [];
@@ -285,7 +285,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         uri: string,
         position: Position,
         existingImports: Set<string>
-    ): AppCompletionItem<CompletionEntryWithIdentifer> | null {
+    ): AppCompletionItem<CompletionEntryWithIdentifier> | null {
         const completionLabelAndInsert = this.getCompletionLabelAndInsert(fragment, comp);
         if (!completionLabelAndInsert) {
             return null;
@@ -435,9 +435,9 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
 
     async resolveCompletion(
         document: Document,
-        completionItem: AppCompletionItem<CompletionEntryWithIdentifer>,
+        completionItem: AppCompletionItem<CompletionEntryWithIdentifier>,
         cancellationToken?: CancellationToken
-    ): Promise<AppCompletionItem<CompletionEntryWithIdentifer>> {
+    ): Promise<AppCompletionItem<CompletionEntryWithIdentifier>> {
         const { data: comp } = completionItem;
         const { tsDoc, lang, userPreferences } = await this.lsAndTsDocResolver.getLSAndTSDoc(
             document

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -863,8 +863,7 @@ function test(useNewTransformation: boolean) {
                             {
                                 edits: [
                                     {
-                                        newText:
-                                            "import { } from './t.png';\n",
+                                        newText: "import { } from './t.png';\n",
                                         range: {
                                             end: {
                                                 character: 0,

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -864,12 +864,10 @@ function test(useNewTransformation: boolean) {
                                 edits: [
                                     {
                                         newText:
-                                            '// @ts-ignore\n' +
-                                            "    import { } from './somepng.png';\n" +
-                                            "    import { } from './t.png';\n",
+                                            "import { } from './t.png';\n",
                                         range: {
                                             end: {
-                                                character: 4,
+                                                character: 0,
                                                 line: 2
                                             },
                                             start: {
@@ -879,7 +877,7 @@ function test(useNewTransformation: boolean) {
                                         }
                                     },
                                     {
-                                        newText: '',
+                                        newText: "import { } from './somepng.png';\n",
                                         range: {
                                             end: {
                                                 character: 0,
@@ -887,7 +885,7 @@ function test(useNewTransformation: boolean) {
                                             },
                                             start: {
                                                 character: 4,
-                                                line: 2
+                                                line: 3
                                             }
                                         }
                                     }

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -17,7 +17,7 @@ import {
 } from 'vscode-languageserver';
 import {
     CompletionsProviderImpl,
-    CompletionEntryWithIdentifer
+    CompletionEntryWithIdentifier
 } from '../../../../src/plugins/typescript/features/CompletionProvider';
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { sortBy } from 'lodash';
@@ -466,6 +466,7 @@ function test(useNewTransformation: boolean) {
                 isSnippet: undefined,
                 kind: 'method',
                 kindModifiers: '',
+                labelDetails: undefined,
                 name: 'b',
                 position: {
                     character: 49,
@@ -476,7 +477,7 @@ function test(useNewTransformation: boolean) {
                 source: undefined,
                 sourceDisplay: undefined,
                 uri: fileNameToAbsoluteUri(filename)
-            } as CompletionEntryWithIdentifer);
+            } as CompletionEntryWithIdentifier);
         });
 
         it('resolve completion and provide documentation', async () => {

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/organize-imports-leading-comment.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/organize-imports-leading-comment.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { } from './t.png';
+    import { } from './t.png'
     // @ts-ignore
-    import { } from './somepng.png';
+    import { } from './somepng.png'
 </script>

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -37,7 +37,7 @@
         "svelte": "~3.48.0",
         "tiny-glob": "^0.2.6",
         "tslib": "^1.10.0",
-        "typescript": "^4.6.2"
+        "typescript": "^4.7.2"
     },
     "peerDependencies": {
         "svelte": "^3.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,10 +2634,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@*, typescript@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+typescript@*, typescript@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
+  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
Draft for now as it seems like the string literal prop completion is broken. From my debugging, it seems like typescript now looks at the first argument of the component class construtor instead of the `JSX.ElementAttributesProperty`. Since we plan to switch to the new transformation, not sure if it's still worth the effort to ask the typescript team to support it. 