### PR TITLE
(feat) preserve bind: in new transformation

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
@@ -117,7 +117,13 @@ export function convertHtmlxToJsx(
                         handleComment(str, node);
                         break;
                     case 'Binding':
-                        handleBinding(str, node as BaseDirective, parent, element);
+                        handleBinding(
+                            str,
+                            node as BaseDirective,
+                            parent,
+                            element,
+                            options.typingsNamespace === 'svelteHTML'
+                        );
                         break;
                     case 'Class':
                         handleClassDirective(str, node as BaseDirective, element as Element);

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-bare/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-bare/expectedv2.js
@@ -1,2 +1,2 @@
- { svelteHTML.createElement("input", {  "type":`text`,value,});}
- { svelteHTML.createElement("input", {  "type":`checkbox`,checked,});}
+ { svelteHTML.createElement("input", {  "type":`text`,"bind:value":value,});}
+ { svelteHTML.createElement("input", {  "type":`checkbox`,"bind:checked":checked,});}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding/expectedv2.js
@@ -1,3 +1,3 @@
-  { svelteHTML.createElement("input", {   "type":`text`,value:test,});}
- { svelteHTML.createElement("input", {    "type":`text`,value:test,});}
- { svelteHTML.createElement("input", {    "type":`text`,value:test,});}
+  { svelteHTML.createElement("input", {  "type":`text`,"bind:value":test,});}
+ { svelteHTML.createElement("input", {   "type":`text`,"bind:value":test,});}
+ { svelteHTML.createElement("input", {   "type":`text`,"bind:value":test,});}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/directive-quoted/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/directive-quoted/expectedv2.js
@@ -4,4 +4,4 @@
  { svelteHTML.createElement("img", {   });__sveltets_2_ensureTransition(fade(svelteHTML.mapElementTag('img'),(params)));}
  { svelteHTML.createElement("img", {  });classthing;}
  { svelteHTML.createElement("img", {   });__sveltets_2_ensureAnimation(thing(svelteHTML.mapElementTag('img'),__sveltets_2_AnimationMove,(params)));}
- { svelteHTML.createElement("img", {   thing:binding,});}
+ { svelteHTML.createElement("img", {  "bind:thing":binding,});}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-binding/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-binding/expectedv2.js
@@ -1,3 +1,3 @@
  { svelteHTML.createElement("input", { });obj.;}
- { svelteHTML.createElement("input", {  value:obj.,});}
+ { svelteHTML.createElement("input", { "bind:value":obj.,});}
  { const $$_Input0C = __sveltets_2_ensureComponent(Input); new $$_Input0C({ target: __sveltets_2_any(), props: {   value:obj.,}});}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-assignment-$store/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-assignment-$store/expectedv2.ts
@@ -4,8 +4,8 @@ async () => { { const $$_div0 = svelteHTML.createElement("div", {  });$compile_o
  { const $$_div0 = svelteHTML.createElement("div", {  });$compile_options.foo= $$_div0.offsetHeight;}
  { const $$_div0 = svelteHTML.createElement("div", {  });$compile_options = $$_div0;}
  { const $$_div0 = svelteHTML.createElement("div", {  });$compile_options.foo = $$_div0;}
- { svelteHTML.createElement("div", {   noAssignment:$compile_options,});}
- { svelteHTML.createElement("div", {   noAssignment:$compile_options.foo,});}};
+ { svelteHTML.createElement("div", {  "bind:noAssignment":$compile_options,});}
+ { svelteHTML.createElement("div", {  "bind:noAssignment":$compile_options.foo,});}};
 return { props: {}, slots: {}, getters: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {


### PR DESCRIPTION
On HTML attributes

@jasonlyu123 this would be needed if we want to switch to explicit `bind:X` typings in the new transformation - does that look correct to you?