### PR TITLE
fix `getCompletionEntryDetails` crash

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -271,7 +271,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
         if (basename(filePath).startsWith('+')) {
             const $typeImports = new Map<string, CompletionItem>();
             for (const c of completionItems) {
-                if (c.data.source?.includes('.svelte-kit/types')) {
+                if (c.data?.source?.includes('.svelte-kit/types')) {
                     $typeImports.set(c.label, c);
                 }
             }

--- a/packages/typescript-plugin/src/language-service/completions.ts
+++ b/packages/typescript-plugin/src/language-service/completions.ts
@@ -81,9 +81,9 @@ export function decorateCompletions(ls: ts.LanguageService, logger: Logger): voi
         formatOptions,
         source,
         preferences,
-        data
+        data: (ts.CompletionEntryData & {__is_sveltekit$typeImport: boolean }) | undefined
     ) => {
-        const is$typeImport = (data as any).__is_sveltekit$typeImport;
+        const is$typeImport = data?.__is_sveltekit$typeImport;
 
         const details = getCompletionEntryDetails(
             fileName,

--- a/packages/typescript-plugin/src/language-service/completions.ts
+++ b/packages/typescript-plugin/src/language-service/completions.ts
@@ -81,9 +81,9 @@ export function decorateCompletions(ls: ts.LanguageService, logger: Logger): voi
         formatOptions,
         source,
         preferences,
-        data: (ts.CompletionEntryData & {__is_sveltekit$typeImport: boolean }) | undefined
+        data
     ) => {
-        const is$typeImport = data?.__is_sveltekit$typeImport;
+        const is$typeImport = (data as any)?.__is_sveltekit$typeImport;
 
         const details = getCompletionEntryDetails(
             fileName,


### PR DESCRIPTION
By the type `data` can be `undefined`, unfortunately due to limited time, I can't provide exact str of to get `undefined` in `data`, most probably some another plugin causing it. Anyway, casting possibly undefined value to `any` usually a bad idea. Thank you.

#1630