### PR TITLE
(feat) enable actions to enhance typings on applied element

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/actions-enhance-types.only/expected.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/actions-enhance-types.only/expected.json
@@ -1,0 +1,68 @@
+[
+    {
+        "range": {
+            "start": { "line": 22, "character": 9 },
+            "end": { "line": 22, "character": 14 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Argument of type '{ $$_attributes: { foo: string; 'on:bar': (e: CustomEvent<boolean>) => void; }; }' is not assignable to parameter of type 'SvelteActionReturnType'.",
+        "code": 2345,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 22, "character": 16 },
+            "end": { "line": 22, "character": 19 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Type '{ foo: string; onbar: (e: CustomEvent<boolean>) => void; }' is not assignable to type 'HTMLProps<HTMLDivElement>'.\n  Property 'foo' does not exist on type 'HTMLProps<HTMLDivElement>'.",
+        "code": 2322,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 25, "character": 9 },
+            "end": { "line": 25, "character": 14 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Argument of type '{ $$_attributes: { foo: string; 'on:bar': (e: CustomEvent<boolean>) => void; }; }' is not assignable to parameter of type 'SvelteActionReturnType'.",
+        "code": 2345,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 25, "character": 16 },
+            "end": { "line": 25, "character": 19 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Type '{ foo: number; onbar: (e: CustomEvent<boolean>) => void; }' is not assignable to type 'HTMLProps<HTMLDivElement>'.\n  Property 'foo' does not exist on type 'HTMLProps<HTMLDivElement>'.",
+        "code": 2322,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 26, "character": 9 },
+            "end": { "line": 26, "character": 14 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Argument of type '{ $$_attributes: { foo: string; 'on:bar': (e: CustomEvent<boolean>) => void; }; }' is not assignable to parameter of type 'SvelteActionReturnType'.",
+        "code": 2345,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 26, "character": 16 },
+            "end": { "line": 26, "character": 19 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Type '{ foo: string; onbar: (e: CustomEvent<string>) => void; }' is not assignable to type 'HTMLProps<HTMLDivElement>'.\n  Property 'foo' does not exist on type 'HTMLProps<HTMLDivElement>'.",
+        "code": 2322,
+        "tags": []
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/actions-enhance-types.only/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/actions-enhance-types.only/expectedv2.json
@@ -1,0 +1,24 @@
+[
+    {
+        "range": {
+            "start": { "line": 25, "character": 16 },
+            "end": { "line": 25, "character": 19 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Type 'number' is not assignable to type 'string'.",
+        "code": 2322,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 26, "character": 31 },
+            "end": { "line": 26, "character": 34 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Type '(e: CustomEvent<string>) => void' is not assignable to type '(e: CustomEvent<boolean>) => void'.\n  Types of parameters 'e' and 'e' are incompatible.\n    Type 'CustomEvent<boolean>' is not assignable to type 'CustomEvent<string>'.\n      Type 'boolean' is not assignable to type 'string'.",
+        "code": 2322,
+        "tags": []
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/actions-enhance-types.only/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/actions-enhance-types.only/input.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+    function action(node: any) {
+        node;
+        return {
+            // TODO: replace this with the Svelte interface generic once it lands in Svelte; this fails for the old transformation
+            $$_attributes: {
+                foo: 'string',
+                'on:bar': (e: CustomEvent<boolean>) => {e;}
+            }
+        }
+    }
+
+    function onBar(e: CustomEvent<boolean>) {
+        e;
+    }
+
+    function onWrongBar(e: CustomEvent<string>) {
+        e;
+    }
+</script>
+
+<!-- valid for new transformation -->
+<div use:action foo="valid" on:bar={onBar} />
+
+<!-- invalid -->
+<div use:action foo={1} on:bar={onBar} />
+<div use:action foo="valid" on:bar={onWrongBar} />

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
@@ -126,7 +126,7 @@ export function convertHtmlxToJsx(
                         handleStyleDirective(str, node as StyleDirective, element as Element);
                         break;
                     case 'Action':
-                        handleActionDirective(str, node as BaseDirective, element as Element);
+                        handleActionDirective(node as BaseDirective, element as Element);
                         break;
                     case 'Transition':
                         handleTransitionDirective(str, node as BaseDirective, element as Element);

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Action.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Action.ts
@@ -1,32 +1,9 @@
-import MagicString from 'magic-string';
 import { BaseDirective } from '../../interfaces';
-import {
-    getDirectiveNameStartEndIdx,
-    rangeWithTrailingPropertyAccess,
-    TransformationArray
-} from '../utils/node-utils';
 import { Element } from './Element';
 
 /**
  * use:xxx={params}   --->    __sveltets_2_ensureAction(xxx(svelte.mapElementTag('ParentNodeName'),(params)));
  */
-export function handleActionDirective(
-    str: MagicString,
-    attr: BaseDirective,
-    element: Element
-): void {
-    const transformations: TransformationArray = [
-        '__sveltets_2_ensureAction(',
-        getDirectiveNameStartEndIdx(str, attr),
-        `(${element.typingsNamespace}.mapElementTag('${element.tagName}')`
-    ];
-    if (attr.expression) {
-        transformations.push(
-            ',(',
-            rangeWithTrailingPropertyAccess(str.original, attr.expression),
-            ')'
-        );
-    }
-    transformations.push('));');
-    element.appendToStartEnd(transformations);
+export function handleActionDirective(attr: BaseDirective, element: Element): void {
+    element.addAction(attr);
 }

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -17,7 +17,10 @@ declare namespace svelteHTML {
     // "undefined | null" because of <svelte:element>
     element: Key | undefined | null, attrs: Elements[Key]
   ): Key extends keyof ElementTagNameMap ? ElementTagNameMap[Key] : Key extends keyof SVGElementTagNameMap ? SVGElementTagNameMap[Key] : any;
-
+  function createElement<Elements extends IntrinsicElements, Key extends keyof Elements, T>(
+    // "undefined | null" because of <svelte:element>
+    element: Key | undefined | null, attrsEnhancers: T, attrs: Elements[Key] & T
+  ): Key extends keyof ElementTagNameMap ? ElementTagNameMap[Key] : Key extends keyof SVGElementTagNameMap ? SVGElementTagNameMap[Key] : any;
 
   type NativeElement = HTMLElement;
 

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -247,9 +247,9 @@ declare function __sveltets_2_ensureAnimation(animationCall: __sveltets_2_Svelte
 type __sveltets_2_SvelteActionReturnType = {
 	update?: (args: any) => void,
 	destroy?: () => void,
-    $$attributes?: Record<string, any>,
+    $$_attributes?: Record<string, any>,
 } | void
-declare function __sveltets_2_ensureAction<T extends __sveltets_2_SvelteActionReturnType>(actionCall: T): T extends  {$$attributes?: any} ? T['$$attributes'] : {};
+declare function __sveltets_2_ensureAction<T extends __sveltets_2_SvelteActionReturnType>(actionCall: T): T extends  {$$_attributes?: any} ? T['$$_attributes'] : {};
 
 type __sveltets_2_SvelteTransitionConfig = {
     delay?: number,

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -247,10 +247,9 @@ declare function __sveltets_2_ensureAnimation(animationCall: __sveltets_2_Svelte
 type __sveltets_2_SvelteActionReturnType = {
 	update?: (args: any) => void,
 	destroy?: () => void,
-    attributes?: Record<string, any>,
-    events?: Record<string, any>
+    $$attributes?: Record<string, any>,
 } | void
-declare function __sveltets_2_ensureAction<T extends __sveltets_2_SvelteActionReturnType>(actionCall: T): T extends  {attributes?: any, events?: any} ? T['attributes'] & {[Key in keyof T['events'] as `on:${Key & string}`]?: T['events'][Key]} : {};
+declare function __sveltets_2_ensureAction<T extends __sveltets_2_SvelteActionReturnType>(actionCall: T): T extends  {$$attributes?: any} ? T['$$attributes'] : {};
 
 type __sveltets_2_SvelteTransitionConfig = {
     delay?: number,

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -246,9 +246,11 @@ declare function __sveltets_2_ensureAnimation(animationCall: __sveltets_2_Svelte
 
 type __sveltets_2_SvelteActionReturnType = {
 	update?: (args: any) => void,
-	destroy?: () => void
+	destroy?: () => void,
+    attributes?: Record<string, any>,
+    events?: Record<string, any>
 } | void
-declare function __sveltets_2_ensureAction(actionCall: __sveltets_2_SvelteActionReturnType): {};
+declare function __sveltets_2_ensureAction<T extends __sveltets_2_SvelteActionReturnType>(actionCall: T): T extends  {attributes?: any, events?: any} ? T['attributes'] & {[Key in keyof T['events'] as `on:${Key & string}`]?: T['events'][Key]} : {};
 
 type __sveltets_2_SvelteTransitionConfig = {
     delay?: number,

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/action-bare/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/action-bare/expectedv2.js
@@ -1,1 +1,1 @@
- { svelteHTML.createElement("h1", { });__sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('h1')));  }
+ {const $$action_0 = __sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('h1')));{ svelteHTML.createElement("h1", __sveltets_2_union($$action_0), { });  }}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/action-nested/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/action-nested/expectedv2.js
@@ -1,6 +1,6 @@
- { svelteHTML.createElement("svg", { });__sveltets_2_ensureAction(svgAction(svelteHTML.mapElementTag('svg'))); }
- { svelteHTML.createElement("div", { });__sveltets_2_ensureAction(divAction(svelteHTML.mapElementTag('div')));
-    { svelteHTML.createElement("input", { });__sveltets_2_ensureAction(action(svelteHTML.mapElementTag('input')));}
-   { svelteHTML.createElement("p", { });__sveltets_2_ensureAction(pAction(svelteHTML.mapElementTag('p'))); }
-   { svelteHTML.createElement("unknownTag", { });__sveltets_2_ensureAction(unknownAction(svelteHTML.mapElementTag('unknownTag'))); }
- }
+ {const $$action_0 = __sveltets_2_ensureAction(svgAction(svelteHTML.mapElementTag('svg')));{ svelteHTML.createElement("svg", __sveltets_2_union($$action_0), { }); }}
+ {const $$action_0 = __sveltets_2_ensureAction(divAction(svelteHTML.mapElementTag('div')));{ svelteHTML.createElement("div", __sveltets_2_union($$action_0), { });
+    {const $$action_0 = __sveltets_2_ensureAction(action(svelteHTML.mapElementTag('input')));{ svelteHTML.createElement("input", __sveltets_2_union($$action_0), { });}}
+   {const $$action_0 = __sveltets_2_ensureAction(pAction(svelteHTML.mapElementTag('p')));{ svelteHTML.createElement("p", __sveltets_2_union($$action_0), { }); }}
+   {const $$action_0 = __sveltets_2_ensureAction(unknownAction(svelteHTML.mapElementTag('unknownTag')));{ svelteHTML.createElement("unknownTag", __sveltets_2_union($$action_0), { }); }}
+ }}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/action-params/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/action-params/expectedv2.js
@@ -1,3 +1,3 @@
- { svelteHTML.createElement("h1", {  });__sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('h1'),(500,2)));  }
-  { svelteHTML.createElement("h1", {  });__sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('h1'),(500,2)));  }
-  { svelteHTML.createElement("h1", {  });__sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('h1'),(500,2)));  }
+ {const $$action_0 = __sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('h1'),(500,2)));{ svelteHTML.createElement("h1", __sveltets_2_union($$action_0), {  });  }}
+  {const $$action_0 = __sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('h1'),(500,2)));{ svelteHTML.createElement("h1", __sveltets_2_union($$action_0), {  });  }}
+  {const $$action_0 = __sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('h1'),(500,2)));{ svelteHTML.createElement("h1", __sveltets_2_union($$action_0), {  });  }}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/action-svelte-body/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/action-svelte-body/expectedv2.js
@@ -1,1 +1,1 @@
-  { svelteHTML.createElement("svelte:body", { });__sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('body')));}
+  {const $$action_0 = __sveltets_2_ensureAction(blink(svelteHTML.mapElementTag('body')));{ svelteHTML.createElement("svelte:body", __sveltets_2_union($$action_0), { });}}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/directive-quoted/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/directive-quoted/expectedv2.js
@@ -1,6 +1,6 @@
   { svelteHTML.createElement("h1", {  "onclick":()=>console.log("click"),});  }
  { const $$_Component0C = __sveltets_2_ensureComponent(Component); const $$_Component0 = new $$_Component0C({ target: __sveltets_2_any(), props: {   }});$$_Component0.$on("click", test);}
- { svelteHTML.createElement("img", {   });__sveltets_2_ensureAction(action(svelteHTML.mapElementTag('img'),(thing)));}
+ {const $$action_0 = __sveltets_2_ensureAction(action(svelteHTML.mapElementTag('img'),(thing)));{ svelteHTML.createElement("img", __sveltets_2_union($$action_0), {   });}}
  { svelteHTML.createElement("img", {   });__sveltets_2_ensureTransition(fade(svelteHTML.mapElementTag('img'),(params)));}
  { svelteHTML.createElement("img", {  });classthing;}
  { svelteHTML.createElement("img", {   });__sveltets_2_ensureAnimation(thing(svelteHTML.mapElementTag('img'),__sveltets_2_AnimationMove,(params)));}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-action/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-action/expectedv2.js
@@ -1,1 +1,1 @@
- { svelteHTML.createElement("div", {  });__sveltets_2_ensureAction(action(svelteHTML.mapElementTag('div'),(opt.))); }
+ {const $$action_0 = __sveltets_2_ensureAction(action(svelteHTML.mapElementTag('div'),(opt.)));{ svelteHTML.createElement("div", __sveltets_2_union($$action_0), {  }); }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-as-directive/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-as-directive/expectedv2.ts
@@ -9,8 +9,8 @@
 ;
 async () => {
 
- { svelteHTML.createElement("div", {      });__sveltets_2_ensureTransition($transitionStore(svelteHTML.mapElementTag('div'),({ y: 100 })));__sveltets_2_ensureAction($actionStore(svelteHTML.mapElementTag('div')));__sveltets_2_ensureTransition($inStore(svelteHTML.mapElementTag('div')));__sveltets_2_ensureTransition($outStore(svelteHTML.mapElementTag('div')));__sveltets_2_ensureAnimation($animateStore(svelteHTML.mapElementTag('div'),__sveltets_2_AnimationMove));
- }};
+ {const $$action_0 = __sveltets_2_ensureAction($actionStore(svelteHTML.mapElementTag('div')));{ svelteHTML.createElement("div", __sveltets_2_union($$action_0), {      });__sveltets_2_ensureTransition($transitionStore(svelteHTML.mapElementTag('div'),({ y: 100 })));__sveltets_2_ensureTransition($inStore(svelteHTML.mapElementTag('div')));__sveltets_2_ensureTransition($outStore(svelteHTML.mapElementTag('div')));__sveltets_2_ensureAnimation($animateStore(svelteHTML.mapElementTag('div'),__sveltets_2_AnimationMove));
+ }}};
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {


### PR DESCRIPTION
#1243
#431

This assumes we also enhance the typing of the action type in Svelte core so they match. Assuming we have this:

```ts
export interface ActionReturn<Parameter = any, Attributes extends Record<string, any> = Record<never, any>> {
	update?: (parameter: Parameter) => void;
	destroy?: () => void;
	$$attributes?: Attributes;
}
```

You could define an action like this:

```ts
export function action(node: HTMLElement): ActionReturn<never, { foo: boolean; 'on:bar': EventHandler<Event> }> {
   // ..
}
```

and it would enhance the DOM element with the new required attribute `foo` and the optional `on:bar` event.

This requires newer TS types so we can only merge that right before the new transformation (also see https://github.com/sveltejs/language-tools/issues/1552)

Question (cc @jasonlyu123 @ignatiusmb @ivanhofer ):
Is the assumed `ActionReturn` good like this? Should we put both event handler and attributes into one parameter (people would have to type `onbar` or `on:bar` then (undecided yet what we do here, see other issues)? If not, are the typings for Events good? Should it be `bar: Event` instead and we add the `EventHandler` typing ourselves (but how to get currentTarget of the correct DOM element into that then?)
