### PR TITLE
(fix) skip inferring type for event forwarded from svelte:self

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/nodes/event-handler.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/event-handler.ts
@@ -10,13 +10,15 @@ export class EventHandler {
         // pass-through/ bubble
         if (!node.expression) {
             if (parent.type === 'InlineComponent') {
-                this.handleEventHandlerBubble(parent, eventName);
-            } else {
-                this.bubbledEvents.set(
-                    eventName,
-                    getEventDefExpressionForNonCompoent(eventName, parent)
-                );
+                if (parent.name !== 'svelte:self') {
+                    this.handleEventHandlerBubble(parent, eventName);
+                }
+                return;
             }
+            this.bubbledEvents.set(
+                eventName,
+                getEventDefExpressionForNonComponent(eventName, parent)
+            );
         }
     }
 
@@ -58,7 +60,7 @@ export class EventHandler {
     }
 }
 
-function getEventDefExpressionForNonCompoent(eventName: string, ele: Node) {
+function getEventDefExpressionForNonComponent(eventName: string, ele: Node) {
     switch (ele.type) {
         case 'Element':
             return `__sveltets_1_mapElementEvent('${eventName}')`;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/expected.tsx
@@ -1,0 +1,23 @@
+///<reference types="svelte" />
+<></>;
+import { createEventDispatcher } from "svelte";
+function render() {
+
+    
+
+    let a = [''];
+    const dispatch = createEventDispatcher<{
+        foo: string
+    }>();
+;
+() => (<>
+
+{__sveltets_1_each(a, (item) => <>
+    <svelteself ></svelteself>
+</>)}</>);
+return { props: {}, slots: {}, getters: {}, events: {...__sveltets_1_toEventTypings<{
+        foo: string
+    }>()} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/expectedv2.ts
@@ -1,0 +1,23 @@
+///<reference types="svelte" />
+;
+import { createEventDispatcher } from "svelte";
+function render() {
+
+    
+
+    let a = [''];
+    const dispatch = createEventDispatcher<{
+        foo: string
+    }>();
+;
+async () => {
+
+  for(let item of __sveltets_2_ensureArray(a)){
+     { const $$_svelteself0 = __sveltets_2_createComponentAny({ });$$_svelteself0.$on("foo", () => {}); }
+}};
+return { props: {}, slots: {}, getters: {}, events: {...__sveltets_1_toEventTypings<{
+        foo: string
+    }>()} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/input.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    import { createEventDispatcher } from "svelte";
+
+    let a = [''];
+    const dispatch = createEventDispatcher<{
+        foo: string
+    }>();
+</script>
+
+{#each a as item}
+    <svelte:self on:foo></svelte:self>
+{/each}


### PR DESCRIPTION
#1686. The rationale is that It must be dispatched or forwarded elsewhere already. Otherwise, it probably is an invalid event forward anyway. 