### PR TITLE
(feat) support node16/nodenext

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "prettier --check . && eslint \"packages/**/*.{ts,js}\""
     },
     "dependencies": {
-        "typescript": "^4.7.2"
+        "typescript": "^4.7.3"
     },
     "devDependencies": {
         "@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.2.0",

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -70,11 +70,10 @@ class ModuleResolutionCache {
 }
 
 class ImpliedNodeFormatResolver {
-    private alreadyResolved = new Map<string, ReturnType<typeof ts.getModeForFileReference>>();
+    private alreadyResolved = new Map<string, ReturnType<typeof ts.getModeForResolutionAtIndex>>();
 
     resolve(
-        to: string,
-        indexInSourceFile: number,
+        importIdxInFile: number,
         sourceFile: ts.SourceFile | undefined,
         compilerOptions: ts.CompilerOptions
     ) {
@@ -96,7 +95,7 @@ class ImpliedNodeFormatResolver {
                     sourceFile.impliedNodeFormat = this.alreadyResolved.get(sourceFile.fileName);
                 }
             }
-            mode = ts.getModeForResolutionAtIndex(sourceFile, indexInSourceFile);
+            mode = ts.getModeForResolutionAtIndex(sourceFile, importIdxInFile);
         }
         return mode;
     }
@@ -168,7 +167,6 @@ export function createSvelteModuleLoader(
         index: number
     ): ts.ResolvedModule | undefined {
         const mode = impliedNodeFormatResolver.resolve(
-            name,
             index,
             containingSourceFile,
             compilerOptions

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -292,8 +292,6 @@ async function createLanguageService(
         const forcedCompilerOptions: ts.CompilerOptions = {
             allowNonTsExtensions: true,
             target: ts.ScriptTarget.Latest,
-            module: ts.ModuleKind.ESNext,
-            moduleResolution: ts.ModuleResolutionKind.NodeJs,
             allowJs: true,
             noEmit: true,
             declaration: false,
@@ -344,6 +342,25 @@ async function createLanguageService(
             ...parsedConfig.options,
             ...forcedCompilerOptions
         };
+        if (
+            !compilerOptions.moduleResolution ||
+            compilerOptions.moduleResolution === ts.ModuleResolutionKind.Classic
+        ) {
+            compilerOptions.moduleResolution = ts.ModuleResolutionKind.NodeJs;
+        }
+        if (
+            !compilerOptions.module ||
+            [
+                ts.ModuleKind.AMD,
+                ts.ModuleKind.CommonJS,
+                ts.ModuleKind.ES2015,
+                ts.ModuleKind.None,
+                ts.ModuleKind.System,
+                ts.ModuleKind.UMD
+            ].includes(compilerOptions.module)
+        ) {
+            compilerOptions.module = ts.ModuleKind.ESNext;
+        }
 
         // detect which JSX namespace to use (svelte | svelteNative) if not specified or not compatible
         if (!compilerOptions.jsxFactory || !compilerOptions.jsxFactory.startsWith('svelte')) {

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -76,6 +76,10 @@ export function toRealSvelteFilePath(filePath: string) {
     return filePath.slice(0, -'.ts'.length);
 }
 
+export function toVirtualSvelteFilePath(filePath: string) {
+    return filePath.endsWith('.ts') ? filePath : filePath + '.ts';
+}
+
 export function ensureRealSvelteFilePath(filePath: string) {
     return isVirtualSvelteFilePath(filePath) ? toRealSvelteFilePath(filePath) : filePath;
 }

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/bar.js
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/bar.js
@@ -1,0 +1,2 @@
+export const foo = true;
+export const baz = true;

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/expected.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/expected.json
@@ -1,0 +1,10 @@
+[
+    {
+        "range": { "start": { "line": 4, "character": 22 }, "end": { "line": 4, "character": 29 } },
+        "severity": 1,
+        "source": "ts",
+        "message": "Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './bar.js'?",
+        "code": 2835,
+        "tags": []
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/expectedv2.json
@@ -1,0 +1,10 @@
+[
+    {
+        "range": { "start": { "line": 4, "character": 22 }, "end": { "line": 4, "character": 29 } },
+        "severity": 1,
+        "source": "ts",
+        "message": "Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './bar.js'?",
+        "code": 2835,
+        "tags": []
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/input.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  // valid
+  import { foo } from './bar.js';
+  // invalid
+  import { baz } from './bar';
+
+  foo;baz;
+</script>

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/package.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/tsconfig.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/node16/tsconfig.json
@@ -1,11 +1,12 @@
 {
     "compilerOptions": {
-        "strict": true,
+        "allowJs": true,
+        "module": "Node16",
+        "moduleResolution": "Node16",
         /**
           This is actually not needed, but makes the tests faster
           because TS does not look up other types.
         */
         "types": ["svelte"]
-    },
-    "exclude": ["./svelte-native/**/*", "./node16/**/*"]
+    }
 }

--- a/packages/language-server/test/plugins/typescript/module-loader.test.ts
+++ b/packages/language-server/test/plugins/typescript/module-loader.test.ts
@@ -47,7 +47,10 @@ describe('createSvelteModuleLoader', () => {
         const { resolveStub, moduleResolver, compilerOptions } = setup(resolvedModule);
         const result = moduleResolver.resolveModuleNames(
             ['./normal.ts'],
-            'C:/somerepo/somefile.svelte'
+            'C:/somerepo/somefile.svelte',
+            undefined,
+            undefined,
+            undefined as any
         );
 
         assert.deepStrictEqual(result, [resolvedModule]);
@@ -55,7 +58,10 @@ describe('createSvelteModuleLoader', () => {
             './normal.ts',
             'C:/somerepo/somefile.svelte',
             compilerOptions,
-            ts.sys
+            ts.sys,
+            undefined,
+            undefined,
+            undefined
         ]);
     });
 
@@ -67,7 +73,10 @@ describe('createSvelteModuleLoader', () => {
         const { resolveStub, moduleResolver, compilerOptions } = setup(resolvedModule);
         const result = moduleResolver.resolveModuleNames(
             ['/@/normal'],
-            'C:/somerepo/somefile.svelte'
+            'C:/somerepo/somefile.svelte',
+            undefined,
+            undefined,
+            undefined as any
         );
 
         assert.deepStrictEqual(result, [resolvedModule]);
@@ -75,7 +84,10 @@ describe('createSvelteModuleLoader', () => {
             '/@/normal',
             'C:/somerepo/somefile.svelte',
             compilerOptions,
-            ts.sys
+            ts.sys,
+            undefined,
+            undefined,
+            undefined
         ]);
     });
 
@@ -87,7 +99,10 @@ describe('createSvelteModuleLoader', () => {
         const { resolveStub, moduleResolver, compilerOptions } = setup(resolvedModule);
         const result = moduleResolver.resolveModuleNames(
             ['./normal.ts'],
-            'C:/somerepo/somefile.svelte'
+            'C:/somerepo/somefile.svelte',
+            undefined,
+            undefined,
+            undefined as any
         );
 
         assert.deepStrictEqual(result, [resolvedModule]);
@@ -95,7 +110,10 @@ describe('createSvelteModuleLoader', () => {
             './normal.ts',
             'C:/somerepo/somefile.svelte',
             compilerOptions,
-            ts.sys
+            ts.sys,
+            undefined,
+            undefined,
+            undefined
         ]);
     });
 
@@ -108,7 +126,10 @@ describe('createSvelteModuleLoader', () => {
             setup(resolvedModule);
         const result = moduleResolver.resolveModuleNames(
             ['./svelte.svelte'],
-            'C:/somerepo/somefile.svelte'
+            'C:/somerepo/somefile.svelte',
+            undefined,
+            undefined,
+            undefined as any
         );
 
         assert.deepStrictEqual(result, [
@@ -122,7 +143,10 @@ describe('createSvelteModuleLoader', () => {
             './svelte.svelte',
             'C:/somerepo/somefile.svelte',
             compilerOptions,
-            svelteSys
+            svelteSys,
+            undefined,
+            undefined,
+            undefined
         ]);
         assert.deepStrictEqual(lastCall(getSvelteSnapshotStub).args, ['filename.svelte']);
     });
@@ -136,7 +160,10 @@ describe('createSvelteModuleLoader', () => {
             setup(resolvedModule);
         const result = moduleResolver.resolveModuleNames(
             ['/@/svelte.svelte'],
-            'C:/somerepo/somefile.svelte'
+            'C:/somerepo/somefile.svelte',
+            undefined,
+            undefined,
+            undefined as any
         );
 
         assert.deepStrictEqual(result, [
@@ -150,7 +177,10 @@ describe('createSvelteModuleLoader', () => {
             '/@/svelte.svelte',
             'C:/somerepo/somefile.svelte',
             compilerOptions,
-            svelteSys
+            svelteSys,
+            undefined,
+            undefined,
+            undefined
         ]);
         assert.deepStrictEqual(lastCall(getSvelteSnapshotStub).args, ['filename.svelte']);
     });
@@ -162,11 +192,20 @@ describe('createSvelteModuleLoader', () => {
         };
         const { resolveStub, moduleResolver } = setup(resolvedModule);
         // first call
-        moduleResolver.resolveModuleNames(['./normal.ts'], 'C:/somerepo/somefile.svelte');
+        moduleResolver.resolveModuleNames(
+            ['./normal.ts'],
+            'C:/somerepo/somefile.svelte',
+            undefined,
+            undefined,
+            undefined as any
+        );
         // second call, which should be from cache
         const result = moduleResolver.resolveModuleNames(
             ['./normal.ts'],
-            'C:/somerepo/somefile.svelte'
+            'C:/somerepo/somefile.svelte',
+            undefined,
+            undefined,
+            undefined as any
         );
 
         assert.deepStrictEqual(result, [resolvedModule]);

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -37,7 +37,7 @@
         "svelte": "~3.48.0",
         "tiny-glob": "^0.2.6",
         "tslib": "^1.10.0",
-        "typescript": "^4.7.2"
+        "typescript": "^4.7.3"
     },
     "peerDependencies": {
         "svelte": "^3.24",

--- a/packages/typescript-plugin/src/module-loader.ts
+++ b/packages/typescript-plugin/src/module-loader.ts
@@ -88,7 +88,8 @@ export function patchModuleLoader(
         containingFile: string,
         reusedNames: string[] | undefined,
         redirectedReference: ts.ResolvedProjectReference | undefined,
-        compilerOptions: ts.CompilerOptions
+        compilerOptions: ts.CompilerOptions,
+        containingSourceFile?: ts.SourceFile
     ): Array<ts.ResolvedModule | undefined> {
         logger.log('Resolving modules names for ' + containingFile);
         // Try resolving all module names with the original method first.
@@ -101,7 +102,8 @@ export function patchModuleLoader(
                 containingFile,
                 reusedNames,
                 redirectedReference,
-                compilerOptions
+                compilerOptions,
+                containingSourceFile
             ) || Array.from<undefined>(Array(moduleNames.length));
 
         if (!configManager.getConfig().enable) {

--- a/packages/typescript-plugin/src/module-loader.ts
+++ b/packages/typescript-plugin/src/module-loader.ts
@@ -130,6 +130,10 @@ export function patchModuleLoader(
         containingFile: string,
         compilerOptions: ts.CompilerOptions
     ): ts.ResolvedModule | undefined {
+        // If we were to do this correctly, we'd need to check the module resolution mode for
+        // Node16/NodeNext in order to determine whether or not someone needs to have .js file
+        // endings in relative import paths. But because we don't do diagnostics within Svelte
+        // files in this TS plugin, we can ignore this and deal with some false positive resolutions
         const svelteResolvedModule = typescript.resolveModuleName(
             name,
             containingFile,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,10 +2634,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@*, typescript@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
-  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+typescript@*,typescript@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
+  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
#1522

Not sure how to test this, I thought that this would error if I leave out `.js` in imports but that's not the case, so I'm not sure if this is actually working. @jasonlyu123 @JuanM04 do you know more? Edit: Turns out that was an error on our part, we need to pass a new parameter to resolveModuleNames in the TypeScript plugin.

@JuanM04 would be great if you could test this out:
1. Check out this branch
2. Make sure you have yarn 1.x
3. yarn install
4. yarn bootstrap
5. go in language-server and run yarn build
6. go in svelte-check and run yarn build
7. copy over dist folder into your project (replace the dist folder of your existing svelte-check in your node_modules)