### PR TITLE
(fix) workaround for unbalanced bracket

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -430,7 +430,14 @@
                     "source.js": "javascript",
                     "source.ts": "typescript",
                     "source.coffee": "coffeescript"
-                }
+                },
+                "unbalancedBracketScopes": [
+                    "keyword.operator.relational",
+                    "storage.type.function.arrow",
+                    "keyword.operator.bitwise.shift",
+                    "meta.brace.angle",
+                    "punctuation.definition.tag"
+                ]
             },
             {
                 "scopeName": "svelte.pug",


### PR DESCRIPTION
For https://github.com/sveltejs/language-tools/issues/1586. According to the workaround from the VSCode team, see https://github.com/johnsoncodehk/volar/issues/1677#issuecomment-1207912785. These highlight scopes are all in the typescript TM language so the workaround should also apply to us. 

 I tried with a VSCode version before this config was supported and it doesn't throw an error so it is probably fine to workaround it for now. 