### PR TITLE
(fix) ts-nocheck, ts-ignore code action for module script

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -663,13 +663,14 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
         document: Document,
         edit: ts.TextChange
     ): TextEdit | undefined {
-        if (!document.scriptInfo) {
+        const scriptInfo = document.moduleScriptInfo ?? document.scriptInfo;
+        if (!scriptInfo) {
             return undefined;
         }
 
         const newText = ts.sys.newLine + edit.newText;
 
-        return TextEdit.insert(document.scriptInfo.startPos, newText);
+        return TextEdit.insert(scriptInfo.startPos, newText);
     }
 
     private checkDisableJsDiagnosticsCodeInsert(
@@ -677,12 +678,14 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
         document: Document,
         edit: ts.TextChange
     ): TextEdit | null {
-        if (!isInTag(originalRange.start, document.scriptInfo)) {
+        const inModuleScript = isInTag(originalRange.start, document.moduleScriptInfo);
+        if (!isInTag(originalRange.start, document.scriptInfo) && !inModuleScript) {
             return null;
         }
 
-        const position =
-            this.fixPropsCodeActionRange(originalRange.start, document) ?? originalRange.start;
+        const position = inModuleScript
+            ? originalRange.start
+            : this.fixPropsCodeActionRange(originalRange.start, document) ?? originalRange.start;
 
         // fix the length of trailing indent
         const linesOfNewText = edit.newText.split('\n');

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-checkJs-module.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-checkJs-module.svelte
@@ -1,0 +1,5 @@
+<script context="module">
+    // @ts-check
+    let a = 1;
+    a = ''
+</script>


### PR DESCRIPTION
Didn't consider the module script in #1643 and also find that `ts-nocheck` quick fix doesn't work when there isn't an instance script.