### PR TITLE
(feat) better commit characters handling

### DIFF
--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -247,39 +247,6 @@ export function scriptElementKindToCompletionItemKind(
     return CompletionItemKind.Property;
 }
 
-export function getCommitCharactersForScriptElement(
-    kind: ts.ScriptElementKind
-): string[] | undefined {
-    const commitCharacters: string[] = [];
-    switch (kind) {
-        case ts.ScriptElementKind.memberGetAccessorElement:
-        case ts.ScriptElementKind.memberSetAccessorElement:
-        case ts.ScriptElementKind.constructSignatureElement:
-        case ts.ScriptElementKind.callSignatureElement:
-        case ts.ScriptElementKind.indexSignatureElement:
-        case ts.ScriptElementKind.enumElement:
-        case ts.ScriptElementKind.interfaceElement:
-            commitCharacters.push('.');
-            break;
-
-        case ts.ScriptElementKind.moduleElement:
-        case ts.ScriptElementKind.alias:
-        case ts.ScriptElementKind.constElement:
-        case ts.ScriptElementKind.letElement:
-        case ts.ScriptElementKind.variableElement:
-        case ts.ScriptElementKind.localVariableElement:
-        case ts.ScriptElementKind.memberVariableElement:
-        case ts.ScriptElementKind.classElement:
-        case ts.ScriptElementKind.functionElement:
-        case ts.ScriptElementKind.memberFunctionElement:
-            commitCharacters.push('.', ',');
-            commitCharacters.push('(');
-            break;
-    }
-
-    return commitCharacters.length === 0 ? undefined : commitCharacters;
-}
-
 export function mapSeverity(category: ts.DiagnosticCategory): DiagnosticSeverity {
     switch (category) {
         case ts.DiagnosticCategory.Error:

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -85,7 +85,7 @@ function test(useNewTransformation: boolean) {
                 insertText: undefined,
                 kind: CompletionItemKind.Method,
                 sortText: '11',
-                commitCharacters: ['.', ',', '('],
+                commitCharacters: ['.', ',', ';', '('],
                 preselect: undefined,
                 textEdit: undefined
             });
@@ -111,7 +111,7 @@ function test(useNewTransformation: boolean) {
                 insertText: undefined,
                 kind: CompletionItemKind.Field,
                 sortText: '11',
-                commitCharacters: ['.', ',', '('],
+                commitCharacters: ['.', ',', ';', '('],
                 preselect: undefined,
                 textEdit: undefined
             });
@@ -512,7 +512,7 @@ function test(useNewTransformation: boolean) {
             const { documentation, detail } = await completionProvider.resolveCompletion(document, {
                 label: 'foo',
                 kind: 6,
-                commitCharacters: ['.', ',', '('],
+                commitCharacters: ['.', ',', ';', '('],
                 data: {
                     name: 'foo',
                     kind: ts.ScriptElementKind.alias,
@@ -1168,7 +1168,7 @@ function test(useNewTransformation: boolean) {
                 insertText: 'import { blubb } from "../definitions";',
                 kind: CompletionItemKind.Function,
                 sortText: '11',
-                commitCharacters: ['.', ',', '('],
+                commitCharacters: undefined,
                 preselect: undefined,
                 textEdit: {
                     newText: '{ blubb } from "../definitions";',
@@ -1226,7 +1226,7 @@ function test(useNewTransformation: boolean) {
                 insertText: '?.toString',
                 kind: CompletionItemKind.Method,
                 sortText: '11',
-                commitCharacters: ['.', ',', '('],
+                commitCharacters: ['.', ',', ';', '('],
                 preselect: undefined,
                 textEdit: {
                     newText: '.toString',
@@ -1268,7 +1268,7 @@ function test(useNewTransformation: boolean) {
                 sortText: '11',
                 preselect: undefined,
                 insertText: undefined,
-                commitCharacters: undefined,
+                commitCharacters: ['.', ',', ';', '('],
                 textEdit: {
                     newText: '@hi',
                     range: {


### PR DESCRIPTION
#1737
- no commit characters in invalid state in template
- no commit characters when TS says it's `isNewIdentifierLocation` (matches VS Code behavior)