### PR TITLE
TypeScript: Allow SapperAnchorProps & SvelteKitAnchorProps on svelte:element

### DIFF
--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -1456,7 +1456,7 @@ declare namespace svelte.JSX {
       sveltefragment: { slot?: string; };
       svelteoptions: { [name: string]: any };
       sveltehead: { [name: string]: any };
-      svelteelement: { 'this': string | undefined | null; } & HTMLProps<any> & SVGProps<any>;
+      svelteelement: { 'this': string | undefined | null; } & HTMLProps<any> & SVGProps<any> & SapperAnchorProps & SvelteKitAnchorProps;
 
       [name: string]: { [name: string]: any };
     }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expected.jsx
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expected.jsx
@@ -1,3 +1,4 @@
 <><a sveltekitNoscroll></a>
 <a sveltekitPrefetch></a>
-<a sveltekitReload></a></>
+<a sveltekitReload></a>
+<svelteelement this="a" sveltekitPrefetch></svelteelement></>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expectedv2.js
@@ -1,3 +1,4 @@
  { svelteHTML.createElement("a", {"sveltekit:noscroll":true,}); }
  { svelteHTML.createElement("a", {"sveltekit:prefetch":true,}); }
  { svelteHTML.createElement("a", {"sveltekit:reload":true,}); }
+ { svelteHTML.createElement("a", { "sveltekit:prefetch":true,}); }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/input.svelte
@@ -1,3 +1,4 @@
 <a sveltekit:noscroll></a>
 <a sveltekit:prefetch></a>
 <a sveltekit:reload></a>
+<svelte:element this="a" sveltekit:prefetch></svelte:element>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/expected.tsx
@@ -9,7 +9,8 @@
 <svelteelement this="tag" />
 <svelteelement this={tag ? 'a' : 'b'} />
 <svelteelement this={tag}>{tag}</svelteelement>
-<svelteelement this={tag} onclick={() => tag} /></>);
+<svelteelement this={tag} onclick={() => tag} />
+<svelteelement this={'a'} sveltekitPrefetch href="https://kit.svelte.dev" /></>);
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/expectedv2.ts
@@ -9,7 +9,8 @@ async () => {
  { svelteHTML.createElement("tag", { });}
  { svelteHTML.createElement(tag ? 'a' : 'b', {  });}
  { svelteHTML.createElement(tag, { });tag; }
- { svelteHTML.createElement(tag, {    "onclick":() => tag,});}};
+ { svelteHTML.createElement(tag, {    "onclick":() => tag,});}
+ { svelteHTML.createElement('a', {    "sveltekit:prefetch":true,"href":`https://kit.svelte.dev`,});}};
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/input.svelte
@@ -7,3 +7,4 @@
 <svelte:element this={tag ? 'a' : 'b'} />
 <svelte:element this={tag}>{tag}</svelte:element>
 <svelte:element this={tag} on:click={() => tag} />
+<svelte:element this={'a'} sveltekit:prefetch href="https://kit.svelte.dev" />


### PR DESCRIPTION
Ref: https://github.com/sveltejs/language-tools/issues/1576