### PR TITLE
(fix) user defined prettier plugins gets overridden by svelte plugin

### DIFF
--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -106,7 +106,7 @@ export class SveltePlugin
 
         const formattedCode = prettier.format(document.getText(), {
             ...config,
-            plugins: getSveltePlugin(),
+            plugins: [...(config.plugins ?? []), ...getSveltePlugin()],
             parser: 'svelte' as any
         });
 


### PR DESCRIPTION
so the following config will not work and language server will use it's `prettier-plugin-svelte`
```javascript
// prettier.config.cjs
module.exports = {
    plugins: [require('prettier-plugin-tailwindcss')]
}
```