### PR TITLE
(feat) watch tsconfig and extended tsconfig

### DIFF
--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -82,7 +82,8 @@ export class LSAndTSDocResolver {
             notifyExceedSizeLimit: this.options?.notifyExceedSizeLimit,
             extendedConfigCache: this.extendedConfigCache,
             onProjectReloaded: this.options?.onProjectReloaded,
-            watchTsConfig: !!this.options?.watchTsConfig
+            watchTsConfig: !!this.options?.watchTsConfig,
+            tsSystem: ts.sys
         };
     }
 

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -65,6 +65,7 @@ export class LSAndTSDocResolver {
     };
 
     private globalSnapshotsManager = new GlobalSnapshotsManager();
+    private extendedConfigCache = new Map<string, ts.ExtendedConfigCacheEntry>();
 
     private get lsDocumentContext(): LanguageServiceDocumentContext {
         return {
@@ -73,7 +74,8 @@ export class LSAndTSDocResolver {
             useNewTransformation: this.configManager.getConfig().svelte.useNewTransformation,
             transformOnTemplateError: !this.isSvelteCheck,
             globalSnapshotsManager: this.globalSnapshotsManager,
-            notifyExceedSizeLimit: this.notifyExceedSizeLimit
+            notifyExceedSizeLimit: this.notifyExceedSizeLimit,
+            extendedConfigCache: this.extendedConfigCache
         };
     }
 

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -13,23 +13,27 @@ import {
 } from './service';
 import { GlobalSnapshotsManager, SnapshotManager } from './SnapshotManager';
 
-export class LSAndTSDocResolver {
+interface LSAndTSDocResolverOptions {
+    notifyExceedSizeLimit?: () => void;
     /**
-     *
-     * @param docManager
-     * @param workspaceUris
-     * @param configManager
-     * @param notifyExceedSizeLimit
-     * @param isSvelteCheck True, if used in the context of svelte-check
-     * @param tsconfigPath This should only be set via svelte-check. Makes sure all documents are resolved to that tsconfig. Has to be absolute.
+     * True, if used in the context of svelte-check
      */
+    isSvelteCheck?: boolean;
+
+    /**
+     * This should only be set via svelte-check. Makes sure all documents are resolved to that tsconfig. Has to be absolute.
+     */
+    tsconfigPath?: string;
+
+    onProjectReloaded?: () => void;
+}
+
+export class LSAndTSDocResolver {
     constructor(
         private readonly docManager: DocumentManager,
         private readonly workspaceUris: string[],
         private readonly configManager: LSConfigManager,
-        private readonly notifyExceedSizeLimit?: () => void,
-        private readonly isSvelteCheck = false,
-        private readonly tsconfigPath?: string
+        private readonly options?: LSAndTSDocResolverOptions
     ) {
         const handleDocumentChange = (document: Document) => {
             // This refreshes the document in the ts language service
@@ -69,13 +73,14 @@ export class LSAndTSDocResolver {
 
     private get lsDocumentContext(): LanguageServiceDocumentContext {
         return {
-            ambientTypesSource: this.isSvelteCheck ? 'svelte-check' : 'svelte2tsx',
+            ambientTypesSource: this.options?.isSvelteCheck ? 'svelte-check' : 'svelte2tsx',
             createDocument: this.createDocument,
             useNewTransformation: this.configManager.getConfig().svelte.useNewTransformation,
-            transformOnTemplateError: !this.isSvelteCheck,
+            transformOnTemplateError: !this.options?.isSvelteCheck,
             globalSnapshotsManager: this.globalSnapshotsManager,
-            notifyExceedSizeLimit: this.notifyExceedSizeLimit,
-            extendedConfigCache: this.extendedConfigCache
+            notifyExceedSizeLimit: this.options?.notifyExceedSizeLimit,
+            extendedConfigCache: this.extendedConfigCache,
+            onProjectReloaded: this.options?.onProjectReloaded
         };
     }
 
@@ -159,8 +164,8 @@ export class LSAndTSDocResolver {
     }
 
     async getTSService(filePath?: string): Promise<LanguageServiceContainer> {
-        if (this.tsconfigPath) {
-            return getServiceForTsconfig(this.tsconfigPath, this.lsDocumentContext);
+        if (this.options?.tsconfigPath) {
+            return getServiceForTsconfig(this.options?.tsconfigPath, this.lsDocumentContext);
         }
         if (!filePath) {
             throw new Error('Cannot call getTSService without filePath and without tsconfigPath');

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -26,6 +26,7 @@ interface LSAndTSDocResolverOptions {
     tsconfigPath?: string;
 
     onProjectReloaded?: () => void;
+    watchTsConfig?: boolean
 }
 
 export class LSAndTSDocResolver {
@@ -80,7 +81,8 @@ export class LSAndTSDocResolver {
             globalSnapshotsManager: this.globalSnapshotsManager,
             notifyExceedSizeLimit: this.options?.notifyExceedSizeLimit,
             extendedConfigCache: this.extendedConfigCache,
-            onProjectReloaded: this.options?.onProjectReloaded
+            onProjectReloaded: this.options?.onProjectReloaded,
+            watchTsConfig: !!this.options?.watchTsConfig
         };
     }
 

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -26,7 +26,7 @@ interface LSAndTSDocResolverOptions {
     tsconfigPath?: string;
 
     onProjectReloaded?: () => void;
-    watchTsConfig?: boolean
+    watchTsConfig?: boolean;
 }
 
 export class LSAndTSDocResolver {

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -69,6 +69,7 @@ export interface LanguageServiceDocumentContext {
     notifyExceedSizeLimit: (() => void) | undefined;
     extendedConfigCache: Map<string, ts.ExtendedConfigCacheEntry>;
     onProjectReloaded: (() => void) | undefined;
+    watchTsConfig: boolean;
 }
 
 export async function getService(
@@ -133,7 +134,7 @@ function updateExtendedConfigDependents(service: LanguageServiceContainer) {
 }
 
 function watchConfigFile(ls: LanguageServiceContainer, docContext: LanguageServiceDocumentContext) {
-    if (!ts.sys.watchFile) {
+    if (!ts.sys.watchFile || !docContext.watchTsConfig) {
         return;
     }
 

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -104,7 +104,7 @@ export async function getServiceForTsconfig(
         const reloading = pendingReloads.has(tsconfigPath);
 
         if (reloading) {
-            Logger.log('Reloading ts service at ', tsconfigPath, 'due to config updated');
+            Logger.log('Reloading ts service at ', tsconfigPath, ' due to config updated');
         } else {
             Logger.log('Initialize new ts service at ', tsconfigPath);
         }

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -68,6 +68,7 @@ export interface LanguageServiceDocumentContext {
     globalSnapshotsManager: GlobalSnapshotsManager;
     notifyExceedSizeLimit: (() => void) | undefined;
     extendedConfigCache: Map<string, ts.ExtendedConfigCacheEntry>;
+    onProjectReloaded: (() => void) | undefined;
 }
 
 export async function getService(

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -124,12 +124,16 @@ export function rangeToTextSpan(
     return { start, length: end - start };
 }
 
-export function findTsConfigPath(fileName: string, rootUris: string[]) {
+export function findTsConfigPath(
+    fileName: string,
+    rootUris: string[],
+    fileExists: (path: string) => boolean
+) {
     const searchDir = dirname(fileName);
 
     const path =
-        ts.findConfigFile(searchDir, ts.sys.fileExists, 'tsconfig.json') ||
-        ts.findConfigFile(searchDir, ts.sys.fileExists, 'jsconfig.json') ||
+        ts.findConfigFile(searchDir, fileExists, 'tsconfig.json') ||
+        ts.findConfigFile(searchDir, fileExists, 'jsconfig.json') ||
         '';
     // Don't return config files that exceed the current workspace context.
     return !!path && rootUris.some((rootUri) => isSubPath(rootUri, path)) ? path : '';

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -163,7 +163,8 @@ export function startServer(options?: LSOptions) {
                 configManager,
                 new LSAndTSDocResolver(docManager, workspaceUris.map(normalizeUri), configManager, {
                     notifyExceedSizeLimit: notifyTsServiceExceedSizeLimit,
-                    onProjectReloaded: updateAllDiagnostics
+                    onProjectReloaded: updateAllDiagnostics,
+                    watchTsConfig: true
                 })
             )
         );

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -161,12 +161,10 @@ export function startServer(options?: LSOptions) {
         pluginHost.register(
             new TypeScriptPlugin(
                 configManager,
-                new LSAndTSDocResolver(
-                    docManager,
-                    workspaceUris.map(normalizeUri),
-                    configManager,
-                    notifyTsServiceExceedSizeLimit
-                )
+                new LSAndTSDocResolver(docManager, workspaceUris.map(normalizeUri), configManager, {
+                    notifyExceedSizeLimit: notifyTsServiceExceedSizeLimit,
+                    onProjectReloaded: updateAllDiagnostics
+                })
             )
         );
 

--- a/packages/language-server/src/svelte-check.ts
+++ b/packages/language-server/src/svelte-check.ts
@@ -30,6 +30,8 @@ export interface SvelteCheckOptions {
      * Whether or not to use the new transformation of svelte2tsx
      */
     useNewTransformation?: boolean;
+    onProjectReload?: () => void;
+    watch?: boolean
 }
 
 /**
@@ -85,7 +87,9 @@ export class SvelteCheck {
                 this.configManager,
                 {
                     tsconfigPath: options.tsconfig,
-                    isSvelteCheck: true
+                    isSvelteCheck: true,
+                    onProjectReloaded: options.onProjectReload,
+                    watchTsConfig: options.watch
                 }
             );
             this.pluginHost.register(

--- a/packages/language-server/src/svelte-check.ts
+++ b/packages/language-server/src/svelte-check.ts
@@ -83,9 +83,10 @@ export class SvelteCheck {
                 this.docManager,
                 [pathToUrl(workspacePath)],
                 this.configManager,
-                undefined,
-                true,
-                options.tsconfig
+                {
+                    tsconfigPath: options.tsconfig,
+                    isSvelteCheck: true
+                }
             );
             this.pluginHost.register(
                 new TypeScriptPlugin(this.configManager, this.lsAndTSDocResolver)

--- a/packages/language-server/src/svelte-check.ts
+++ b/packages/language-server/src/svelte-check.ts
@@ -31,7 +31,7 @@ export interface SvelteCheckOptions {
      */
     useNewTransformation?: boolean;
     onProjectReload?: () => void;
-    watch?: boolean
+    watch?: boolean;
 }
 
 /**

--- a/packages/language-server/test/plugins/typescript/service.test.ts
+++ b/packages/language-server/test/plugins/typescript/service.test.ts
@@ -1,0 +1,272 @@
+import path from 'path';
+import assert from 'assert';
+import ts, { FileWatcherEventKind } from 'typescript';
+import { Document } from '../../../src/lib/documents';
+import {
+    getService,
+    LanguageServiceDocumentContext
+} from '../../../src/plugins/typescript/service';
+import { GlobalSnapshotsManager } from '../../../src/plugins/typescript/SnapshotManager';
+import { normalizePath, pathToUrl } from '../../../src/utils';
+
+describe('service', () => {
+    const testDir = path.join(__dirname, 'testfiles');
+
+    function setup() {
+        const virtualFs = new Map<string, string>();
+        // array behave more similar to the actual fs event than Set
+        const watchers = new Map<string, ts.FileWatcherCallback[]>();
+        const watchTimeout = new Map<string, Array<ReturnType<typeof setTimeout>>>();
+
+        const virtualSystem: ts.System = {
+            ...ts.sys,
+            writeFile(path, data) {
+                const normalizedPath = normalizePath(path);
+                const existsBefore = virtualFs.has(normalizedPath);
+                virtualFs.set(normalizedPath, data);
+                triggerWatch(
+                    normalizedPath,
+                    existsBefore ? ts.FileWatcherEventKind.Changed : ts.FileWatcherEventKind.Created
+                );
+            },
+            readFile(path) {
+                return virtualFs.get(normalizePath(path));
+            },
+            fileExists(path) {
+                return virtualFs.has(normalizePath(path));
+            },
+            deleteFile(path) {
+                const normalizedPath = normalizePath(path);
+                const existsBefore = virtualFs.has(normalizedPath);
+                virtualFs.delete(normalizedPath);
+
+                if (existsBefore) {
+                    triggerWatch(normalizedPath, ts.FileWatcherEventKind.Deleted);
+                }
+            },
+            watchFile(path, callback) {
+                const normalizedPath = normalizePath(path);
+                let watchersOfPath = watchers.get(normalizedPath);
+
+                if (!watchersOfPath) {
+                    watchersOfPath = [];
+                    watchers.set(normalizedPath, watchersOfPath);
+                }
+
+                watchersOfPath.push(callback);
+
+                return {
+                    close() {
+                        const watchersOfPath = watchers.get(normalizedPath);
+
+                        if (watchersOfPath) {
+                            watchers.set(
+                                normalizedPath,
+                                watchersOfPath.filter((watcher) => watcher === callback)
+                            );
+                        }
+
+                        const timeouts = watchTimeout.get(normalizedPath);
+
+                        if (timeouts != null) {
+                            timeouts.forEach((timeout) => clearTimeout(timeout));
+                        }
+                    }
+                };
+            }
+        };
+
+        const lsDocumentContext: LanguageServiceDocumentContext = {
+            ambientTypesSource: 'svelte2tsx',
+            createDocument(fileName, content) {
+                return new Document(pathToUrl(fileName), content);
+            },
+            extendedConfigCache: new Map(),
+            globalSnapshotsManager: new GlobalSnapshotsManager(),
+            transformOnTemplateError: true,
+            tsSystem: virtualSystem,
+            useNewTransformation: true,
+            watchTsConfig: false,
+            notifyExceedSizeLimit: undefined,
+            onProjectReloaded: undefined
+        };
+
+        const rootUris = [pathToUrl(testDir)];
+
+        return { virtualSystem, lsDocumentContext, rootUris };
+
+        function triggerWatch(normalizedPath: string, kind: FileWatcherEventKind) {
+            let timeoutsOfPath = watchTimeout.get(normalizedPath);
+
+            if (!timeoutsOfPath) {
+                timeoutsOfPath = [];
+                watchTimeout.set(normalizedPath, timeoutsOfPath);
+            }
+
+            timeoutsOfPath.push(
+                setTimeout(
+                    () =>
+                        watchers
+                            .get(normalizedPath)
+                            ?.forEach((callback) => callback(normalizedPath, kind)),
+                    0
+                )
+            );
+        }
+    }
+
+    function getRandomVirtualDirPath() {
+        return path.join(testDir, `virtual-path-${Math.floor(Math.random() * 100_000)}`);
+    }
+
+    it('can find tsconfig and override with default config', async () => {
+        const dirPath = getRandomVirtualDirPath();
+        const { virtualSystem, lsDocumentContext, rootUris } = setup();
+
+        virtualSystem.writeFile(
+            path.join(dirPath, 'tsconfig.json'),
+            JSON.stringify({
+                compilerOptions: <ts.CompilerOptions>{
+                    checkJs: true,
+                    strict: true
+                }
+            })
+        );
+
+        const ls = await getService(
+            path.join(dirPath, 'random.svelte'),
+            rootUris,
+            lsDocumentContext
+        );
+
+        // ts internal
+        delete ls.compilerOptions.configFilePath;
+
+        assert.deepStrictEqual(ls.compilerOptions, <ts.CompilerOptions>{
+            allowJs: true,
+            allowNonTsExtensions: true,
+            checkJs: true,
+            strict: true,
+            declaration: false,
+            module: ts.ModuleKind.ESNext,
+            moduleResolution: ts.ModuleResolutionKind.NodeJs,
+            noEmit: true,
+            skipLibCheck: true,
+            target: ts.ScriptTarget.ESNext
+        });
+    });
+
+    function createReloadTester(
+        docContext: LanguageServiceDocumentContext,
+        testAfterReload: () => Promise<void>
+    ) {
+        let _resolve: () => void;
+        const reloadPromise = new Promise<void>((resolve) => {
+            _resolve = resolve;
+        });
+
+        return {
+            docContextWithReload: {
+                ...docContext,
+                async onProjectReloaded() {
+                    try {
+                        await testAfterReload();
+                    } finally {
+                        _resolve();
+                    }
+                }
+            },
+            reloadPromise
+        };
+    }
+
+    it('can watch tsconfig', async () => {
+        const dirPath = getRandomVirtualDirPath();
+        const { virtualSystem, lsDocumentContext, rootUris } = setup();
+        const tsconfigPath = path.join(dirPath, 'tsconfig.json');
+
+        virtualSystem.writeFile(
+            tsconfigPath,
+            JSON.stringify({
+                compilerOptions: <ts.CompilerOptions>{
+                    strict: false
+                }
+            })
+        );
+
+        const { reloadPromise, docContextWithReload } = createReloadTester(
+            { ...lsDocumentContext, watchTsConfig: true },
+            testAfterReload
+        );
+
+        await getService(path.join(dirPath, 'random.svelte'), rootUris, docContextWithReload);
+
+        virtualSystem.writeFile(
+            tsconfigPath,
+            JSON.stringify({
+                compilerOptions: <ts.CompilerOptions>{
+                    strict: true
+                }
+            })
+        );
+
+        await reloadPromise;
+
+        async function testAfterReload() {
+            const newLs = await getService(path.join(dirPath, 'random.svelte'), rootUris, {
+                ...lsDocumentContext,
+                watchTsConfig: true
+            });
+            assert.strictEqual(
+                newLs.compilerOptions.strict,
+                true,
+                'expected to reload compilerOptions'
+            );
+        }
+    });
+
+    it('can watch extended tsconfig', async () => {
+        const dirPath = getRandomVirtualDirPath();
+        const { virtualSystem, lsDocumentContext, rootUris } = setup();
+        const tsconfigPath = path.join(dirPath, 'tsconfig.json');
+        const extend = './.svelte-kit/tsconfig.json';
+        const extendedConfigPathFull = path.resolve(tsconfigPath, extend);
+
+        virtualSystem.writeFile(
+            tsconfigPath,
+            JSON.stringify({
+                extends: extend
+            })
+        );
+
+        const { reloadPromise, docContextWithReload } = createReloadTester(
+            { ...lsDocumentContext, watchTsConfig: true },
+            testAfterReload
+        );
+
+        await getService(path.join(dirPath, 'random.svelte'), rootUris, docContextWithReload);
+
+        virtualSystem.writeFile(
+            extendedConfigPathFull,
+            JSON.stringify({
+                compilerOptions: <ts.CompilerOptions>{
+                    strict: true
+                }
+            })
+        );
+
+        await reloadPromise;
+
+        async function testAfterReload() {
+            const newLs = await getService(path.join(dirPath, 'random.svelte'), rootUris, {
+                ...lsDocumentContext,
+                watchTsConfig: true
+            });
+            assert.strictEqual(
+                newLs.compilerOptions.strict,
+                true,
+                'expected to reload compilerOptions'
+            );
+        }
+    });
+});

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -182,8 +182,8 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
         const parts = doc.uri.toString(true).split(/\/|\\/);
         if (
             [
-                /^tsconfig\.json$/,
-                /^jsconfig\.json$/,
+                // /^tsconfig\.json$/,
+                // /^jsconfig\.json$/,
                 /^svelte\.config\.(js|cjs|mjs)$/,
                 // https://prettier.io/docs/en/configuration.html
                 /^\.prettierrc$/,


### PR DESCRIPTION
#1529

Steps:
1. use a proxy of `extendedConfigCache` to monitor referenced `extendedConfig`
2. watch the tsconfig and the extended config file. 
3. if tsconfig is updated, delete the service.
4. if extended tsconfig is updated, delete the services extending the config file
5. update diagnostic and restart service if the deleted one is still used.

todo:
find a way to test this. currently thinking about adding another property to `LanguageServiceDocumentContext`. To allow mocking the `ts.sys` object so we can more easily test it without needing to `try finally` on the file system