### PR TITLE
fix(language-server): replace deprecated package `vscode-emmet-helper` in favor of `@vscode/emmet-helper`

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -48,6 +48,7 @@
     },
     "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.9",
+        "@vscode/emmet-helper": "^2.8.4",
         "chokidar": "^3.4.1",
         "estree-walker": "^2.0.1",
         "fast-glob": "^3.2.7",
@@ -59,7 +60,6 @@
         "svelte2tsx": "~0.5.0",
         "typescript": "*",
         "vscode-css-languageservice": "~5.1.0",
-        "vscode-emmet-helper": "~2.6.0",
         "vscode-html-languageservice": "~4.1.0",
         "vscode-languageserver": "7.1.0-next.4",
         "vscode-languageserver-protocol": "3.16.0",

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -1,6 +1,6 @@
 import { get, merge } from 'lodash';
 import ts from 'typescript';
-import { VSCodeEmmetConfig } from 'vscode-emmet-helper';
+import { VSCodeEmmetConfig } from '@vscode/emmet-helper';
 import { importPrettier } from './importPackage';
 import { Document } from './lib/documents';
 import { returnObjectIfHasKeys } from './utils';

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -1,4 +1,4 @@
-import { doComplete as doEmmetComplete } from 'vscode-emmet-helper';
+import { doComplete as doEmmetComplete } from '@vscode/emmet-helper';
 import {
     Color,
     ColorInformation,

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -1,4 +1,4 @@
-import { doComplete as doEmmetComplete } from 'vscode-emmet-helper';
+import { doComplete as doEmmetComplete } from '@vscode/emmet-helper';
 import {
     getLanguageService,
     HTMLDocument,


### PR DESCRIPTION
The `vscode-emmet-helper` package has long been deprecated in favor of the renamed `@vscode/emmet-helper`. This causes NPM to emit warnings when installing the `svelte-language-server` package. This PR fixes that issue.