### PR TITLE
(feat) support inert attribute

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -888,6 +888,7 @@ declare namespace svelte.JSX {
       autosave?: string | undefined | null;
       color?: string | undefined | null;
       controlslist?: 'nodownload' | 'nofullscreen' | 'noplaybackrate' | 'noremoteplayback';
+      inert?: boolean | undefined | null;
       itemprop?: string | undefined | null;
       itemscope?: boolean | undefined | null;
       itemtype?: string | undefined | null;


### PR DESCRIPTION
#1564 

https://html.spec.whatwg.org/multipage/interaction.html#the-inert-attribute

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes

supported by chromium and safari. And the nightly version for firefox.

Do we want to add this now or do we want to wait until it's out of beta in firefox?