### PR TITLE
(fix) don't organize imports in error state

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -103,7 +103,10 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
         const { lang, tsDoc, userPreferences } = await this.getLSAndTSDoc(document);
         const fragment = tsDoc.getFragment();
 
-        if (cancellationToken?.isCancellationRequested) {
+        if (cancellationToken?.isCancellationRequested || tsDoc.parserError) {
+            // If there's a parser error, we fall back to only the script contents,
+            // so organize imports likely throws out a lot of seemingly unused imports
+            // because they are only used in the template. Therefore do nothing in this case.
             return [];
         }
 

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -905,6 +905,21 @@ function test(useNewTransformation: boolean) {
             ]);
         });
 
+        it('organize imports should do nothing if there is a parser error', async () => {
+            const { provider, document } = setup('organize-imports-error.svelte');
+
+            const codeActions = await provider.getCodeActions(
+                document,
+                Range.create(Position.create(1, 4), Position.create(1, 5)),
+                {
+                    diagnostics: [],
+                    only: [CodeActionKind.SourceOrganizeImports]
+                }
+            );
+
+            assert.deepStrictEqual(codeActions, []);
+        });
+
         it('should do extract into const refactor', async () => {
             const { provider, document } = setup('codeactions.svelte');
 


### PR DESCRIPTION
If there's a parser error, we fall back to only the script contents, so organize imports likely throws out a lot of seemingly unused imports because they are only used in the template. Therefore do nothing in this case.
#1476