### PR TITLE
(fix) don't ignore .svelte-kit/types in file watch

### DIFF
--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -455,7 +455,13 @@ export class TypeScriptPlugin
         for (const { fileName, changeType } of onWatchFileChangesParas) {
             const pathParts = fileName.split(/\/|\\/);
             const dirPathParts = pathParts.slice(0, pathParts.length - 1);
-            if (ignoredBuildDirectories.some((dir) => dirPathParts.includes(dir))) {
+            const inIgnoredBuildDirectory = ignoredBuildDirectories.some((dir) => {
+                const index = dirPathParts.indexOf(dir);
+
+                return index > 0 && (dir !== '.svelte-kit' || dirPathParts[index + 1] !== 'types');
+            });
+
+            if (inIgnoredBuildDirectory) {
                 continue;
             }
 

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -455,13 +455,12 @@ export class TypeScriptPlugin
         for (const { fileName, changeType } of onWatchFileChangesParas) {
             const pathParts = fileName.split(/\/|\\/);
             const dirPathParts = pathParts.slice(0, pathParts.length - 1);
-            const inIgnoredBuildDirectory = ignoredBuildDirectories.some((dir) => {
-                const index = dirPathParts.indexOf(dir);
+            const declarationExtensions = [ts.Extension.Dcts, ts.Extension.Dts, ts.Extension.Dmts];
+            const canSafelyIgnore =
+                declarationExtensions.every((ext) => !fileName.endsWith(ext)) &&
+                ignoredBuildDirectories.some((dir) => dirPathParts.includes(dir));
 
-                return index > 0 && (dir !== '.svelte-kit' || dirPathParts[index + 1] !== 'types');
-            });
-
-            if (inIgnoredBuildDirectory) {
+            if (canSafelyIgnore) {
                 continue;
             }
 

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -940,6 +940,10 @@ function test(useNewTransformation: boolean) {
             }
         });
 
+        it('should add snapshot when files added to .svelte-kit/types', async () => {
+            await testForOnWatchedFileAdd(path.join('.svelte-kit', 'types', 'index.d.ts'), true);
+        });
+
         it('should update ts/js file after document change', async () => {
             const { snapshotManager, projectJsFile, plugin } =
                 await setupForOnWatchedFileUpdateOrDelete();

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -940,8 +940,8 @@ function test(useNewTransformation: boolean) {
             }
         });
 
-        it('should add snapshot when files added to .svelte-kit/types', async () => {
-            await testForOnWatchedFileAdd(path.join('.svelte-kit', 'types', 'index.d.ts'), true);
+        it('should add declaration file snapshot when added to known build directory', async () => {
+            await testForOnWatchedFileAdd(path.join('.svelte-kit', 'ambient.d.ts'), true);
         });
 
         it('should update ts/js file after document change', async () => {


### PR DESCRIPTION
#1568 For the generated types for svelte-kit. 

Another alternative is to check all the .d.ts files in the ignored build folder. @dummdidumm What do you think is better?