### PR TITLE
(fix) fixes around SvelteKit imports

### DIFF
--- a/packages/typescript-plugin/src/language-service/completions.ts
+++ b/packages/typescript-plugin/src/language-service/completions.ts
@@ -28,10 +28,12 @@ export function decorateCompletions(ls: ts.LanguageService, logger: Logger): voi
                 const relativeFileName = fileName.split(routesFolder)[1]?.slice(1);
 
                 if (relativeFileName) {
+                    const relativePath =
+                        dirname(relativeFileName) === '.' ? '' : `${dirname(relativeFileName)}/`;
                     const modifiedSource =
                         $typeImport.source!.split('.svelte-kit/types')[0] +
                         // note the missing .d.ts at the end - TS wants it that way for some reason
-                        `.svelte-kit/types/${routesFolder}/${dirname(relativeFileName)}/$types`;
+                        `.svelte-kit/types/${routesFolder}/${relativePath}$types`;
                     completions.entries.push({
                         ...$typeImport,
                         // Ensure it's sorted above the other imports

--- a/packages/typescript-plugin/src/language-service/update-imports.ts
+++ b/packages/typescript-plugin/src/language-service/update-imports.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type ts from 'typescript/lib/tsserverlibrary';
 import { Logger } from '../logger';
 import { SvelteSnapshotManager } from '../svelte-snapshots';
@@ -16,17 +17,28 @@ export function decorateUpdateImports(
             formatOptions,
             preferences
         );
-        // If a file move/rename of a TS/JS file results a Svelte file change,
-        // the Svelte extension will notice that, too, and adjusts the same imports.
-        // This results in duplicate adjustments or race conditions with conflicting text spans
-        // which can break imports in some cases.
-        // Therefore don't do any updates of Svelte files and and also no updates of mixed TS files
-        // and let the Svelte extension handle that.
-        return renameLocations?.filter((renameLocation) => {
-            return (
-                !isSvelteFilePath(renameLocation.fileName) &&
-                !renameLocation.textChanges.some((change) => change.newText.endsWith('.svelte'))
-            );
-        });
+        return renameLocations
+            ?.filter((renameLocation) => {
+                // If a file move/rename of a TS/JS file results a Svelte file change,
+                // the Svelte extension will notice that, too, and adjusts the same imports.
+                // This results in duplicate adjustments or race conditions with conflicting text spans
+                // which can break imports in some cases.
+                // Therefore don't do any updates of Svelte files and and also no updates of mixed TS files
+                // and let the Svelte extension handle that.
+                return (
+                    !isSvelteFilePath(renameLocation.fileName) &&
+                    !renameLocation.textChanges.some((change) => change.newText.endsWith('.svelte'))
+                );
+            })
+            .map((renameLocation) => {
+                if (path.basename(renameLocation.fileName).startsWith('+')) {
+                    // Filter out changes to './$type' imports for Kit route files,
+                    // you'll likely want these to stay as-is
+                    renameLocation.textChanges = renameLocation.textChanges.filter((change) => {
+                        return !change.newText.includes('.svelte-kit/types/');
+                    });
+                }
+                return renameLocation;
+            });
     };
 }


### PR DESCRIPTION
- don't update ./$types in TS files (plugin)
- handle special root dir case when modifying source during completions
- handle leading whitespace in import text