### PR TITLE
(fix) allow falsy values for svelte:component

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expected.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expected.json
@@ -23,8 +23,8 @@
     },
     {
         "range": {
-            "start": { "line": 44, "character": 16 },
-            "end": { "line": 44, "character": 23 }
+            "start": { "line": 45, "character": 16 },
+            "end": { "line": 45, "character": 23 }
         },
         "severity": 1,
         "source": "ts",
@@ -34,8 +34,8 @@
     },
     {
         "range": {
-            "start": { "line": 45, "character": 34 },
-            "end": { "line": 45, "character": 48 }
+            "start": { "line": 46, "character": 34 },
+            "end": { "line": 46, "character": 48 }
         },
         "severity": 1,
         "source": "ts",
@@ -45,8 +45,8 @@
     },
     {
         "range": {
-            "start": { "line": 46, "character": 35 },
-            "end": { "line": 46, "character": 57 }
+            "start": { "line": 47, "character": 35 },
+            "end": { "line": 47, "character": 57 }
         },
         "severity": 1,
         "source": "ts",
@@ -56,8 +56,8 @@
     },
     {
         "range": {
-            "start": { "line": 47, "character": 46 },
-            "end": { "line": 47, "character": 60 }
+            "start": { "line": 48, "character": 46 },
+            "end": { "line": 48, "character": 60 }
         },
         "severity": 1,
         "source": "ts",

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expectedv2.json
@@ -23,8 +23,8 @@
     },
     {
         "range": {
-            "start": { "line": 44, "character": 16 },
-            "end": { "line": 44, "character": 23 }
+            "start": { "line": 45, "character": 16 },
+            "end": { "line": 45, "character": 23 }
         },
         "severity": 1,
         "source": "ts",
@@ -34,8 +34,8 @@
     },
     {
         "range": {
-            "start": { "line": 45, "character": 34 },
-            "end": { "line": 45, "character": 48 }
+            "start": { "line": 46, "character": 34 },
+            "end": { "line": 46, "character": 48 }
         },
         "severity": 1,
         "source": "ts",
@@ -45,8 +45,8 @@
     },
     {
         "range": {
-            "start": { "line": 46, "character": 35 },
-            "end": { "line": 46, "character": 57 }
+            "start": { "line": 47, "character": 35 },
+            "end": { "line": 47, "character": 57 }
         },
         "severity": 1,
         "source": "ts",
@@ -56,8 +56,8 @@
     },
     {
         "range": {
-            "start": { "line": 47, "character": 1 },
-            "end": { "line": 47, "character": 17 }
+            "start": { "line": 48, "character": 1 },
+            "end": { "line": 48, "character": 17 }
         },
         "severity": 1,
         "source": "ts",
@@ -67,8 +67,8 @@
     },
     {
         "range": {
-            "start": { "line": 47, "character": 46 },
-            "end": { "line": 47, "character": 60 }
+            "start": { "line": 48, "character": 46 },
+            "end": { "line": 48, "character": 60 }
         },
         "severity": 1,
         "source": "ts",
@@ -78,8 +78,8 @@
     },
     {
         "range": {
-            "start": { "line": 50, "character": 45 },
-            "end": { "line": 50, "character": 65 }
+            "start": { "line": 51, "character": 45 },
+            "end": { "line": 51, "character": 65 }
         },
         "severity": 1,
         "source": "ts",
@@ -89,8 +89,8 @@
     },
     {
         "range": {
-            "start": { "line": 51, "character": 1 },
-            "end": { "line": 51, "character": 17 }
+            "start": { "line": 52, "character": 1 },
+            "end": { "line": 52, "character": 17 }
         },
         "severity": 1,
         "source": "ts",

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/input.svelte
@@ -40,6 +40,7 @@
 <ComponentWithFunction2 bind:this={componentWithFunction1} />
 <ComponentWithGeneric prop={''} bind:this={componentWithGeneric} />
 <svelte:component this={Component} bind:this={component} prop={true} />
+<svelte:component this={Math.random() > 0.5 ? Component : null} bind:this={component} prop={true} />
 
 <!-- errors -->
 <div bind:this={element} />

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -298,6 +298,6 @@ declare type ATypedSvelteComponent = {
  * Ambient type only used for intellisense, DO NOT USE IN YOUR PROJECT
  */
 declare type ConstructorOfATypedSvelteComponent = new (args: {target: any, props?: any}) => ATypedSvelteComponent
-declare function __sveltets_2_ensureComponent<T extends ConstructorOfATypedSvelteComponent>(type: T): T;
+declare function __sveltets_2_ensureComponent<T extends ConstructorOfATypedSvelteComponent | null | undefined>(type: T): NonNullable<T>;
 
 declare function __sveltets_2_ensureArray<T extends ArrayLike<unknown>>(array: T): T extends ArrayLike<infer U> ? U[] : any[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,6 +420,18 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+"@vscode/emmet-helper@^2.8.4":
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/@vscode/emmet-helper/-/emmet-helper-2.8.4.tgz#ab937e3ce79b0873c604d1ad50a9eeb7abae2937"
+  integrity sha512-lUki5QLS47bz/U8IlG9VQ+1lfxMtxMZENmU5nu4Z71eOD5j9FK0SmYGL5NiVJg9WBWeAU0VxRADMY2Qpq7BfVg==
+  dependencies:
+    emmet "^2.3.0"
+    jsonc-parser "^2.3.0"
+    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-types "^3.15.1"
+    vscode-nls "^5.0.0"
+    vscode-uri "^2.1.2"
+
 acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
@@ -2688,18 +2700,6 @@ vscode-css-languageservice@~5.1.0:
     vscode-languageserver-types "^3.16.0"
     vscode-nls "^5.0.0"
     vscode-uri "^3.0.2"
-
-vscode-emmet-helper@~2.6.0:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-2.6.4.tgz#bea47f17649bba26b412f3d1fac18aaee43eba25"
-  integrity sha512-fP0nunW1RUWEKGf4gqiYLOVNFFGXSRHjCl0pikxtwCFlty8WwimM+RBJ5o0aIiwerrYD30HqeaVyvDW027Sseg==
-  dependencies:
-    emmet "^2.3.0"
-    jsonc-parser "^2.3.0"
-    vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "^3.15.1"
-    vscode-nls "^5.0.0"
-    vscode-uri "^2.1.2"
 
 vscode-html-languageservice@~4.1.0:
   version "4.1.1"


### PR DESCRIPTION
#1692
This isn't 100% correct as this would also allow falsy <Components> but that probably never happens