### PR TITLE
(fix) missing search event

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -465,6 +465,7 @@ declare namespace svelte.JSX {
       onmouseout?: MouseEventHandler<T> | undefined | null;
       onmouseover?: MouseEventHandler<T> | undefined | null;
       onmouseup?: MouseEventHandler<T> | undefined | null;
+      onsearch?: MouseEventHandler<T> | undefined | null;
 
       // Selection Events
       onselect?: EventHandler<Event, T> | undefined | null;


### PR DESCRIPTION
Hello,

I was getting a TypeScript error when listening to the "search" DOM event. This event is triggered when you click the "X" that appears in an input `type=search` field.

![image](https://user-images.githubusercontent.com/4426088/177426031-86061c36-dd0b-4a07-a05f-c337d85c2d52.png)


Here is an article about the "X" or clear button for more context: https://www.freecodecamp.org/news/targeting-click-of-clear-button-x-on-input-field/

I had a look and there was a similar fix done in this raised issue: https://github.com/sveltejs/language-tools/issues/220
Adding the `onsearch` property here has made the error go away. Hope this helps
 