### PR TITLE
(feat) missing handler quick fix

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -38,6 +38,7 @@ import {
     findContainingNode,
     FormatCodeBasis,
     getFormatCodeBasis,
+    getQuotePreference,
     isTextSpanInGeneratedCode,
     SnapshotMap
 } from './utils';
@@ -271,7 +272,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
             document,
             tsDoc.scriptKind
         );
-        const formatCodeBasis = getFormatCodeBasis(formatCodeSettings, userPreferences);
+        const formatCodeBasis = getFormatCodeBasis(formatCodeSettings);
 
         let codeFixes = cannotFoundNameDiagnostic.length
             ? this.getComponentImportQuickFix(
@@ -302,7 +303,8 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                         document,
                         cannotFoundNameDiagnostic,
                         tsDoc,
-                        formatCodeBasis
+                        formatCodeBasis,
+                        userPreferences
                     )
                 );
 
@@ -520,7 +522,8 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
         document: Document,
         diagnostics: Diagnostic[],
         tsDoc: DocumentSnapshot,
-        formatCodeBasis: FormatCodeBasis
+        formatCodeBasis: FormatCodeBasis,
+        userPreferences: ts.UserPreferences
     ): ts.CodeFixAction[] {
         const program = lang.getProgram();
         const sourceFile = program?.getSourceFile(tsDoc.filePath);
@@ -530,6 +533,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
 
         const typeChecker = program.getTypeChecker();
         const result: ts.CodeFixAction[] = [];
+        const quote = getQuotePreference(sourceFile, userPreferences);
 
         for (const diagnostic of diagnostics) {
             const htmlNode = document.html.findNodeAt(document.offsetAt(diagnostic.range.start));
@@ -601,7 +605,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                     useJsDoc ? '' : ': ' + returnType
                 } {`,
                 formatCodeBasis.indent +
-                    `throw new Error(${formatCodeBasis.quote}Function not implemented.${formatCodeBasis.quote})` +
+                    `throw new Error(${quote}Function not implemented.${quote})` +
                     formatCodeBasis.semi,
                 '}'
             ]

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -588,7 +588,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
             const parametersText = (
                 useJsDoc
                     ? parameters.map((p) => p.name)
-                    : parameters.map((p) => p.name + ': ' + p.typeString)
+                    : parameters.map((p) => p.name + (p.typeString ? ': ' + p.typeString : ''))
             ).join(', ');
 
             const jsDoc = useJsDoc

--- a/packages/language-server/src/plugins/typescript/features/utils.ts
+++ b/packages/language-server/src/plugins/typescript/features/utils.ts
@@ -293,3 +293,35 @@ export const gatherIdentifiers = (node: ts.Node) => gatherDescendants(node, ts.i
 export function isKitTypePath(path?: string): boolean {
     return !!path?.includes('.svelte-kit/types');
 }
+
+export function getFormatCodeBasis(
+    formatCodeSetting: ts.FormatCodeSettings,
+    userPreferences: ts.UserPreferences
+): FormatCodeBasis {
+    const { baseIndentSize, indentSize, convertTabsToSpaces } = formatCodeSetting;
+    const baseIndent = convertTabsToSpaces
+        ? ' '.repeat(baseIndentSize ?? 4)
+        : baseIndentSize
+        ? '\t'
+        : '';
+    const indent = convertTabsToSpaces ? ' '.repeat(indentSize ?? 4) : baseIndentSize ? '\t' : '';
+    const quote = userPreferences.quotePreference === 'single' ? "'" : '"';
+    const semi = formatCodeSetting.semicolons === 'remove' ? '' : ';';
+    const newLine = formatCodeSetting.newLineCharacter ?? ts.sys.newLine;
+
+    return {
+        baseIndent,
+        indent,
+        quote,
+        semi,
+        newLine
+    };
+}
+
+export interface FormatCodeBasis {
+    baseIndent: string;
+    indent: string;
+    quote: string;
+    semi: string;
+    newLine: string;
+}

--- a/packages/language-server/src/plugins/typescript/features/utils.ts
+++ b/packages/language-server/src/plugins/typescript/features/utils.ts
@@ -294,10 +294,7 @@ export function isKitTypePath(path?: string): boolean {
     return !!path?.includes('.svelte-kit/types');
 }
 
-export function getFormatCodeBasis(
-    formatCodeSetting: ts.FormatCodeSettings,
-    userPreferences: ts.UserPreferences
-): FormatCodeBasis {
+export function getFormatCodeBasis(formatCodeSetting: ts.FormatCodeSettings): FormatCodeBasis {
     const { baseIndentSize, indentSize, convertTabsToSpaces } = formatCodeSetting;
     const baseIndent = convertTabsToSpaces
         ? ' '.repeat(baseIndentSize ?? 4)
@@ -305,14 +302,12 @@ export function getFormatCodeBasis(
         ? '\t'
         : '';
     const indent = convertTabsToSpaces ? ' '.repeat(indentSize ?? 4) : baseIndentSize ? '\t' : '';
-    const quote = userPreferences.quotePreference === 'single' ? "'" : '"';
     const semi = formatCodeSetting.semicolons === 'remove' ? '' : ';';
     const newLine = formatCodeSetting.newLineCharacter ?? ts.sys.newLine;
 
     return {
         baseIndent,
         indent,
-        quote,
         semi,
         newLine
     };
@@ -321,7 +316,34 @@ export function getFormatCodeBasis(
 export interface FormatCodeBasis {
     baseIndent: string;
     indent: string;
-    quote: string;
     semi: string;
     newLine: string;
+}
+
+/**
+ * https://github.com/microsoft/TypeScript/blob/00dc0b6674eef3fbb3abb86f9d71705b11134446/src/services/utilities.ts#L2452
+ */
+export function getQuotePreference(
+    sourceFile: ts.SourceFile,
+    preferences: ts.UserPreferences
+): '"' | "'" {
+    const single = "'";
+    const double = '"';
+    if (preferences.quotePreference && preferences.quotePreference !== 'auto') {
+        return preferences.quotePreference === 'single' ? single : double;
+    }
+
+    const firstModuleSpecifier = Array.from(sourceFile.statements).find(
+        (
+            statement
+        ): statement is Omit<ts.ImportDeclaration, 'moduleSpecifier'> & {
+            moduleSpecifier: ts.StringLiteral;
+        } => ts.isImportDeclaration(statement) && ts.isStringLiteral(statement.moduleSpecifier)
+    )?.moduleSpecifier;
+
+    return firstModuleSpecifier
+        ? sourceFile.getText()[firstModuleSpecifier.pos] === '"'
+            ? double
+            : single
+        : double;
 }

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -277,8 +277,12 @@ export function getIndent(text: string) {
  * Also, svelte directives like action and event modifier only work
  * with element not component
  */
-export function possiblyComponent(node: Node): boolean {
-    return !!node.tag?.[0].match(/[A-Z]/);
+export function possiblyComponent(node: Node): boolean;
+export function possiblyComponent(tagName: string): boolean;
+export function possiblyComponent(nodeOrTagName: Node | string): boolean {
+    return !!(typeof nodeOrTagName === 'object' ? nodeOrTagName.tag : nodeOrTagName)?.[0].match(
+        /[A-Z]/
+    );
 }
 
 /**

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -252,7 +252,7 @@ function test(useNewTransformation: boolean) {
                                     {
                                         newText:
                                             `\n\n${indent}function handleClick(event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement; }): any {\n` +
-                                            `${indent}${indent}throw new Error('Function not implemented.');\n` +
+                                            `${indent}${indent}throw new Error("Function not implemented.");\n` +
                                             `${indent}}\n`,
                                         range: {
                                             start: {

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -220,7 +220,7 @@ function test(useNewTransformation: boolean) {
             ]);
         });
 
-        it.only('provides quickfix for missing function for element event handler', async () => {
+        it('provides quickfix for missing function for element event handler', async () => {
             const { provider, document } = setup('fix-missing-function-element.svelte');
 
             const codeActions = await provider.getCodeActions(

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -220,6 +220,65 @@ function test(useNewTransformation: boolean) {
             ]);
         });
 
+        it.only('provides quickfix for missing function for element event handler', async () => {
+            const { provider, document } = setup('fix-missing-function-element.svelte');
+
+            const codeActions = await provider.getCodeActions(
+                document,
+                Range.create(Position.create(4, 18), Position.create(4, 29)),
+                {
+                    diagnostics: [
+                        {
+                            code: 2304,
+                            message: "Cannot find name 'handleClick'.",
+                            range: Range.create(Position.create(4, 18), Position.create(4, 29)),
+                            source: 'ts'
+                        }
+                    ],
+                    only: [CodeActionKind.QuickFix]
+                }
+            );
+
+            (<TextDocumentEdit>codeActions[0]?.edit?.documentChanges?.[0])?.edits.forEach(
+                (edit) => (edit.newText = harmonizeNewLines(edit.newText))
+            );
+
+            assert.deepStrictEqual(codeActions, [
+                {
+                    edit: {
+                        documentChanges: [
+                            {
+                                edits: [
+                                    {
+                                        newText:
+                                            `\n\n${indent}function handleClick(event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement; }): any {\n` +
+                                            `${indent}${indent}throw new Error('Function not implemented.');\n` +
+                                            `${indent}}\n`,
+                                        range: {
+                                            start: {
+                                                character: 0,
+                                                line: 2
+                                            },
+                                            end: {
+                                                character: 0,
+                                                line: 2
+                                            }
+                                        }
+                                    }
+                                ],
+                                textDocument: {
+                                    uri: getUri('fix-missing-function-element.svelte'),
+                                    version: null
+                                }
+                            }
+                        ]
+                    },
+                    kind: CodeActionKind.QuickFix,
+                    title: "Add missing function declaration 'handleClick'"
+                }
+            ]);
+        });
+
         function testFixMissingFunctionQuickFix(codeActions: CodeAction[]) {
             (<TextDocumentEdit>codeActions[0]?.edit?.documentChanges?.[0])?.edits.forEach(
                 (edit) => (edit.newText = harmonizeNewLines(edit.newText))

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/fix-missing-function-element.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/fix-missing-function-element.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+
+</script>
+
+<button on:click={handleClick} />


### PR DESCRIPTION
#1554

As mentioned in https://github.com/sveltejs/language-tools/issues/1554#issuecomment-1320822454. The implementation in ts 4.9 doesn't work for functions typed as nullable. We can add this on our own and remove the custom implementation once TypeScript added the support. Usually, TypeScript only adds critical fixes in patch releases. So I think even if it was fixed in TypeScript it would be in TypeScript 5.0 which is planned to be nearly 4 months later. 

