### PR TITLE
(fix) always update files from .svelte-kit/types

### DIFF
--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -458,8 +458,14 @@ export class TypeScriptPlugin
             const declarationExtensions = [ts.Extension.Dcts, ts.Extension.Dts, ts.Extension.Dmts];
             const canSafelyIgnore =
                 declarationExtensions.every((ext) => !fileName.endsWith(ext)) &&
-                ignoredBuildDirectories.some((dir) => dirPathParts.includes(dir));
+                ignoredBuildDirectories.some((dir) => {
+                    const index = dirPathParts.indexOf(dir);
 
+                    return (
+                        // Files in .svelte-kit/types should always come through
+                        index > 0 && (dir !== '.svelte-kit' || dirPathParts[index + 1] !== 'types')
+                    );
+                });
             if (canSafelyIgnore) {
                 continue;
             }


### PR DESCRIPTION
https://github.com/sveltejs/kit/issues/5940

@jasonlyu123 turns out we need your original solution, because there's also `.js` (proxy) files in the types directory.