### PR TITLE
(fix) auto import in workspace without tsconfig/jsconfig

### DIFF
--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -96,12 +96,13 @@ export namespace DocumentSnapshot {
     export function fromFilePath(
         filePath: string,
         createDocument: (filePath: string, text: string) => Document,
-        options: SvelteSnapshotOptions
+        options: SvelteSnapshotOptions,
+        tsSystem: ts.System
     ) {
         if (isSvelteFilePath(filePath)) {
             return DocumentSnapshot.fromSvelteFilePath(filePath, createDocument, options);
         } else {
-            return DocumentSnapshot.fromNonSvelteFilePath(filePath);
+            return DocumentSnapshot.fromNonSvelteFilePath(filePath, tsSystem);
         }
     }
 
@@ -110,7 +111,7 @@ export namespace DocumentSnapshot {
      * @param filePath path to the js/ts file
      * @param options options that apply in case it's a svelte file
      */
-    export function fromNonSvelteFilePath(filePath: string) {
+    export function fromNonSvelteFilePath(filePath: string, tsSystem: ts.System) {
         let originalText = '';
 
         // The following (very hacky) code makes sure that the ambient module definitions
@@ -121,7 +122,7 @@ export namespace DocumentSnapshot {
         // on their own.
         const normalizedPath = filePath.replace(/\\/g, '/');
         if (!normalizedPath.endsWith('node_modules/svelte/types/runtime/ambient.d.ts')) {
-            originalText = ts.sys.readFile(filePath) || '';
+            originalText = tsSystem.readFile(filePath) || '';
         }
         if (
             normalizedPath.endsWith('svelte2tsx/svelte-shims.d.ts') ||

--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -16,6 +16,8 @@ export class GlobalSnapshotsManager {
     private emitter = new EventEmitter();
     private documents = new Map<string, DocumentSnapshot>();
 
+    constructor(private readonly tsSystem: ts.System) {}
+
     get(fileName: string) {
         fileName = normalizePath(fileName);
         return this.documents.get(fileName);
@@ -48,7 +50,7 @@ export class GlobalSnapshotsManager {
             this.emitter.emit('change', fileName, previousSnapshot);
             return previousSnapshot;
         } else {
-            const newSnapshot = DocumentSnapshot.fromNonSvelteFilePath(fileName);
+            const newSnapshot = DocumentSnapshot.fromNonSvelteFilePath(fileName, this.tsSystem);
 
             if (previousSnapshot) {
                 newSnapshot.version = previousSnapshot.version + 1;

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -121,9 +121,10 @@ class ImpliedNodeFormatResolver {
  */
 export function createSvelteModuleLoader(
     getSnapshot: (fileName: string) => DocumentSnapshot,
-    compilerOptions: ts.CompilerOptions
+    compilerOptions: ts.CompilerOptions,
+    tsSystem: ts.System
 ) {
-    const svelteSys = createSvelteSys(getSnapshot);
+    const svelteSys = createSvelteSys(getSnapshot, tsSystem);
     const moduleCache = new ModuleResolutionCache();
     const impliedNodeFormatResolver = new ImpliedNodeFormatResolver();
 

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -87,7 +87,8 @@ export async function getService(
 
     return getServiceForTsconfig(
         tsconfigPath,
-        (nearestWorkspaceUri && urlToPath(nearestWorkspaceUri)) ?? ts.sys.getCurrentDirectory(),
+        (nearestWorkspaceUri && urlToPath(nearestWorkspaceUri)) ??
+            docContext.tsSystem.getCurrentDirectory(),
         docContext
     );
 }

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -263,7 +263,8 @@ async function createLanguageService(
         const newSnapshot = DocumentSnapshot.fromFilePath(
             filePath,
             docContext.createDocument,
-            transformationConfig
+            transformationConfig,
+            tsSystem
         );
         snapshotManager.set(filePath, newSnapshot);
         return newSnapshot;
@@ -281,7 +282,8 @@ async function createLanguageService(
         doc = DocumentSnapshot.fromFilePath(
             fileName,
             docContext.createDocument,
-            transformationConfig
+            transformationConfig,
+            tsSystem
         );
         snapshotManager.set(fileName, doc);
         return doc;

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -87,7 +87,7 @@ export async function getService(
 
     return getServiceForTsconfig(
         tsconfigPath,
-        (nearestWorkspaceUri && urlToPath(nearestWorkspaceUri)) ?? '',
+        (nearestWorkspaceUri && urlToPath(nearestWorkspaceUri)) ?? ts.sys.getCurrentDirectory(),
         docContext
     );
 }

--- a/packages/language-server/src/plugins/typescript/svelte-sys.ts
+++ b/packages/language-server/src/plugins/typescript/svelte-sys.ts
@@ -5,7 +5,10 @@ import { ensureRealSvelteFilePath, isVirtualSvelteFilePath, toRealSvelteFilePath
 /**
  * This should only be accessed by TS svelte module resolution.
  */
-export function createSvelteSys(getSnapshot: (fileName: string) => DocumentSnapshot, tsSystem: ts.System) {
+export function createSvelteSys(
+    getSnapshot: (fileName: string) => DocumentSnapshot,
+    tsSystem: ts.System
+) {
     const fileExistsCache = new Map<string, boolean>();
 
     const svelteSys: ts.System & { deleteFromCache: (path: string) => void } = {

--- a/packages/language-server/src/plugins/typescript/svelte-sys.ts
+++ b/packages/language-server/src/plugins/typescript/svelte-sys.ts
@@ -5,14 +5,14 @@ import { ensureRealSvelteFilePath, isVirtualSvelteFilePath, toRealSvelteFilePath
 /**
  * This should only be accessed by TS svelte module resolution.
  */
-export function createSvelteSys(getSnapshot: (fileName: string) => DocumentSnapshot) {
+export function createSvelteSys(getSnapshot: (fileName: string) => DocumentSnapshot, tsSystem: ts.System) {
     const fileExistsCache = new Map<string, boolean>();
 
     const svelteSys: ts.System & { deleteFromCache: (path: string) => void } = {
-        ...ts.sys,
+        ...tsSystem,
         fileExists(path: string) {
             path = ensureRealSvelteFilePath(path);
-            const exists = fileExistsCache.get(path) ?? ts.sys.fileExists(path);
+            const exists = fileExistsCache.get(path) ?? tsSystem.fileExists(path);
             fileExistsCache.set(path, exists);
             return exists;
         },
@@ -23,19 +23,19 @@ export function createSvelteSys(getSnapshot: (fileName: string) => DocumentSnaps
         readDirectory(path, extensions, exclude, include, depth) {
             const extensionsWithSvelte = (extensions ?? []).concat('.svelte');
 
-            return ts.sys.readDirectory(path, extensionsWithSvelte, exclude, include, depth);
+            return tsSystem.readDirectory(path, extensionsWithSvelte, exclude, include, depth);
         },
         deleteFile(path) {
             fileExistsCache.delete(ensureRealSvelteFilePath(path));
-            return ts.sys.deleteFile?.(path);
+            return tsSystem.deleteFile?.(path);
         },
         deleteFromCache(path) {
             fileExistsCache.delete(ensureRealSvelteFilePath(path));
         }
     };
 
-    if (ts.sys.realpath) {
-        const realpath = ts.sys.realpath;
+    if (tsSystem.realpath) {
+        const realpath = tsSystem.realpath;
         svelteSys.realpath = function (path) {
             if (isVirtualSvelteFilePath(path)) {
                 return realpath(toRealSvelteFilePath(path)) + '.ts';

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -23,6 +23,7 @@ import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDo
 import { sortBy } from 'lodash';
 import { LSConfigManager } from '../../../../src/ls-config';
 import { __resetCache } from '../../../../src/plugins/typescript/service';
+import { getRandomVirtualDirPath, setupVirtualEnvironment } from '../test-utils';
 
 const testDir = join(__dirname, '..');
 const testFilesDir = join(testDir, 'testfiles', 'completions');
@@ -1318,6 +1319,52 @@ function test(useNewTransformation: boolean) {
                 completions?.items.map((item) => item.label),
                 ['s', 'm', 'l']
             );
+        });
+
+        it('can auto import in workspace without tsconfig/jsconfig', async () => {
+            const virtualTestDir = getRandomVirtualDirPath(testFilesDir);
+            const { docManager, document, lsAndTsDocResolver, lsConfigManager, virtualSystem } =
+                setupVirtualEnvironment({
+                    filename: 'index.svelte',
+                    fileContent: '<script>f</script>',
+                    testDir: virtualTestDir,
+                    useNewTransformation
+                });
+
+            const mockPackageDir = join(virtualTestDir, 'node_modules', '@types/random-package');
+
+            // the main problem is how ts resolve reference type directive
+            // it would start with relative url and failed to auto import
+            virtualSystem.writeFile(
+                join(mockPackageDir, 'index.d.ts'),
+                '/// <reference types="random-package2" />' + '\nexport function bar(): string'
+            );
+
+            virtualSystem.writeFile(
+                join(virtualTestDir, 'node_modules', '@types', 'random-package2', 'index.d.ts'),
+                'declare function foo(): string\n' + 'export = foo'
+            );
+
+            const completionProvider = new CompletionsProviderImpl(
+                lsAndTsDocResolver,
+                lsConfigManager
+            );
+
+            // let the language service aware of random-package and random-package2
+            docManager.openDocument({
+                text: '<script>import {} from "random-package";</script>',
+                uri: pathToUrl(join(virtualTestDir, 'test.svelte'))
+            });
+
+            const completions = await completionProvider.getCompletions(document, {
+                line: 0,
+                character: 2
+            });
+            const item = completions?.items.find((item) => item.label === 'Test');
+
+            const { detail } = await completionProvider.resolveCompletion(document, item!);
+
+            assert.strictEqual(detail, 'Auto import from random-package2\nfunction foo(): string');
         });
 
         // Hacky, but it works. Needed due to testing both new and old transformation

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1334,7 +1334,7 @@ function test(useNewTransformation: boolean) {
             const mockPackageDir = join(virtualTestDir, 'node_modules', '@types/random-package');
 
             // the main problem is how ts resolve reference type directive
-            // it would start with relative url and failed to auto import
+            // it would start with a relative url and fail to auto import
             virtualSystem.writeFile(
                 join(mockPackageDir, 'index.d.ts'),
                 '/// <reference types="random-package2" />' + '\nexport function bar(): string'

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1358,9 +1358,9 @@ function test(useNewTransformation: boolean) {
 
             const completions = await completionProvider.getCompletions(document, {
                 line: 0,
-                character: 2
+                character: 9
             });
-            const item = completions?.items.find((item) => item.label === 'Test');
+            const item = completions?.items.find((item) => item.label === 'foo');
 
             const { detail } = await completionProvider.resolveCompletion(document, item!);
 

--- a/packages/language-server/test/plugins/typescript/module-loader.test.ts
+++ b/packages/language-server/test/plugins/typescript/module-loader.test.ts
@@ -24,7 +24,11 @@ describe('createSvelteModuleLoader', () => {
         sinon.stub(svS, 'createSvelteSys').returns(svelteSys);
 
         const compilerOptions: ts.CompilerOptions = { strict: true, paths: { '/@/*': [] } };
-        const moduleResolver = createSvelteModuleLoader(getSvelteSnapshotStub, compilerOptions, ts.sys);
+        const moduleResolver = createSvelteModuleLoader(
+            getSvelteSnapshotStub,
+            compilerOptions,
+            ts.sys
+        );
 
         return {
             getSvelteSnapshotStub,

--- a/packages/language-server/test/plugins/typescript/module-loader.test.ts
+++ b/packages/language-server/test/plugins/typescript/module-loader.test.ts
@@ -24,7 +24,7 @@ describe('createSvelteModuleLoader', () => {
         sinon.stub(svS, 'createSvelteSys').returns(svelteSys);
 
         const compilerOptions: ts.CompilerOptions = { strict: true, paths: { '/@/*': [] } };
-        const moduleResolver = createSvelteModuleLoader(getSvelteSnapshotStub, compilerOptions);
+        const moduleResolver = createSvelteModuleLoader(getSvelteSnapshotStub, compilerOptions, ts.sys);
 
         return {
             getSvelteSnapshotStub,

--- a/packages/language-server/test/plugins/typescript/svelte-sys.test.ts
+++ b/packages/language-server/test/plugins/typescript/svelte-sys.test.ts
@@ -23,8 +23,11 @@ describe('Svelte Sys', () => {
                 }
         );
 
-        sinon.replace(ts.sys, 'fileExists', fileExistsStub);
-        const loader = createSvelteSys(getSnapshotStub);
+        // sinon.replace(ts.sys, 'fileExists', fileExistsStub);
+        const loader = createSvelteSys(getSnapshotStub, {
+            ...ts.sys,
+            fileExists: fileExistsStub
+        });
 
         return {
             tsFile,

--- a/packages/language-server/test/plugins/typescript/test-utils.ts
+++ b/packages/language-server/test/plugins/typescript/test-utils.ts
@@ -1,0 +1,153 @@
+import path, { isAbsolute, join } from 'path';
+import ts from 'typescript';
+import { DocumentManager, Document } from '../../../src/lib/documents';
+import { LSConfigManager } from '../../../src/ls-config';
+import { LSAndTSDocResolver } from '../../../src/plugins';
+import { normalizePath, pathToUrl } from '../../../src/utils';
+
+export function createVirtualTsSystem(currentDirectory: string): ts.System {
+    const virtualFs = new Map<string, string>();
+    // array behave more similar to the actual fs event than Set
+    const watchers = new Map<string, ts.FileWatcherCallback[]>();
+    const watchTimeout = new Map<string, Array<ReturnType<typeof setTimeout>>>();
+
+    function toAbsolute(path: string) {
+        return isAbsolute(path) ? path : join(currentDirectory, path);
+    }
+
+    const virtualSystem: ts.System = {
+        ...ts.sys,
+        getCurrentDirectory() {
+            return currentDirectory;
+        },
+        writeFile(path, data) {
+            const normalizedPath = normalizePath(toAbsolute(path));
+            const existsBefore = virtualFs.has(normalizedPath);
+            virtualFs.set(normalizedPath, data);
+            triggerWatch(
+                normalizedPath,
+                existsBefore ? ts.FileWatcherEventKind.Changed : ts.FileWatcherEventKind.Created
+            );
+        },
+        readFile(path) {
+            return virtualFs.get(normalizePath(toAbsolute(path)));
+        },
+        fileExists(path) {
+            return virtualFs.has(normalizePath(toAbsolute(path)));
+        },
+        directoryExists(path) {
+            const normalizedPath = normalizePath(toAbsolute(path));
+            return Array.from(virtualFs.keys()).some(fileName => fileName.startsWith(normalizedPath));
+        },
+        deleteFile(path) {
+            const normalizedPath = normalizePath(toAbsolute(path));
+            const existsBefore = virtualFs.has(normalizedPath);
+            virtualFs.delete(normalizedPath);
+
+            if (existsBefore) {
+                triggerWatch(normalizedPath, ts.FileWatcherEventKind.Deleted);
+            }
+        },
+        watchFile(path, callback) {
+            const normalizedPath = normalizePath(toAbsolute(path));
+            let watchersOfPath = watchers.get(normalizedPath);
+
+            if (!watchersOfPath) {
+                watchersOfPath = [];
+                watchers.set(normalizedPath, watchersOfPath);
+            }
+
+            watchersOfPath.push(callback);
+
+            return {
+                close() {
+                    const watchersOfPath = watchers.get(normalizedPath);
+
+                    if (watchersOfPath) {
+                        watchers.set(
+                            normalizedPath,
+                            watchersOfPath.filter((watcher) => watcher === callback)
+                        );
+                    }
+
+                    const timeouts = watchTimeout.get(normalizedPath);
+
+                    if (timeouts != null) {
+                        timeouts.forEach((timeout) => clearTimeout(timeout));
+                    }
+                }
+            };
+        }
+    };
+
+    return virtualSystem;
+
+    function triggerWatch(normalizedPath: string, kind: ts.FileWatcherEventKind) {
+        let timeoutsOfPath = watchTimeout.get(normalizedPath);
+
+        if (!timeoutsOfPath) {
+            timeoutsOfPath = [];
+            watchTimeout.set(normalizedPath, timeoutsOfPath);
+        }
+
+        timeoutsOfPath.push(
+            setTimeout(
+                () =>
+                    watchers
+                        .get(normalizedPath)
+                        ?.forEach((callback) => callback(normalizedPath, kind)),
+                0
+            )
+        );
+    }
+}
+
+export function getRandomVirtualDirPath(testDir: string) {
+    return path.join(testDir, `virtual-path-${Math.floor(Math.random() * 100_000)}`);
+}
+
+interface VirtualEnvironmentOptions {
+    testDir: string;
+    filename: string;
+    useNewTransformation: boolean;
+    fileContent: string;
+}
+
+export function setupVirtualEnvironment({
+    testDir,
+    fileContent,
+    filename,
+    useNewTransformation
+}: VirtualEnvironmentOptions) {
+    const docManager = new DocumentManager(
+        (textDocument) => new Document(textDocument.uri, textDocument.text)
+    );
+
+    const lsConfigManager = new LSConfigManager();
+    lsConfigManager.update({ svelte: { useNewTransformation } });
+
+    const virtualSystem = createVirtualTsSystem(testDir);
+    const lsAndTsDocResolver = new LSAndTSDocResolver(
+        docManager,
+        [pathToUrl(testDir)],
+        lsConfigManager,
+        {
+            tsSystem: virtualSystem
+        }
+    );
+
+    const filePath = join(testDir, filename);
+    virtualSystem.writeFile(filePath, fileContent);
+    const document = docManager.openDocument(<any>{
+        uri: pathToUrl(filePath),
+        text: virtualSystem.readFile(filePath) || ''
+    });
+
+    return {
+        lsAndTsDocResolver,
+        document,
+        docManager,
+        virtualSystem,
+        lsConfigManager
+    };
+}

--- a/packages/language-server/test/plugins/typescript/test-utils.ts
+++ b/packages/language-server/test/plugins/typescript/test-utils.ts
@@ -37,7 +37,9 @@ export function createVirtualTsSystem(currentDirectory: string): ts.System {
         },
         directoryExists(path) {
             const normalizedPath = normalizePath(toAbsolute(path));
-            return Array.from(virtualFs.keys()).some(fileName => fileName.startsWith(normalizedPath));
+            return Array.from(virtualFs.keys()).some((fileName) =>
+                fileName.startsWith(normalizedPath)
+            );
         },
         deleteFile(path) {
             const normalizedPath = normalizePath(toAbsolute(path));


### PR DESCRIPTION
#1175. Not 100% sure it's the problem but the error is the same. It also happens in the [rollup template](https://github.com/sveltejs/template) that what I get the reproduction.  

This one is very tricky to write a test for. So I use a virtual system to write an isolated test. It only happens because of some declaration files that are referenced by the `/// <reference type="">` [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html). And it needs the `node_modules` to be at the root of the workspace. 

What happens is that typescript resolved a module by a relative path to `node_module`. And try to resolve the absolute path to the module so it can proceed with the auto import. But the provided `currentDirectory` is an empty string. I changed it to use the target file path to find the nearest workspace root. So we would always have a current directory.