### PR TITLE
Add Svelte anchor missing attribute code action

### DIFF
--- a/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
@@ -45,7 +45,16 @@ export async function getQuickfixActions(
     const codeActions: CodeAction[] = [];
 
     for (const diagnostic of svelteDiagnostics) {
-        codeActions.push(...(await createQuickfixActions(textDocument, transpiled, content, lineOffsets, html, diagnostic)));
+        codeActions.push(
+            ...(await createQuickfixActions(
+                textDocument,
+                transpiled,
+                content,
+                lineOffsets,
+                html,
+                diagnostic
+            ))
+        );
     }
 
     return codeActions;
@@ -59,7 +68,9 @@ async function createQuickfixActions(
     html: TemplateNode,
     diagnostic: Diagnostic
 ): Promise<CodeAction[]> {
-    const { range: { start, end } } = diagnostic;
+    const {
+        range: { start, end }
+    } = diagnostic;
     const generatedStart = transpiled.getGeneratedPosition(start);
     const generatedEnd = transpiled.getGeneratedPosition(end);
     const diagnosticStartOffset = offsetAt(generatedStart, content, lineOffsets);
@@ -73,10 +84,27 @@ async function createQuickfixActions(
     const codeActions: CodeAction[] = [];
 
     if (diagnostic.code == 'security-anchor-rel-noreferrer') {
-        codeActions.push(createSvelteAnchorMissingAttributeQuickfixAction(textDocument, transpiled, content, lineOffsets, node));
+        codeActions.push(
+            createSvelteAnchorMissingAttributeQuickfixAction(
+                textDocument,
+                transpiled,
+                content,
+                lineOffsets,
+                node
+            )
+        );
     }
 
-    codeActions.push(createSvelteIgnoreQuickfixAction(textDocument, transpiled, content, lineOffsets, node, diagnostic));
+    codeActions.push(
+        createSvelteIgnoreQuickfixAction(
+            textDocument,
+            transpiled,
+            content,
+            lineOffsets,
+            node,
+            diagnostic
+        )
+    );
 
     return codeActions;
 }
@@ -88,7 +116,6 @@ function createSvelteAnchorMissingAttributeQuickfixAction(
     lineOffsets: number[],
     node: Node
 ): CodeAction {
-
     // Assert non-null because the node target attribute is required for 'security-anchor-rel-noreferrer'
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const targetAttribute = node.attributes.find((i: any) => i.name == 'target')!;

--- a/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
@@ -1,6 +1,6 @@
 import { walk } from 'estree-walker';
 import { EOL } from 'os';
-import { Ast } from 'svelte/types/compiler/interfaces';
+import { TemplateNode } from 'svelte/types/compiler/interfaces';
 import {
     CodeAction,
     CodeActionKind,
@@ -18,7 +18,7 @@ import {
     positionAt
 } from '../../../../lib/documents';
 import { getIndent, pathToUrl } from '../../../../utils';
-import { SvelteDocument } from '../../SvelteDocument';
+import { ITranspiledSvelteDocument, SvelteDocument } from '../../SvelteDocument';
 import ts from 'typescript';
 // estree does not have start/end in their public Node interface,
 // but the AST returned by svelte/compiler does. Type as any as a workaround.
@@ -30,32 +30,99 @@ type Node = any;
 export async function getQuickfixActions(
     svelteDoc: SvelteDocument,
     svelteDiagnostics: Diagnostic[]
-) {
-    const { ast } = await svelteDoc.getCompiled();
-
-    return Promise.all(
-        svelteDiagnostics.map(
-            async (diagnostic) => await createQuickfixAction(diagnostic, svelteDoc, ast)
-        )
-    );
-}
-
-async function createQuickfixAction(
-    diagnostic: Diagnostic,
-    svelteDoc: SvelteDocument,
-    ast: Ast
-): Promise<CodeAction> {
+): Promise<CodeAction[]> {
     const textDocument = OptionalVersionedTextDocumentIdentifier.create(
         pathToUrl(svelteDoc.getFilePath()),
         null
     );
 
+    const { ast } = await svelteDoc.getCompiled();
+    const transpiled = await svelteDoc.getTranspiled();
+    const content = transpiled.getText();
+    const lineOffsets = getLineOffsets(content);
+    const { html } = ast;
+
+    const codeActions: CodeAction[] = [];
+
+    for (const diagnostic of svelteDiagnostics) {
+        codeActions.push(...(await createQuickfixActions(textDocument, transpiled, content, lineOffsets, html, diagnostic)));
+    }
+
+    return codeActions;
+}
+
+async function createQuickfixActions(
+    textDocument: OptionalVersionedTextDocumentIdentifier,
+    transpiled: ITranspiledSvelteDocument,
+    content: string,
+    lineOffsets: number[],
+    html: TemplateNode,
+    diagnostic: Diagnostic
+): Promise<CodeAction[]> {
+    const { range: { start, end } } = diagnostic;
+    const generatedStart = transpiled.getGeneratedPosition(start);
+    const generatedEnd = transpiled.getGeneratedPosition(end);
+    const diagnosticStartOffset = offsetAt(generatedStart, content, lineOffsets);
+    const diagnosticEndOffset = offsetAt(generatedEnd, content, lineOffsets);
+    const offsetRange: ts.TextRange = {
+        pos: diagnosticStartOffset,
+        end: diagnosticEndOffset
+    };
+    const node = findTagForRange(html, offsetRange);
+
+    const codeActions: CodeAction[] = [];
+
+    if (diagnostic.code == 'security-anchor-rel-noreferrer') {
+        codeActions.push(createSvelteAnchorMissingAttributeQuickfixAction(textDocument, transpiled, content, lineOffsets, node));
+    }
+
+    codeActions.push(createSvelteIgnoreQuickfixAction(textDocument, transpiled, content, lineOffsets, node, diagnostic));
+
+    return codeActions;
+}
+
+function createSvelteAnchorMissingAttributeQuickfixAction(
+    textDocument: OptionalVersionedTextDocumentIdentifier,
+    transpiled: ITranspiledSvelteDocument,
+    content: string,
+    lineOffsets: number[],
+    node: Node
+): CodeAction {
+
+    // Assert non-null because the node target attribute is required for 'security-anchor-rel-noreferrer'
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const targetAttribute = node.attributes.find((i: any) => i.name == 'target')!;
+    const targetAttributePosition = positionAt(targetAttribute.end, content, lineOffsets);
+
+    const relNoReferrerTextEdit = TextEdit.insert(targetAttributePosition, ' rel="noreferrer"');
+
+    return CodeAction.create(
+        '(svelte) Add missing attribute rel="noreferrer"',
+        {
+            documentChanges: [
+                TextDocumentEdit.create(textDocument, [
+                    mapObjWithRangeToOriginal(transpiled, relNoReferrerTextEdit)
+                ])
+            ]
+        },
+        CodeActionKind.QuickFix
+    );
+}
+
+function createSvelteIgnoreQuickfixAction(
+    textDocument: OptionalVersionedTextDocumentIdentifier,
+    transpiled: ITranspiledSvelteDocument,
+    content: string,
+    lineOffsets: number[],
+    node: Node,
+    diagnostic: Diagnostic
+): CodeAction {
     return CodeAction.create(
         getCodeActionTitle(diagnostic),
         {
             documentChanges: [
                 TextDocumentEdit.create(textDocument, [
-                    await getSvelteIgnoreEdit(svelteDoc, ast, diagnostic)
+                    getSvelteIgnoreEdit(transpiled, content, lineOffsets, node, diagnostic)
                 ])
             ]
         },
@@ -87,26 +154,14 @@ const nonIgnorableWarnings = [
     'css-unused-selector'
 ];
 
-async function getSvelteIgnoreEdit(svelteDoc: SvelteDocument, ast: Ast, diagnostic: Diagnostic) {
-    const {
-        code,
-        range: { start, end }
-    } = diagnostic;
-    const transpiled = await svelteDoc.getTranspiled();
-    const content = transpiled.getText();
-    const lineOffsets = getLineOffsets(content);
-    const { html } = ast;
-    const generatedStart = transpiled.getGeneratedPosition(start);
-    const generatedEnd = transpiled.getGeneratedPosition(end);
-
-    const diagnosticStartOffset = offsetAt(generatedStart, content, lineOffsets);
-    const diagnosticEndOffset = offsetAt(generatedEnd, content, lineOffsets);
-    const offsetRange: ts.TextRange = {
-        pos: diagnosticStartOffset,
-        end: diagnosticEndOffset
-    };
-
-    const node = findTagForRange(html, offsetRange);
+function getSvelteIgnoreEdit(
+    transpiled: ITranspiledSvelteDocument,
+    content: string,
+    lineOffsets: number[],
+    node: Node,
+    diagnostic: Diagnostic
+) {
+    const { code } = diagnostic;
 
     const nodeStartPosition = positionAt(node.start, content, lineOffsets);
     const nodeLineStart = offsetAt(

--- a/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
@@ -6,10 +6,13 @@ import {
     CodeAction,
     CodeActionContext,
     CreateFile,
-    DiagnosticSeverity, OptionalVersionedTextDocumentIdentifier, Position,
+    DiagnosticSeverity,
+    OptionalVersionedTextDocumentIdentifier,
+    Position,
     Range,
     TextDocumentEdit,
-    TextEdit, WorkspaceEdit
+    TextEdit,
+    WorkspaceEdit
 } from 'vscode-languageserver';
 import { Document } from '../../../../src/lib/documents';
 import { getCodeActions } from '../../../../src/plugins/svelte/features/getCodeActions';
@@ -100,7 +103,8 @@ describe('SveltePlugin#getCodeAction', () => {
     });
 
     describe('It should provide svelte anchor missing attribute code actions', () => {
-        const svelteAnchorMissingAttributeCodeAction = 'svelte-anchor-missing-attribute-code-action.svelte';
+        const svelteAnchorMissingAttributeCodeAction =
+            'svelte-anchor-missing-attribute-code-action.svelte';
 
         it('Should provide svelte anchor add missing attribute', async () => {
             (
@@ -113,7 +117,8 @@ describe('SveltePlugin#getCodeAction', () => {
                                 { line: 0, character: 0 },
                                 { line: 0, character: 55 }
                             ),
-                            message: 'Security: Anchor with "target=_blank" should have rel attribute containing the value "noreferrer"',
+                            message:
+                                'Security: Anchor with "target=_blank" should have rel attribute containing the value "noreferrer"',
                             source: 'svelte'
                         }
                     ]

--- a/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
@@ -6,13 +6,10 @@ import {
     CodeAction,
     CodeActionContext,
     CreateFile,
-    DiagnosticSeverity,
-    Position,
+    DiagnosticSeverity, OptionalVersionedTextDocumentIdentifier, Position,
     Range,
     TextDocumentEdit,
-    TextEdit,
-    OptionalVersionedTextDocumentIdentifier,
-    WorkspaceEdit
+    TextEdit, WorkspaceEdit
 } from 'vscode-languageserver';
 import { Document } from '../../../../src/lib/documents';
 import { getCodeActions } from '../../../../src/plugins/svelte/features/getCodeActions';
@@ -99,6 +96,89 @@ describe('SveltePlugin#getCodeAction', () => {
                     ]
                 })
             ).toEqual([]);
+        });
+    });
+
+    describe('It should provide svelte anchor missing attribute code actions', () => {
+        const svelteAnchorMissingAttributeCodeAction = 'svelte-anchor-missing-attribute-code-action.svelte';
+
+        it('Should provide svelte anchor add missing attribute', async () => {
+            (
+                await expectCodeActionFor(svelteAnchorMissingAttributeCodeAction, {
+                    diagnostics: [
+                        {
+                            severity: DiagnosticSeverity.Warning,
+                            code: 'security-anchor-rel-noreferrer',
+                            range: Range.create(
+                                { line: 0, character: 0 },
+                                { line: 0, character: 55 }
+                            ),
+                            message: 'Security: Anchor with "target=_blank" should have rel attribute containing the value "noreferrer"',
+                            source: 'svelte'
+                        }
+                    ]
+                })
+            ).toEqual([
+                {
+                    edit: {
+                        documentChanges: [
+                            {
+                                edits: [
+                                    {
+                                        newText: ' rel="noreferrer"',
+                                        range: {
+                                            end: {
+                                                character: 44,
+                                                line: 0
+                                            },
+                                            start: {
+                                                character: 44,
+                                                line: 0
+                                            }
+                                        }
+                                    }
+                                ],
+                                textDocument: {
+                                    uri: getUri(svelteAnchorMissingAttributeCodeAction),
+                                    version: null
+                                }
+                            }
+                        ]
+                    },
+                    title: '(svelte) Add missing attribute rel="noreferrer"',
+                    kind: 'quickfix'
+                },
+                {
+                    edit: {
+                        documentChanges: [
+                            {
+                                edits: [
+                                    {
+                                        // eslint-disable-next-line max-len
+                                        newText: `<!-- svelte-ignore security-anchor-rel-noreferrer -->${EOL}`,
+                                        range: {
+                                            end: {
+                                                character: 0,
+                                                line: 0
+                                            },
+                                            start: {
+                                                character: 0,
+                                                line: 0
+                                            }
+                                        }
+                                    }
+                                ],
+                                textDocument: {
+                                    uri: getUri(svelteAnchorMissingAttributeCodeAction),
+                                    version: null
+                                }
+                            }
+                        ]
+                    },
+                    title: '(svelte) Disable security-anchor-rel-noreferrer for this line',
+                    kind: 'quickfix'
+                }
+            ]);
         });
     });
 

--- a/packages/language-server/test/plugins/svelte/testfiles/svelte-anchor-missing-attribute-code-action.svelte
+++ b/packages/language-server/test/plugins/svelte/testfiles/svelte-anchor-missing-attribute-code-action.svelte
@@ -1,0 +1,1 @@
+<a href="https://svelte.dev" target="_blank">Svelte</a>


### PR DESCRIPTION
This PR adds a code action for the Svelte warning `security-anchor-rel-noreferrer` that inserts the `rel="noreferrer"` attribute after the target attribute

![svelte-anchor-missing-attribute-code-action](https://user-images.githubusercontent.com/43595566/203675299-7499b770-e019-4e99-87b1-b60242fb212e.gif)
