### PR TITLE
(fix) stricter check for component import quick fix

### DIFF
--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeactions.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeactions.svelte
@@ -11,3 +11,4 @@ abc();
 </script>
 {abc()}
 <Empty />
+<button on:click={e => handleClick(e)} />


### PR DESCRIPTION
Preventing the component import quick fix to hide other quick fixes in the element start tag. Doesn't fix_ #1554. But at least provide a workaround for it. I'll explain why this code action doesn't work in that issue. 