### PR TITLE
Add ResourceType.SERVER to handleMultiple

### DIFF
--- a/packages/svelte-vscode/src/sveltekit/generateFiles/index.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/index.ts
@@ -71,7 +71,8 @@ async function handleMultiple(uri: Uri | undefined) {
         ResourceType.LAYOUT,
         ResourceType.LAYOUT_LOAD,
         ResourceType.LAYOUT_SERVER,
-        ResourceType.ERROR
+        ResourceType.ERROR,
+        ResourceType.SERVER
     ].map((type) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const resource = resourcesMap.get(type)!;


### PR DESCRIPTION
Fixes #1699 

Adds the option `+server.js/ts` to the dropdown when using `SvelteKit: Create Route`.

