### PR TITLE
(fix) skip parser error when there's likely another preprocessor involved

### DIFF
--- a/packages/language-server/src/lib/documents/Document.ts
+++ b/packages/language-server/src/lib/documents/Document.ts
@@ -113,6 +113,17 @@ export class Document extends WritableDocument {
         return lang.replace(/^text\//, '');
     }
 
+    /**
+     * Returns true if there's `lang="X"` on script or style or template.
+     */
+    hasLanguageAttribute(): boolean {
+        return (
+            !!this.getLanguageAttribute('script') ||
+            !!this.getLanguageAttribute('style') ||
+            !!this.getLanguageAttribute('template')
+        );
+    }
+
     private addDefaultLanguage(
         config: SvelteConfig | undefined,
         tagInfo: TagInformation | null,

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -22,6 +22,7 @@ export interface SvelteConfig {
     compilerOptions?: CompileOptions;
     preprocess?: InternalPreprocessorGroup | InternalPreprocessorGroup[];
     loadConfigError?: any;
+    isFallbackConfig?: boolean;
 }
 
 const DEFAULT_OPTIONS: CompileOptions = {
@@ -257,7 +258,8 @@ export class ConfigLoader {
                     transpileOnly: true,
                     compilerOptions: { sourceMap: true, inlineSourceMap: false }
                 }
-            })
+            }),
+            isFallbackConfig: true
         };
     }
 }

--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -91,7 +91,10 @@ async function createParserErrorDiagnostic(error: any, document: Document) {
             document.scriptInfo || document.moduleScriptInfo
         );
 
-        if (!document.config?.preprocess && document.getText().includes('lang="')) {
+        if (
+            (!document.config?.preprocess || document.config.isFallbackConfig) &&
+            document.hasLanguageAttribute()
+        ) {
             Logger.error(
                 `Parsing ${document.getFilePath()} failed. No preprocess config found but lang tag exists. Skip showing error because they likely use other preprocessors.`
             );

--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -91,6 +91,13 @@ async function createParserErrorDiagnostic(error: any, document: Document) {
             document.scriptInfo || document.moduleScriptInfo
         );
 
+        if (!document.config?.preprocess && document.getText().includes('lang="')) {
+            Logger.error(
+                `Parsing ${document.getFilePath()} failed. No preprocess config found but lang tag exists. Skip showing error because they likely use other preprocessors.`
+            );
+            return [];
+        }
+
         if (isInStyle || isInScript) {
             diagnostic.message +=
                 '\n\nIf you expect this syntax to work, here are some suggestions: ';


### PR DESCRIPTION
#1259
#1479
#1558

This may give false negatives for people who do not use Vite/forgot to create a svelte.config.js when they use rollup or webpack, but that's likely OK since we can think about these diagnostics as being opt-in: you add a preprocessor config when you want the Svelte warnings, too. Most people who have this problem also likely use TypeScript or a CSS preprocessor. When using TS, errors are caught through the TS intellisense. When using a CSS preprocessor, the only warning they'll miss is the unused CSS warning, which is apparent anyway since those styles are not visible in the browser.

@jasonlyu123 thoughts?