### PR TITLE
(fix) type error for component with no props

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expected.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expected.json
@@ -12,8 +12,19 @@
     },
     {
         "range": {
-            "start": { "line": 40, "character": 0 },
-            "end": { "line": 40, "character": 49 }
+            "start": { "line": 37, "character": 10 },
+            "end": { "line": 37, "character": 25 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Type 'boolean' is not assignable to type 'never'.",
+        "code": 2322,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 41, "character": 0 },
+            "end": { "line": 41, "character": 49 }
         },
         "severity": 1,
         "source": "ts",
@@ -23,8 +34,8 @@
     },
     {
         "range": {
-            "start": { "line": 40, "character": 1 },
-            "end": { "line": 40, "character": 11 }
+            "start": { "line": 41, "character": 1 },
+            "end": { "line": 41, "character": 11 }
         },
         "severity": 1,
         "source": "ts",
@@ -34,8 +45,8 @@
     },
     {
         "range": {
-            "start": { "line": 40, "character": 48 },
-            "end": { "line": 40, "character": 48 }
+            "start": { "line": 41, "character": 48 },
+            "end": { "line": 41, "character": 48 }
         },
         "severity": 1,
         "source": "ts",
@@ -45,8 +56,8 @@
     },
     {
         "range": {
-            "start": { "line": 40, "character": 24 },
-            "end": { "line": 42, "character": 12 }
+            "start": { "line": 41, "character": 24 },
+            "end": { "line": 43, "character": 12 }
         },
         "severity": 1,
         "source": "ts",

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expectedv2.json
@@ -12,8 +12,19 @@
     },
     {
         "range": {
-            "start": { "line": 37, "character": 24 },
-            "end": { "line": 37, "character": 34 }
+            "start": { "line": 37, "character": 10 },
+            "end": { "line": 37, "character": 25 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Type 'boolean' is not assignable to type 'never'.",
+        "code": 2322,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 38, "character": 24 },
+            "end": { "line": 38, "character": 34 }
         },
         "severity": 1,
         "source": "ts",
@@ -23,8 +34,8 @@
     },
     {
         "range": {
-            "start": { "line": 40, "character": 1 },
-            "end": { "line": 40, "character": 11 }
+            "start": { "line": 41, "character": 1 },
+            "end": { "line": 41, "character": 11 }
         },
         "severity": 1,
         "source": "ts",
@@ -34,8 +45,8 @@
     },
     {
         "range": {
-            "start": { "line": 43, "character": 24 },
-            "end": { "line": 43, "character": 34 }
+            "start": { "line": 44, "character": 24 },
+            "end": { "line": 44, "character": 34 }
         },
         "severity": 1,
         "source": "ts",

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/input.svelte
@@ -35,6 +35,7 @@
 
 <!-- invalid -->
 <DoesntWork />
+<Imported propDoesntExist={true} />
 <svelte:component this={DoesntWork} />
 
 <!-- invalid, no additional errors for new transformation (everything else is any) -->

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -346,13 +346,18 @@ export class ExportedNames {
             );
         }
 
+        if (names.length === 0) {
+            // Necessary, because {} roughly equals to any
+            return isTsFile
+                ? '{} as Record<string, never>'
+                : '/** @type {Record<string, never>} */ ({})';
+        }
+
         const dontAddTypeDef =
-            !isTsFile ||
-            names.length === 0 ||
-            names.every(([_, value]) => !value.type && value.required);
+            !isTsFile || names.every(([_, value]) => !value.type && value.required);
         const returnElements = this.createReturnElements(names, dontAddTypeDef);
         if (dontAddTypeDef) {
-            // No exports or only `typeof` exports -> omit the `as {...}` completely.
+            // Only `typeof` exports -> omit the `as {...}` completely.
             // If not TS, omit the types to not have a "cannot use types in jsx" error.
             return `{${returnElements.join(' , ')}}`;
         }

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -102,7 +102,7 @@ type SvelteAnimationReturnType = {
 
 type SvelteWithOptionalProps<Props, Keys extends keyof Props> = Omit<Props, Keys> & Partial<Pick<Props, Keys>>;
 type SvelteAllProps = { [index: string]: any }
-type SveltePropsAnyFallback<Props> = {[K in keyof Props]: Props[K] extends undefined ? any : Props[K]}
+type SveltePropsAnyFallback<Props> = {[K in keyof Props]: Props[K] extends never ? never : Props[K] extends undefined ? any : Props[K]}
 type SvelteSlotsAnyFallback<Slots> = {[K in keyof Slots]: {[S in keyof Slots[K]]: Slots[K][S] extends undefined ? any : Slots[K][S]}}
 type SvelteRestProps = { [index: string]: any }
 type SvelteSlots = { [index: string]: any }

--- a/packages/svelte2tsx/test/emitDts/samples/javascript/expected/TestNoScript.svelte.d.ts
+++ b/packages/svelte2tsx/test/emitDts/samples/javascript/expected/TestNoScript.svelte.d.ts
@@ -1,7 +1,9 @@
 /** @typedef {typeof __propDef.props}  TestNoScriptProps */
 /** @typedef {typeof __propDef.events}  TestNoScriptEvents */
 /** @typedef {typeof __propDef.slots}  TestNoScriptSlots */
-export default class TestNoScript extends SvelteComponentTyped<{}, {
+export default class TestNoScript extends SvelteComponentTyped<{
+    [x: string]: never;
+}, {
     click: MouseEvent;
 } & {
     [evt: string]: CustomEvent<any>;
@@ -14,7 +16,9 @@ export type TestNoScriptEvents = typeof __propDef.events;
 export type TestNoScriptSlots = typeof __propDef.slots;
 import { SvelteComponentTyped } from "svelte";
 declare const __propDef: {
-    props: {};
+    props: {
+        [x: string]: never;
+    };
     events: {
         click: MouseEvent;
     } & {

--- a/packages/svelte2tsx/test/sourcemaps/samples/action-directive/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/action-directive/mappings.jsx
@@ -67,7 +67,7 @@
 /></>↲    [generated] line 24                                                                                                                         
 />        [original] line 22                                                                                                                          
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/await-block/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/await-block/mappings.jsx
@@ -58,7 +58,7 @@
 {                                                                                                                                                     
 {/await}                                                  [original] line 13                                                                          
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/component-props/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/component-props/mappings.jsx
@@ -37,7 +37,7 @@
 /></>↲    [generated] line 19                                                                                                                         
 />        [original] line 17                                                                                                                          
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/each-block/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/each-block/mappings.jsx
@@ -98,7 +98,7 @@
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
     <p>No tasks today!</p>
 </>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/element-attributes/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/element-attributes/mappings.jsx
@@ -57,7 +57,7 @@
 /></>↲    [generated] line 27                                                                                                                         
 />        [original] line 25                                                                                                                          
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/event-binding/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/event-binding/mappings.jsx
@@ -15,7 +15,7 @@
 <button•on:     ={$check•?•method1•:•method2}•>Bla</button>                                                                                           
 <button•on:click={$check•?•method1•:•method2}•>Bla</button>       [original] line 2                                                                   
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/if-block/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/if-block/mappings.jsx
@@ -55,7 +55,7 @@
 {                                                                                                                                                     
 {/if}        [original] line 13                                                                                                                       
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/import-equal/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/import-equal/mappings.jsx
@@ -24,7 +24,7 @@
 </script>    [original] line 4                                                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/let/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/let/mappings.jsx
@@ -24,7 +24,7 @@
 </script>    [original] line 3                                                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/property-shorthand/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/property-shorthand/mappings.jsx
@@ -7,7 +7,7 @@
   <button•      {count}>button</button>                                                                                                               
 <button•{count}>button</button>                [original] line 1                                                                                      
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/reserved-variables/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/reserved-variables/mappings.jsx
@@ -51,7 +51,7 @@
 {                                                                                                                                                     
 {/if}                 [original] line 13                                                                                                              
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/simple-element/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/simple-element/mappings.jsx
@@ -7,7 +7,7 @@
   <h1>Hello•World</h1>                                                                                                                                
 <h1>Hello•World</h1>          [original] line 1                                                                                                       
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/slot-let/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/slot-let/mappings.jsx
@@ -17,7 +17,7 @@
      </Component>                                                                                                                                     
 </Component>             [original] line 3                                                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/sourcemaps/samples/slots/mappings.jsx
+++ b/packages/svelte2tsx/test/sourcemaps/samples/slots/mappings.jsx
@@ -36,7 +36,7 @@
 </slot></>↲    [generated] line 14                                                                                                                    
 </slot>        [original] line 11                                                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------ */}
-return { props: {}, slots: {'default': {}, 'foo': {}, 'bar': {foo:foo, baz:baz}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {}, 'foo': {}, 'bar': {foo:foo, baz:baz}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-as-directive/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-as-directive/expected.tsx
@@ -17,7 +17,7 @@
     {...__sveltets_1_ensureAnimation($animateStore(__sveltets_1_mapElementTag('div'),__sveltets_1_AnimationMove,{}))}
 >
 </div></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-as-directive/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-as-directive/expectedv2.ts
@@ -11,7 +11,7 @@ async () => {
 
  {const $$action_0 = __sveltets_2_ensureAction($actionStore(svelteHTML.mapElementTag('div')));{ svelteHTML.createElement("div", __sveltets_2_union($$action_0), {      });__sveltets_2_ensureTransition($transitionStore(svelteHTML.mapElementTag('div'),({ y: 100 })));__sveltets_2_ensureTransition($inStore(svelteHTML.mapElementTag('div')));__sveltets_2_ensureTransition($outStore(svelteHTML.mapElementTag('div')));__sveltets_2_ensureAnimation($animateStore(svelteHTML.mapElementTag('div'),__sveltets_2_AnimationMove));
  }}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-assign/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-assign/expected.tsx
@@ -23,7 +23,7 @@
     $store.b = false;
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-assign/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-assign/expectedv2.ts
@@ -23,7 +23,7 @@
     $store.b = false;
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-index/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-index/expected.tsx
@@ -3,7 +3,7 @@
 <>{someRecordOrArr[$store]}
 {someObject['$store']}
 {someObject.$store}</>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-index/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-index/expectedv2.ts
@@ -3,7 +3,7 @@
 async () => {someRecordOrArr[$store];
 someObject['$store'];
 someObject.$store;};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-inside-block-without-braces/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-inside-block-without-braces/expected.tsx
@@ -27,7 +27,7 @@
         $store1
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-inside-block-without-braces/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-inside-block-without-braces/expectedv2.ts
@@ -27,7 +27,7 @@
         $store1
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-no-instance-only-module-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-no-instance-only-module-script/expected.tsx
@@ -7,7 +7,7 @@
 
 {$store1}
 {$store2}</>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-no-instance-only-module-script/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-no-instance-only-module-script/expectedv2.ts
@@ -7,7 +7,7 @@ async () => {/*Ωignore_startΩ*/;let $store1 = __sveltets_1_store_get(store1);/
 
 $store1;
 $store2;};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-prop-init/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-prop-init/expected.tsx
@@ -6,7 +6,7 @@
     const bar = { $store: $store };
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-prop-init/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-prop-init/expectedv2.ts
@@ -6,7 +6,7 @@
     const bar = { $store: $store };
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expected.tsx
@@ -2,7 +2,7 @@
 <></>;function render() {
 $var;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-none/expectedv2.ts
@@ -2,7 +2,7 @@
 ;function render() {
 $var;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expected.tsx
@@ -2,7 +2,7 @@
 <></>;function render() {
    $var;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ast-offset-some/expectedv2.ts
@@ -2,7 +2,7 @@
 ;function render() {
    $var;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/attributes-foreign-ns/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/attributes-foreign-ns/expected.tsx
@@ -2,7 +2,7 @@
 <></>;function render() {
 <><element someAttr="hi" someOtherAttribute="there">hello</element>
 <Component someAttr="5" otherAttr={6} /></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/attributes-foreign-ns/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/attributes-foreign-ns/expectedv2.ts
@@ -2,7 +2,7 @@
 ;function render() {
 async () => { { svelteHTML.createElement("element", {   "someAttr":`hi`,"someOtherAttribute":`there`,});  }
  { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {    "someAttr":`5`,"otherAttr":6,}});}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expected.tsx
@@ -13,7 +13,7 @@ function render() {
 </>; __sveltets_1_awaitThen(_$$p, (data) => {<>
 	{data}
 </>})}}</>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/await-with-$store/expectedv2.ts
@@ -13,7 +13,7 @@ async () => {
 const $$_value = await ($store);{ const data = $$_value; 
 	data;
 }}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-assignment-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-assignment-$store/expected.tsx
@@ -6,7 +6,7 @@
 <div {...__sveltets_1_empty($compile_options.foo = /*Ωignore_startΩ*/__sveltets_1_instanceOf(__sveltets_1_ctorOf(__sveltets_1_mapElementTag('div')))/*Ωignore_endΩ*/)} />
 <div noAssignment={$compile_options} />
 <div noAssignment={$compile_options.foo} /></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-assignment-$store/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-assignment-$store/expectedv2.ts
@@ -6,7 +6,7 @@ async () => { { const $$_div0 = svelteHTML.createElement("div", {  });$compile_o
  { const $$_div0 = svelteHTML.createElement("div", {  });$compile_options.foo = $$_div0;}
  { svelteHTML.createElement("div", {  "bind:noAssignment":$compile_options,});}
  { svelteHTML.createElement("div", {  "bind:noAssignment":$compile_options.foo,});}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <><input id="dom-input" type="radio" {...__sveltets_1_empty($compile_options.generate)} value="dom"/></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => { { svelteHTML.createElement("input", {      "id":`dom-input`,"type":`radio`,"value":`dom`,});$compile_options.generate;}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expected.tsx
@@ -88,7 +88,7 @@
 		<input type="range" value={selected.r} oninput={adjust}/>
 	</div>
 </> : <></>}</>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/circle-drawer-example/expectedv2.ts
@@ -84,7 +84,7 @@ if(adjusting){
 		 { svelteHTML.createElement("input", {     "type":`range`,"value":selected.r,"on:input":adjust,});}
 	 }
 }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/commented-out-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/commented-out-script/expected.tsx
@@ -6,7 +6,7 @@
 () => (<>
 
 </>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/commented-out-script/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/commented-out-script/expectedv2.ts
@@ -6,7 +6,7 @@
 async () => {
 
 };
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expected.tsx
@@ -8,7 +8,7 @@
 <div>
     <slot a={__sveltets_ensureSlot("default","a",b)}>Hello</slot>
 </div></>);
-return { props: {}, slots: {'default': {a:b}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:b}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-default-slot/expectedv2.ts
@@ -8,7 +8,7 @@ async () => {
  { svelteHTML.createElement("div", {});
      { __sveltets_createSlot("default", { "a":b,});  }
  }};
-return { props: {}, slots: {'default': {a:b}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:b}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-constant/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-constant/expected.tsx
@@ -13,7 +13,7 @@
     }
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-constant/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-constant/expectedv2.ts
@@ -13,7 +13,7 @@
     }
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-dispatcher/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-dispatcher/expected.tsx
@@ -17,7 +17,7 @@ function render() {
     const dispatch = createEventDispatcher<__sveltets_1_CustomEvents<$$Events>>();
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-dispatcher/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-dispatcher/expectedv2.ts
@@ -17,7 +17,7 @@ function render() {
     const dispatch = createEventDispatcher<__sveltets_1_CustomEvents<$$Events>>();
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-string-literals/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-string-literals/expected.tsx
@@ -11,7 +11,7 @@
     }
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-string-literals/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface-string-literals/expectedv2.ts
@@ -11,7 +11,7 @@
     }
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface/expected.tsx
@@ -11,7 +11,7 @@
     }
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-interface/expectedv2.ts
@@ -11,7 +11,7 @@
     }
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-strictEvents/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-strictEvents/expected.tsx
@@ -11,7 +11,7 @@ function render() {
 () => (<>
 
 <button onclick={undefined}>d</button></>);
-return { props: {}, slots: {}, events: {'click':__sveltets_1_mapElementEvent('click'), 'foo': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_mapElementEvent('click'), 'foo': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-strictEvents/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-strictEvents/expectedv2.ts
@@ -11,7 +11,7 @@ function render() {
 async () => {
 
  { svelteHTML.createElement("button", { "on:click":undefined,});  }};
-return { props: {}, slots: {}, events: {'click':__sveltets_1_mapElementEvent('click'), 'foo': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_mapElementEvent('click'), 'foo': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-type/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-type/expected.tsx
@@ -11,7 +11,7 @@
     }
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-events-type/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-events-type/expectedv2.ts
@@ -11,7 +11,7 @@
     }
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} as unknown as $$Events }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} as unknown as $$Events }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expected.tsx
@@ -12,7 +12,7 @@
     <slot name="test" c={__sveltets_ensureSlot("test","c",d)} e={__sveltets_ensureSlot("test","e",e)}></slot>
     <slot name="abc-cde.113"></slot>
 </div></>);
-return { props: {}, slots: {'default': {a:b}, 'test': {c:d, e:e}, 'abc-cde.113': {}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:b}, 'test': {c:d, e:e}, 'abc-cde.113': {}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-multiple-slots/expectedv2.ts
@@ -12,7 +12,7 @@ async () => {
      { __sveltets_createSlot("test", {    "c":d,e,}); }
      { __sveltets_createSlot("abc-cde.113", { }); }
  }};
-return { props: {}, slots: {'default': {a:b}, 'test': {c:d, e:e}, 'abc-cde.113': {}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:b}, 'test': {c:d, e:e}, 'abc-cde.113': {}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-interface/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-interface/expected.tsx
@@ -18,7 +18,7 @@
     <slot a={__sveltets_ensureSlot("default","a",b)} />
     <slot name="foo" b={__sveltets_ensureSlot("foo","b",b)} />
 </div></>);
-return { props: {}, slots: {} as unknown as $$Slots, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {} as unknown as $$Slots, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-interface/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-interface/expectedv2.ts
@@ -18,7 +18,7 @@ async () => {
      { __sveltets_createSlot("default", {  "a":b,});}
      { __sveltets_createSlot("foo", {   b,});}
  }};
-return { props: {}, slots: {} as unknown as $$Slots, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {} as unknown as $$Slots, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-type/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-type/expected.tsx
@@ -18,7 +18,7 @@
     <slot a={__sveltets_ensureSlot("default","a",b)} />
     <slot name="foo" b={__sveltets_ensureSlot("foo","b",b)} />
 </div></>);
-return { props: {}, slots: {} as unknown as $$Slots, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {} as unknown as $$Slots, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-type/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-$$slot-type/expectedv2.ts
@@ -18,7 +18,7 @@ async () => {
      { __sveltets_createSlot("default", {  "a":b,});}
      { __sveltets_createSlot("foo", {   b,});}
  }};
-return { props: {}, slots: {} as unknown as $$Slots, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {} as unknown as $$Slots, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expected.tsx
@@ -8,7 +8,7 @@
 <div>
     <slot a={__sveltets_ensureSlot("default","a",b)} b={__sveltets_ensureSlot("default","b",b)} c={__sveltets_ensureSlot("default","c","b")} d={__sveltets_ensureSlot("default","d",`a${b}`)} e={__sveltets_ensureSlot("default","e",b)} >Hello</slot>
 </div></>);
-return { props: {}, slots: {'default': {a:b, b:b, c:"b", d:"__svelte_ts_string", e:b}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:b, b:b, c:"b", d:"__svelte_ts_string", e:b}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-crazy-attributes/expectedv2.ts
@@ -8,7 +8,7 @@ async () => {
  { svelteHTML.createElement("div", {});
      { __sveltets_createSlot("default", {       "a":b,b,"c":`b`,"d":`a${b}`,"e":b,});  }
  }};
-return { props: {}, slots: {'default': {a:b, b:b, c:"b", d:"__svelte_ts_string", e:b}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:b, b:b, c:"b", d:"__svelte_ts_string", e:b}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-fallback/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-fallback/expected.tsx
@@ -5,7 +5,7 @@
 <slot name="foo" bar={__sveltets_ensureSlot("foo","bar",bar)} baz={__sveltets_ensureSlot("foo","baz","boo")}>
     <p>fallback</p>
 </slot></>
-return { props: {}, slots: {'default': {}, 'foo': {bar:bar, baz:"boo"}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {}, 'foo': {bar:bar, baz:"boo"}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-fallback/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-fallback/expectedv2.ts
@@ -5,7 +5,7 @@ async () => { { __sveltets_createSlot("default", {}); { svelteHTML.createElement
  { __sveltets_createSlot("foo", {    bar,"baz":`boo`,});
      { svelteHTML.createElement("p", {});  }
  }};
-return { props: {}, slots: {'default': {}, 'foo': {bar:bar, baz:"boo"}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {}, 'foo': {bar:bar, baz:"boo"}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-forward-with-props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-forward-with-props/expected.tsx
@@ -4,7 +4,7 @@
 <><Parent propA propB={propB} propC="val1" propD="val2" propE={`a${a}b${b}`} >{() => { let {foo} = /*Ωignore_startΩ*/new Parent({target: __sveltets_1_any(''), props: {'propA':true, 'propB':propB, 'propC':'val1', 'propD':"val2", 'propE':`a${a}b${b}`}})/*Ωignore_endΩ*/.$$slot_def['default'];<>
     <slot foo={__sveltets_ensureSlot("default","foo",foo)} />
 </>}}</Parent></>
-return { props: {}, slots: {'default': {foo:__sveltets_1_instanceOf(Parent).$$slot_def['default'].foo}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {foo:__sveltets_1_instanceOf(Parent).$$slot_def['default'].foo}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-forward-with-props/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-forward-with-props/expectedv2.ts
@@ -4,7 +4,7 @@
 async () => { { const $$_tneraP0C = __sveltets_2_ensureComponent(Parent); const $$_tneraP0 = new $$_tneraP0C({ target: __sveltets_2_any(), props: {      "propA":true,propB,"propC":`val1`,"propD":`val2`,"propE":`a${a}b${b}`,}});{const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,foo,} = $$_tneraP0.$$slot_def.default;$$_$$;
      { __sveltets_createSlot("default", { foo,});}
  }Parent}};
-return { props: {}, slots: {'default': {foo:__sveltets_1_instanceOf(Parent).$$slot_def['default'].foo}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {foo:__sveltets_1_instanceOf(Parent).$$slot_def['default'].foo}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-await/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-await/expected.tsx
@@ -9,7 +9,7 @@
 {() => {let _$$p = (promise2); __sveltets_1_awaitThen(_$$p, ({ b }) => {<>
     <slot name="second" a={__sveltets_ensureSlot("second","a",b)}>Hello</slot>
 </>})}}</>
-return { props: {}, slots: {'default': {a:__sveltets_1_unwrapPromiseLike(promise)}, 'err': {err:__sveltets_1_any({})}, 'second': {a:(({ b }) => b)(__sveltets_1_unwrapPromiseLike(promise2))}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_unwrapPromiseLike(promise)}, 'err': {err:__sveltets_1_any({})}, 'second': {a:(({ b }) => b)(__sveltets_1_unwrapPromiseLike(promise2))}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-await/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-await/expectedv2.ts
@@ -9,7 +9,7 @@ async () => {    { try { const $$_value = await (promise);{ const value = $$_val
    { const $$_value = await (promise2);{ const { b } = $$_value; 
      { __sveltets_createSlot("second", {   "a":b,});  }
 }}};
-return { props: {}, slots: {'default': {a:__sveltets_1_unwrapPromiseLike(promise)}, 'err': {err:__sveltets_1_any({})}, 'second': {a:(({ b }) => b)(__sveltets_1_unwrapPromiseLike(promise2))}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_unwrapPromiseLike(promise)}, 'err': {err:__sveltets_1_any({})}, 'second': {a:(({ b }) => b)(__sveltets_1_unwrapPromiseLike(promise2))}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-each/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-each/expected.tsx
@@ -7,7 +7,7 @@
 {__sveltets_1_each(items2, ({ a }) => <>
     <slot name="second" a={__sveltets_ensureSlot("second","a",a)}>Hello</slot>
 </>)}</>
-return { props: {}, slots: {'default': {a:__sveltets_1_unwrapArr(items)}, 'second': {a:(({ a }) => a)(__sveltets_1_unwrapArr(items2))}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_unwrapArr(items)}, 'second': {a:(({ a }) => a)(__sveltets_1_unwrapArr(items2))}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-each/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-inside-each/expectedv2.ts
@@ -7,7 +7,7 @@ async () => {  for(let item of __sveltets_2_ensureArray(items)){
   for(let { a } of __sveltets_2_ensureArray(items2)){
      { __sveltets_createSlot("second", {  a,});  }
 }};
-return { props: {}, slots: {'default': {a:__sveltets_1_unwrapArr(items)}, 'second': {a:(({ a }) => a)(__sveltets_1_unwrapArr(items2))}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_unwrapArr(items)}, 'second': {a:(({ a }) => a)(__sveltets_1_unwrapArr(items2))}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward-named-slot/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward-named-slot/expected.tsx
@@ -6,7 +6,7 @@
         <slot a={__sveltets_ensureSlot("default","a",a)}></slot>
     </div></>}}
 </Component></>
-return { props: {}, slots: {'default': {a:__sveltets_1_instanceOf(Component).$$slot_def['b'].a}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_instanceOf(Component).$$slot_def['b'].a}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward-named-slot/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward-named-slot/expectedv2.ts
@@ -6,7 +6,7 @@ async () => { { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); 
          { __sveltets_createSlot("default", {a,}); }
      }}
  Component}};
-return { props: {}, slots: {'default': {a:__sveltets_1_instanceOf(Component).$$slot_def['b'].a}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_instanceOf(Component).$$slot_def['b'].a}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward/expected.tsx
@@ -4,7 +4,7 @@
 <><Component   >{() => { let {name:n, thing, whatever:{ bla }} = /*Ωignore_startΩ*/new Component({target: __sveltets_1_any(''), props: {}})/*Ωignore_endΩ*/.$$slot_def['default'];<>
     <slot n={__sveltets_ensureSlot("default","n",n)} thing={__sveltets_ensureSlot("default","thing",thing)} bla={__sveltets_ensureSlot("default","bla",bla)} />
 </>}}</Component></>
-return { props: {}, slots: {'default': {n:__sveltets_1_instanceOf(Component).$$slot_def['default'].name, thing:__sveltets_1_instanceOf(Component).$$slot_def['default'].thing, bla:(({ bla }) => bla)(__sveltets_1_instanceOf(Component).$$slot_def['default'].whatever)}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {n:__sveltets_1_instanceOf(Component).$$slot_def['default'].name, thing:__sveltets_1_instanceOf(Component).$$slot_def['default'].thing, bla:(({ bla }) => bla)(__sveltets_1_instanceOf(Component).$$slot_def['default'].whatever)}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward/expectedv2.ts
@@ -4,7 +4,7 @@
 async () => { { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); const $$_tnenopmoC0 = new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {     }});{const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,name:n,thing,whatever:{ bla },} = $$_tnenopmoC0.$$slot_def.default;$$_$$;
      { __sveltets_createSlot("default", {   n,thing,bla,});}
  }Component}};
-return { props: {}, slots: {'default': {n:__sveltets_1_instanceOf(Component).$$slot_def['default'].name, thing:__sveltets_1_instanceOf(Component).$$slot_def['default'].thing, bla:(({ bla }) => bla)(__sveltets_1_instanceOf(Component).$$slot_def['default'].whatever)}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {n:__sveltets_1_instanceOf(Component).$$slot_def['default'].name, thing:__sveltets_1_instanceOf(Component).$$slot_def['default'].thing, bla:(({ bla }) => bla)(__sveltets_1_instanceOf(Component).$$slot_def['default'].whatever)}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-nest-scope/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-nest-scope/expected.tsx
@@ -12,7 +12,7 @@
     {d}
 </>})}}
 <slot name="third" d={__sveltets_ensureSlot("third","d",d)} c={__sveltets_ensureSlot("third","c",c)}></slot></>
-return { props: {}, slots: {'default': {a:(({ a }) => a)(__sveltets_1_unwrapArr(__sveltets_1_unwrapArr(items)))}, 'second': {a:a}, 'third': {d:d, c:c}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:(({ a }) => a)(__sveltets_1_unwrapArr(__sveltets_1_unwrapArr(items)))}, 'second': {a:a}, 'third': {d:d, c:c}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-nest-scope/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-nest-scope/expectedv2.ts
@@ -12,7 +12,7 @@ async () => {  for(let item of __sveltets_2_ensureArray(items)){
     d;
 }}
  { __sveltets_createSlot("third", {   d,c,}); }};
-return { props: {}, slots: {'default': {a:(({ a }) => a)(__sveltets_1_unwrapArr(__sveltets_1_unwrapArr(items)))}, 'second': {a:a}, 'third': {d:d, c:c}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:(({ a }) => a)(__sveltets_1_unwrapArr(__sveltets_1_unwrapArr(items)))}, 'second': {a:a}, 'third': {d:d, c:c}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-no-space/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-no-space/expected.tsx
@@ -8,7 +8,7 @@ function render() {
 () => (<>
 
 <div><Test >{() => { let {t} = /*Ωignore_startΩ*/new Test({target: __sveltets_1_any(''), props: {}})/*Ωignore_endΩ*/.$$slot_def['default'];<>xx</>}}</Test></div></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-no-space/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-no-space/expectedv2.ts
@@ -8,7 +8,7 @@ function render() {
 async () => {
 
  { svelteHTML.createElement("div", {}); { const $$_tseT1C = __sveltets_2_ensureComponent(Test); const $$_tseT1 = new $$_tseT1C({ target: __sveltets_2_any(), props: { }});{const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,t,} = $$_tseT1.$$slot_def.default;$$_$$;  }Test} }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-object-key/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-object-key/expected.tsx
@@ -4,7 +4,7 @@
 <>{__sveltets_1_each(items, (item) => <>
     <slot a={__sveltets_ensureSlot("default","a",item)} b={__sveltets_ensureSlot("default","b",{ item })} c={__sveltets_ensureSlot("default","c",{ item: 'abc' }.item)} d={__sveltets_ensureSlot("default","d",{ item: item })} e={__sveltets_ensureSlot("default","e",$item)} f={__sveltets_ensureSlot("default","f",$item)} {...g} {...item}>Hello</slot>
 </>)}</>
-return { props: {}, slots: {'default': {a:__sveltets_1_unwrapArr(items), b:{ item:__sveltets_1_unwrapArr(items) }, c:{ item: 'abc' }.item, d:{ item: __sveltets_1_unwrapArr(items) }, e:$item, f:$item, ...g, ...__sveltets_1_unwrapArr(items)}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_unwrapArr(items), b:{ item:__sveltets_1_unwrapArr(items) }, c:{ item: 'abc' }.item, d:{ item: __sveltets_1_unwrapArr(items) }, e:$item, f:$item, ...g, ...__sveltets_1_unwrapArr(items)}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-object-key/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-object-key/expectedv2.ts
@@ -4,7 +4,7 @@
 async () => {  for(let item of __sveltets_2_ensureArray(items)){
      { __sveltets_createSlot("default", {             "a":item,"b":{ item },"c":{ item: 'abc' }.item,"d":{ item: item },"e":$item,"f":$item,...g,...item,});  }
 }};
-return { props: {}, slots: {'default': {a:__sveltets_1_unwrapArr(items), b:{ item:__sveltets_1_unwrapArr(items) }, c:{ item: 'abc' }.item, d:{ item: __sveltets_1_unwrapArr(items) }, e:$item, f:$item, ...g, ...__sveltets_1_unwrapArr(items)}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_unwrapArr(items), b:{ item:__sveltets_1_unwrapArr(items) }, c:{ item: 'abc' }.item, d:{ item: __sveltets_1_unwrapArr(items) }, e:$item, f:$item, ...g, ...__sveltets_1_unwrapArr(items)}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-var-shadowing/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-var-shadowing/expected.tsx
@@ -4,7 +4,7 @@
 <>{__sveltets_1_each(items, (items) => <>
     <slot a={__sveltets_ensureSlot("default","a",items)}>Hello</slot>
 </>)}</>
-return { props: {}, slots: {'default': {a:__sveltets_1_unwrapArr(items)}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_unwrapArr(items)}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-var-shadowing/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-var-shadowing/expectedv2.ts
@@ -4,7 +4,7 @@
 async () => {  { const $$_each = __sveltets_2_ensureArray(items); for(let items of $$_each){
      { __sveltets_createSlot("default", { "a":items,});  }
 }}};
-return { props: {}, slots: {'default': {a:__sveltets_1_unwrapArr(items)}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:__sveltets_1_unwrapArr(items)}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expected.tsx
@@ -3,7 +3,7 @@
 <>
 
 <main>At least I am documented</main></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 /** This component does nothing at all */
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expectedv2.ts
@@ -3,7 +3,7 @@
 async () => {
 
  { svelteHTML.createElement("main", {});     }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 /** This component does nothing at all */
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expected.tsx
@@ -3,7 +3,7 @@
 <>
 
 <main>At least I am documented</main></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 /**
  * This component has indented multiline documentation:

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expectedv2.ts
@@ -3,7 +3,7 @@
 async () => {
 
  { svelteHTML.createElement("main", {});     }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 /**
  * This component has indented multiline documentation:

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expected.tsx
@@ -3,7 +3,7 @@
 <>
 
 <main>At least I am documented</main></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 /**
  * This component has multiline documentation:

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expectedv2.ts
@@ -3,7 +3,7 @@
 async () => {
 
  { svelteHTML.createElement("main", {});     }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 /**
  * This component has multiline documentation:

--- a/packages/svelte2tsx/test/svelte2tsx/samples/creates-no-script-dts/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/creates-no-script-dts/expected.tsx
@@ -6,7 +6,7 @@ declare function __sveltets_1_createSvelteComponentTyped<Props, Events, Slots>(
 
 function render() {
 
-return { props: {}, slots: {'default': {}}, events: {'click':__sveltets_1_mapElementEvent('click')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {}}, events: {'click':__sveltets_1_mapElementEvent('click')} }}
 const __propDef = __sveltets_1_partial(__sveltets_1_with_any_event(render()));
 /** @typedef {typeof __propDef.props}  InputProps */
 /** @typedef {typeof __propDef.events}  InputEvents */

--- a/packages/svelte2tsx/test/svelte2tsx/samples/creates-no-script-dts/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/creates-no-script-dts/expectedv2.ts
@@ -6,7 +6,7 @@ declare function __sveltets_1_createSvelteComponentTyped<Props, Events, Slots>(
 
 function render() {
 
-return { props: {}, slots: {'default': {}}, events: {'click':__sveltets_1_mapElementEvent('click')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {}}, events: {'click':__sveltets_1_mapElementEvent('click')} }}
 const __propDef = __sveltets_1_partial(__sveltets_1_with_any_event(render()));
 /** @typedef {typeof __propDef.props}  InputProps */
 /** @typedef {typeof __propDef.events}  InputEvents */

--- a/packages/svelte2tsx/test/svelte2tsx/samples/custom-css-properties-with-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/custom-css-properties-with-$store/expected.tsx
@@ -5,7 +5,7 @@
   {...__sveltets_1_cssProp({"--custom-css-property2": `hi${$jo}hi`})}
   {...__sveltets_1_cssProp({"--custom-css-property3": `hi${$jo}hi`})}
   {...__sveltets_1_cssProp({"--custom-css-property4": `hi${$jo}hi`})} /></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/custom-css-properties-with-$store/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/custom-css-properties-with-$store/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => {  { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {       ...__sveltets_2_cssProp({"--custom-css-property1":$jo}),...__sveltets_2_cssProp({"--custom-css-property2":`hi${$jo}hi`}),...__sveltets_2_cssProp({"--custom-css-property3":`hi${$jo}hi`}),...__sveltets_2_cssProp({"--custom-css-property4":`hi${$jo}hi`}),}});}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/debug-block/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/debug-block/expected.tsx
@@ -3,7 +3,7 @@
 <>{myfile}
 {$myfile}{someOtherFile}
 {myfile}{$someOtherFile}{someThirdFile}</>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/debug-block/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/debug-block/expectedv2.ts
@@ -3,7 +3,7 @@
 async () => {;myfile;
 ;$myfile;someOtherFile;
 ;myfile;$someOtherFile;someThirdFile;};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/editing-mustache/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/editing-mustache/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <>{a?.}</>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/editing-mustache/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/editing-mustache/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => {a?.;};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/empty-source/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/empty-source/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <><script></script></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/empty-source/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/empty-source/expectedv2.ts
@@ -2,7 +2,7 @@
 ;function render() {
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-and-forwarded-event/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-and-forwarded-event/expected.tsx
@@ -11,7 +11,7 @@ function render() {
 () => (<>
 
 <input onfocus={undefined} /></>);
-return { props: {}, slots: {}, events: {'focus':__sveltets_1_mapElementEvent('focus'), 'mount': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'focus':__sveltets_1_mapElementEvent('focus'), 'mount': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-and-forwarded-event/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-and-forwarded-event/expectedv2.ts
@@ -11,7 +11,7 @@ function render() {
 async () => {
 
   { svelteHTML.createElement("input", { "on:focus":undefined,});}};
-return { props: {}, slots: {}, events: {'focus':__sveltets_1_mapElementEvent('focus'), 'mount': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'focus':__sveltets_1_mapElementEvent('focus'), 'mount': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component-multi/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component-multi/expected.tsx
@@ -2,7 +2,7 @@
 <></>;function render() {
 <><Button ></Button>
 <Radio ></Radio></>
-return { props: {}, slots: {}, events: {'click':__sveltets_1_unionType(__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Button).$$events_def, 'click'),__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Radio).$$events_def, 'click'))} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_unionType(__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Button).$$events_def, 'click'),__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Radio).$$events_def, 'click'))} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component-multi/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component-multi/expectedv2.ts
@@ -2,7 +2,7 @@
 ;function render() {
 async () => { { const $$_nottuB0C = __sveltets_2_ensureComponent(Button); const $$_nottuB0 = new $$_nottuB0C({ target: __sveltets_2_any(), props: { }});$$_nottuB0.$on("click", () => {}); Button}
  { const $$_oidaR0C = __sveltets_2_ensureComponent(Radio); const $$_oidaR0 = new $$_oidaR0C({ target: __sveltets_2_any(), props: { }});$$_oidaR0.$on("click", () => {}); Radio}};
-return { props: {}, slots: {}, events: {'click':__sveltets_1_unionType(__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Button).$$events_def, 'click'),__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Radio).$$events_def, 'click'))} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_unionType(__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Button).$$events_def, 'click'),__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Radio).$$events_def, 'click'))} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component-with-props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component-with-props/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <><Component propA propB={propB} propC="val1" propD="val2" propE={`a${a}b${b}`}  /></>
-return { props: {}, slots: {}, events: {'click':__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Component).$$events_def, 'click')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Component).$$events_def, 'click')} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component-with-props/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component-with-props/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => {  { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); const $$_tnenopmoC0 = new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {      "propA":true,propB,"propC":`val1`,"propD":`val2`,"propE":`a${a}b${b}`,}});$$_tnenopmoC0.$on("click", () => {});}};
-return { props: {}, slots: {}, events: {'click':__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Component).$$events_def, 'click')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Component).$$events_def, 'click')} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <><Button ></Button></>
-return { props: {}, slots: {}, events: {'click':__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Button).$$events_def, 'click')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Button).$$events_def, 'click')} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-component/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => { { const $$_nottuB0C = __sveltets_2_ensureComponent(Button); const $$_nottuB0 = new $$_nottuB0C({ target: __sveltets_2_any(), props: { }});$$_nottuB0.$on("click", () => {}); Button}};
-return { props: {}, slots: {}, events: {'click':__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Button).$$events_def, 'click')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_bubbleEventDef(__sveltets_1_instanceOf(Button).$$events_def, 'click')} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-element/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-element/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <><button onclick={undefined}></button></>
-return { props: {}, slots: {}, events: {'click':__sveltets_1_mapElementEvent('click')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_mapElementEvent('click')} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-element/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-element/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => { { svelteHTML.createElement("button", { "on:click":undefined,}); }};
-return { props: {}, slots: {}, events: {'click':__sveltets_1_mapElementEvent('click')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_mapElementEvent('click')} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-svelte-element/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-svelte-element/expected.tsx
@@ -2,7 +2,7 @@
 <></>;function render() {
 <><sveltebody onclick={undefined}></sveltebody>
 <sveltewindow onresize={undefined}></sveltewindow></>
-return { props: {}, slots: {}, events: {'click':__sveltets_1_mapBodyEvent('click'), 'resize':__sveltets_1_mapWindowEvent('resize')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_mapBodyEvent('click'), 'resize':__sveltets_1_mapWindowEvent('resize')} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-svelte-element/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-bubble-svelte-element/expectedv2.ts
@@ -2,7 +2,7 @@
 ;function render() {
 async () => { { svelteHTML.createElement("svelte:body", { "on:click":undefined,}); }
  { svelteHTML.createElement("svelte:window", { "on:resize":undefined,}); }};
-return { props: {}, slots: {}, events: {'click':__sveltets_1_mapBodyEvent('click'), 'resize':__sveltets_1_mapWindowEvent('resize')} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_mapBodyEvent('click'), 'resize':__sveltets_1_mapWindowEvent('resize')} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatcher-events-alias/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatcher-events-alias/expected.tsx
@@ -18,7 +18,7 @@ function render() {
 () => (<>
 
 <button onclick={() => dispatch('btn', '')}></button></>);
-return { props: {}, slots: {}, events: {'btn': __sveltets_1_customEvent, 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'btn': __sveltets_1_customEvent, 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatcher-events-alias/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatcher-events-alias/expectedv2.ts
@@ -18,7 +18,7 @@ function render() {
 async () => {
 
  { svelteHTML.createElement("button", {  "on:click":() => dispatch('btn', ''),}); }};
-return { props: {}, slots: {}, events: {'btn': __sveltets_1_customEvent, 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'btn': __sveltets_1_customEvent, 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatcher-events/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatcher-events/expected.tsx
@@ -18,7 +18,7 @@ function render() {
 () => (<>
 
 <button onclick={() => dispatch('btn', '')}></button></>);
-return { props: {}, slots: {}, events: {'btn': __sveltets_1_customEvent, 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'btn': __sveltets_1_customEvent, 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatcher-events/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatcher-events/expectedv2.ts
@@ -18,7 +18,7 @@ function render() {
 async () => {
 
  { svelteHTML.createElement("button", {  "on:click":() => dispatch('btn', ''),}); }};
-return { props: {}, slots: {}, events: {'btn': __sveltets_1_customEvent, 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'btn': __sveltets_1_customEvent, 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatchers/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatchers/expected.tsx
@@ -15,7 +15,7 @@ function render() {
 () => (<>
 
 <button onclick={undefined}></button></>);
-return { props: {}, slots: {}, events: {'click':__sveltets_1_mapElementEvent('click'), 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_mapElementEvent('click'), 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatchers/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/event-dispatchers/expectedv2.ts
@@ -15,7 +15,7 @@ function render() {
 async () => {
 
  { svelteHTML.createElement("button", { "on:click":undefined,}); }};
-return { props: {}, slots: {}, events: {'click':__sveltets_1_mapElementEvent('click'), 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {'click':__sveltets_1_mapElementEvent('click'), 'hi': __sveltets_1_customEvent, 'bye': __sveltets_1_customEvent} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifier/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifier/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class AslugTestUpperUpper3asd4__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifier/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifier/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class AslugTestUpperUpper3asd4__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifiers-only/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifiers-only/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class A0__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifiers-only/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/filename-is-invalid-identifiers-only/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class A0__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/import-equal/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/import-equal/expected.tsx
@@ -5,7 +5,7 @@
     import C = require('');
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/import-equal/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/import-equal/expectedv2.ts
@@ -5,7 +5,7 @@
     import C = require('');
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/import-leading-comment/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/import-leading-comment/expected.tsx
@@ -12,7 +12,7 @@ function render() {
     
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/import-leading-comment/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/import-leading-comment/expectedv2.ts
@@ -12,7 +12,7 @@ function render() {
     
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expected.tsx
@@ -7,7 +7,7 @@ function render() {
 ;
 () => (<><Test b="6" ></Test> 
 </>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/import-single-quote/expectedv2.ts
@@ -7,7 +7,7 @@ function render() {
 ;
 async () => {  { const $$_tseT0C = __sveltets_2_ensureComponent(Test); new $$_tseT0C({ target: __sveltets_2_any(), props: { "b":`6`,}}); Test} 
 };
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/imports-module-instance/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/imports-module-instance/expected.tsx
@@ -11,7 +11,7 @@ function render() {
 () => (<>
 
 </>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/imports-module-instance/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/imports-module-instance/expectedv2.ts
@@ -11,7 +11,7 @@ function render() {
 async () => {
 
 };
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/jsdoc-before-first-import/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/jsdoc-before-first-import/expected.tsx
@@ -11,7 +11,7 @@ function render() {
     
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/jsdoc-before-first-import/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/jsdoc-before-first-import/expectedv2.ts
@@ -11,7 +11,7 @@ function render() {
     
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expected.tsx
@@ -23,7 +23,7 @@ const test4 = ({a,  b: { $top1: $top2 }}) => $top2 && $top1
 
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-script/expectedv2.ts
@@ -23,7 +23,7 @@ const test4 = ({a,  b: { $top1: $top2 }}) => $top2 && $top1
 
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expected.tsx
@@ -25,7 +25,7 @@
     const test4 = ({a,  b: { $top1: $top2 }}) => $top2 && $top1
 
 }}>Hi</h1></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/nested-$-variables-template/expectedv2.ts
@@ -25,7 +25,7 @@ async () => { { svelteHTML.createElement("h1", {  "on:click":() => {
     const test4 = ({a,  b: { $top1: $top2 }}) => $top2 && $top1
 
 },});  }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expected.tsx
@@ -18,7 +18,7 @@ $: ({ bla4, bla5 } = __sveltets_1_invalidate(() => $data))
 $: ([ bla4, bla5 ] = __sveltets_1_invalidate(() => $data))
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-$store-destructuring/expectedv2.ts
@@ -18,7 +18,7 @@ $: ({ bla4, bla5 } = __sveltets_1_invalidate(() => $data))
 $: ([ bla4, bla5 ] = __sveltets_1_invalidate(() => $data))
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-assignment-type-cast/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-assignment-type-cast/expected.tsx
@@ -5,7 +5,7 @@
 	let  team = __sveltets_1_invalidate(() => ({ search: "Real", players: [] } as Team));
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-assignment-type-cast/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-assignment-type-cast/expectedv2.ts
@@ -5,7 +5,7 @@
 	let  team = __sveltets_1_invalidate(() => ({ search: "Real", players: [] } as Team));
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expected.tsx
@@ -7,7 +7,7 @@ let a: 1 | 2 = 1;
 }}
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-block/expectedv2.ts
@@ -7,7 +7,7 @@ let a: 1 | 2 = 1;
 }}
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-break-$/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-break-$/expected.tsx
@@ -4,7 +4,7 @@
     ;() => {$: { break $; }}
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-break-$/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-break-$/expectedv2.ts
@@ -4,7 +4,7 @@
     ;() => {$: { break $; }}
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-destructuring/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-destructuring/expected.tsx
@@ -9,7 +9,7 @@ let  { f } = __sveltets_1_invalidate(() => ({ f: ''}));
 let  { b: g = 1} = __sveltets_1_invalidate(() => ({ b: 1 }));
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-destructuring/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-destructuring/expectedv2.ts
@@ -9,7 +9,7 @@ let  { f } = __sveltets_1_invalidate(() => ({ f: ''}));
 let  { b: g = 1} = __sveltets_1_invalidate(() => ({ b: 1 }));
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-express-starts-with-object/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-express-starts-with-object/expected.tsx
@@ -9,7 +9,7 @@ let  e = __sveltets_1_invalidate(() => ({a: 1} ?? { a: 1 }));
 let  f = __sveltets_1_invalidate(() => ({a: 1}[c] ? '' : '1'));
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-express-starts-with-object/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-express-starts-with-object/expectedv2.ts
@@ -9,7 +9,7 @@ let  e = __sveltets_1_invalidate(() => ({a: 1} ?? { a: 1 }));
 let  f = __sveltets_1_invalidate(() => ({a: 1}[c] ? '' : '1'));
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expected.tsx
@@ -5,7 +5,7 @@
 let  b = __sveltets_1_invalidate(() => ({ a: 1 }));
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-object/expectedv2.ts
@@ -5,7 +5,7 @@
 let  b = __sveltets_1_invalidate(() => ({ a: 1 }));
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-same-name-as-function-parameter/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-same-name-as-function-parameter/expected.tsx
@@ -12,7 +12,7 @@ let  shadowed3 = __sveltets_1_invalidate(() => 1)
 let  shadowed4 = __sveltets_1_invalidate(() => 1)
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-same-name-as-function-parameter/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-same-name-as-function-parameter/expectedv2.ts
@@ -12,7 +12,7 @@ let  shadowed3 = __sveltets_1_invalidate(() => 1)
 let  shadowed4 = __sveltets_1_invalidate(() => 1)
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-same-name-as-import/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-same-name-as-import/expected.tsx
@@ -10,7 +10,7 @@ let a;
 $: a = __sveltets_1_invalidate(() => 5);
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-same-name-as-import/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare-same-name-as-import/expectedv2.ts
@@ -10,7 +10,7 @@ let a;
 $: a = __sveltets_1_invalidate(() => 5);
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expected.tsx
@@ -8,7 +8,7 @@ let a;
 $: a = __sveltets_1_invalidate(() => 5);
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-declare/expectedv2.ts
@@ -8,7 +8,7 @@ let a;
 $: a = __sveltets_1_invalidate(() => 5);
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-statements-store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-statements-store/expected.tsx
@@ -15,7 +15,7 @@
     ;() => {$: console.log({ foo4: $foo4 })}
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-statements-store/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-statements-store/expectedv2.ts
@@ -15,7 +15,7 @@
     ;() => {$: console.log({ foo4: $foo4 })}
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-store-set/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-store-set/expected.tsx
@@ -4,7 +4,7 @@
     $: $store = __sveltets_1_invalidate(() => $store + 1);
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/reactive-store-set/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/reactive-store-set/expectedv2.ts
@@ -4,7 +4,7 @@
     $: $store = __sveltets_1_invalidate(() => $store + 1);
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-in-rawhtml/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-in-rawhtml/expected.tsx
@@ -8,7 +8,7 @@
 () => (<>
 
 { ``}</>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-in-rawhtml/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-in-rawhtml/expectedv2.ts
@@ -8,7 +8,7 @@
 async () => {
 
  `<script type="application/ld+json">${JSON.stringify(schema)}</script>`;};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expected.tsx
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="/lib/jodit.es2018.min.css" />
   
 </sveltehead></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-inside-head-after-toplevel-script/expectedv2.ts
@@ -15,7 +15,7 @@ async () => { { svelteHTML.createElement("div", {});
 
    }
  }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected.tsx
@@ -9,7 +9,7 @@
     <p></p>
 </Script>
 <Style /></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expectedv2.ts
@@ -9,7 +9,7 @@ async () => {
      { svelteHTML.createElement("p", {}); }
  Script}
  { const $$_elytS0C = __sveltets_2_ensureComponent(Style); new $$_elytS0C({ target: __sveltets_2_any(), props: {}});}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-with-src/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-with-src/expected.tsx
@@ -2,7 +2,7 @@
 <></>;function render() {
 <><script src="./abc.js"></script>
 <style src='./abc.js'></style></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-with-src/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-with-src/expectedv2.ts
@@ -3,7 +3,7 @@
 ;
 async () => {
 };
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expected.tsx
@@ -8,7 +8,7 @@ let a = 'b';
 ;
 () => (<><Test b="6" />
 </>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/self-closing-component/expectedv2.ts
@@ -8,7 +8,7 @@ let a = 'b';
 ;
 async () => { { const $$_tseT0C = __sveltets_2_ensureComponent(Test); new $$_tseT0C({ target: __sveltets_2_any(), props: {  "b":`6`,}});}
 };
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <><h1>hello</h1></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/single-element/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => { { svelteHTML.createElement("h1", {});  }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/slot-bind-this/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/slot-bind-this/expected.tsx
@@ -2,7 +2,7 @@
 <></>;function render() {
 /*Ωignore_startΩ*/;const __sveltets_ensureSlot = __sveltets_1_createEnsureSlot();/*Ωignore_endΩ*/
 <><slot name="s" {...__sveltets_1_empty(s = /*Ωignore_startΩ*/__sveltets_1_instanceOf(HTMLSlotElement)/*Ωignore_endΩ*/)} /></>
-return { props: {}, slots: {'s': {}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'s': {}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/slot-bind-this/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/slot-bind-this/expectedv2.ts
@@ -2,7 +2,7 @@
 ;function render() {
 /*Ωignore_startΩ*/;const __sveltets_createSlot = __sveltets_2_createCreateSlot();/*Ωignore_endΩ*/
 async () => { { const $$_slot0 = __sveltets_createSlot("s", {   });s = $$_slot0;}};
-return { props: {}, slots: {'s': {}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'s': {}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-destructuring/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-destructuring/expected.tsx
@@ -11,7 +11,7 @@
 <p>{$store2}</p>
 <p>{$store3}</p>
 <p>{$store4}</p></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-destructuring/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-destructuring/expectedv2.ts
@@ -11,7 +11,7 @@ async () => {
  { svelteHTML.createElement("p", {});$store2; }
  { svelteHTML.createElement("p", {});$store3; }
  { svelteHTML.createElement("p", {});$store4; }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-from-module/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-from-module/expected.tsx
@@ -14,7 +14,7 @@
 
 <p>{$store2}</p>
 <p>{$store4}</p></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-from-module/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-from-module/expectedv2.ts
@@ -14,7 +14,7 @@ async () => {
 
  { svelteHTML.createElement("p", {});$store2; }
  { svelteHTML.createElement("p", {});$store4; }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-from-reactive-assignment/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-from-reactive-assignment/expected.tsx
@@ -9,7 +9,7 @@
 <p>{$store}</p>
 <p>{$store1}</p>
 <p>{$store2}</p></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-from-reactive-assignment/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-from-reactive-assignment/expectedv2.ts
@@ -9,7 +9,7 @@ async () => {
  { svelteHTML.createElement("p", {});$store; }
  { svelteHTML.createElement("p", {});$store1; }
  { svelteHTML.createElement("p", {});$store2; }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-import/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-import/expected.tsx
@@ -14,7 +14,7 @@ function render() {
 <p>{$storeA}</p>
 <p>{$storeB}</p>
 <p>{$storeC}</p></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-import/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-import/expectedv2.ts
@@ -14,7 +14,7 @@ async () => {
  { svelteHTML.createElement("p", {});$storeA; }
  { svelteHTML.createElement("p", {});$storeB; }
  { svelteHTML.createElement("p", {});$storeC; }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-property-access/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-property-access/expected.tsx
@@ -22,7 +22,7 @@
 <p>{$store['prop']['anotherProp']}</p>
 <p>{$store?.prop.anotherProp}</p>
 <p>{$store?.prop?.anotherProp}</p></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/store-property-access/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/store-property-access/expectedv2.ts
@@ -22,7 +22,7 @@ async () => {
  { svelteHTML.createElement("p", {});$store['prop']['anotherProp']; }
  { svelteHTML.createElement("p", {});$store?.prop.anotherProp; }
  { svelteHTML.createElement("p", {});$store?.prop?.anotherProp; }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <><Me f={`${$s} `}/></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/stores-mustache/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => {  { const $$_eM0C = __sveltets_2_ensureComponent(Me); new $$_eM0C({ target: __sveltets_2_any(), props: { "f":`${$s} `,}});}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-after-selfclosing-iframe/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-after-selfclosing-iframe/expected.tsx
@@ -2,7 +2,7 @@
 <></>;function render() {
 <><iframe src="" />
 </>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-after-selfclosing-iframe/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-after-selfclosing-iframe/expectedv2.ts
@@ -2,7 +2,7 @@
 ;function render() {
 async () => {  { svelteHTML.createElement("iframe", {"src":"",});}
 };
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expected.tsx
@@ -4,7 +4,7 @@
 
 
 {true === true}</>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute-bare/expectedv2.ts
@@ -4,7 +4,7 @@ async () => {
 
 
 true === true;};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-attribute/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() {
 <></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/expected.tsx
@@ -11,7 +11,7 @@
 <svelteelement this={tag}>{tag}</svelteelement>
 <svelteelement this={tag} onclick={() => tag} />
 <svelteelement this={'a'} sveltekitPrefetch href="https://kit.svelte.dev" /></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-element/expectedv2.ts
@@ -11,7 +11,7 @@ async () => {
  { svelteHTML.createElement(tag, { });tag; }
  { svelteHTML.createElement(tag, {    "on:click":() => tag,});}
  { svelteHTML.createElement('a', {    "sveltekit:prefetch":true,"href":`https://kit.svelte.dev`,});}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/expected.tsx
@@ -15,7 +15,7 @@ function render() {
 {__sveltets_1_each(a, (item) => <>
     <svelteself ></svelteself>
 </>)}</>);
-return { props: {}, slots: {}, events: {...__sveltets_1_toEventTypings<{
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {...__sveltets_1_toEventTypings<{
         foo: string
     }>()} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/svelte-self-forward-event/expectedv2.ts
@@ -15,7 +15,7 @@ async () => {
   for(let item of __sveltets_2_ensureArray(a)){
      { const $$_svelteself0 = __sveltets_2_createComponentAny({ });$$_svelteself0.$on("foo", () => {}); }
 }};
-return { props: {}, slots: {}, events: {...__sveltets_1_toEventTypings<{
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {...__sveltets_1_toEventTypings<{
         foo: string
     }>()} }}
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatcher-typed/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatcher-typed/expected.tsx
@@ -31,7 +31,7 @@ function render() {
 () => (<>
 
 <button onclick={() => dispatch('btn', '')}></button></>);
-return { props: {}, slots: {}, events: {...__sveltets_1_toEventTypings<{
+return { props: {} as Record<string, never>, slots: {}, events: {...__sveltets_1_toEventTypings<{
     /**
      * A DOC
      */

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatcher-typed/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatcher-typed/expectedv2.ts
@@ -31,7 +31,7 @@ function render() {
 async () => {
 
  { svelteHTML.createElement("button", {  "on:click":() => dispatch('btn', ''),}); }};
-return { props: {}, slots: {}, events: {...__sveltets_1_toEventTypings<{
+return { props: {} as Record<string, never>, slots: {}, events: {...__sveltets_1_toEventTypings<{
     /**
      * A DOC
      */

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatchers-same-event/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatchers-same-event/expected.tsx
@@ -20,7 +20,7 @@ function render() {
 () => (<>
 
 <button onclick={undefined}></button></>);
-return { props: {}, slots: {}, events: {...__sveltets_1_toEventTypings<{
+return { props: {} as Record<string, never>, slots: {}, events: {...__sveltets_1_toEventTypings<{
     /**
      * A DOC
      */

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatchers-same-event/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatchers-same-event/expectedv2.ts
@@ -20,7 +20,7 @@ function render() {
 async () => {
 
  { svelteHTML.createElement("button", { "on:click":undefined,}); }};
-return { props: {}, slots: {}, events: {...__sveltets_1_toEventTypings<{
+return { props: {} as Record<string, never>, slots: {}, events: {...__sveltets_1_toEventTypings<{
     /**
      * A DOC
      */

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatchers/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatchers/expected.tsx
@@ -20,7 +20,7 @@ function render() {
 () => (<>
 
 <button onclick={undefined}></button></>);
-return { props: {}, slots: {}, events: {...__sveltets_1_toEventTypings<{
+return { props: {} as Record<string, never>, slots: {}, events: {...__sveltets_1_toEventTypings<{
     /**
      * A DOC
      */

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatchers/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-event-dispatchers/expectedv2.ts
@@ -20,7 +20,7 @@ function render() {
 async () => {
 
  { svelteHTML.createElement("button", { "on:click":undefined,}); }};
-return { props: {}, slots: {}, events: {...__sveltets_1_toEventTypings<{
+return { props: {} as Record<string, never>, slots: {}, events: {...__sveltets_1_toEventTypings<{
     /**
      * A DOC
      */

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-interface/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-interface/expected.tsx
@@ -3,7 +3,7 @@
     export interface A {}
 ;<></>;function render() {
 <></>
-return { props: {}, slots: {}, events: {} }}
+return { props: {} as Record<string, never>, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-interface/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-interface/expectedv2.ts
@@ -3,7 +3,7 @@
     export interface A {}
 ;;function render() {
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: {} as Record<string, never>, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-type-assertion/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-type-assertion/expected.tsx
@@ -8,7 +8,7 @@
 () => (<>
 
 </>);
-return { props: {}, slots: {}, events: {} }}
+return { props: {} as Record<string, never>, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-type-assertion/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-type-assertion/expectedv2.ts
@@ -8,7 +8,7 @@
 async () => {
 
 };
-return { props: {}, slots: {}, events: {} }}
+return { props: {} as Record<string, never>, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-uses-$$props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-uses-$$props/expected.tsx
@@ -3,7 +3,7 @@
  ;
 () => (<>
 <h1>{$$props['name']}</h1></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: {} as Record<string, never>, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-uses-$$props/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-uses-$$props/expectedv2.ts
@@ -3,7 +3,7 @@
  ;
 async () => {
  { svelteHTML.createElement("h1", {});$$props['name']; }};
-return { props: {}, slots: {}, events: {} }}
+return { props: {} as Record<string, never>, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/typeof-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/typeof-$store/expected.tsx
@@ -8,7 +8,7 @@ function render() {
 	type Foo = typeof $foo;
 ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/typeof-$store/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/typeof-$store/expectedv2.ts
@@ -8,7 +8,7 @@ function render() {
 	type Foo = typeof $foo;
 ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expected.tsx
@@ -5,7 +5,7 @@
 ;
 () => (<><h1>{name}</h1>
 </>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props-script/expectedv2.ts
@@ -5,7 +5,7 @@
 ;
 async () => { { svelteHTML.createElement("h1", {});name; }
 };
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() { let $$props = __sveltets_1_allPropsType();
 <><h1>{$$props['name']}</h1></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$props/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() { let $$props = __sveltets_1_allPropsType();
 async () => { { svelteHTML.createElement("h1", {});$$props['name']; }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expected.tsx
@@ -5,7 +5,7 @@
 ;
 () => (<><h1>{name}</h1>
 </>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps-script/expectedv2.ts
@@ -5,7 +5,7 @@
 ;
 async () => { { svelteHTML.createElement("h1", {});name; }
 };
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expected.tsx
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 <></>;function render() { let $$restProps = __sveltets_1_restPropsType();
 <><h1>{$$restProps['name']}</h1></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$restProps/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() { let $$restProps = __sveltets_1_restPropsType();
 async () => { { svelteHTML.createElement("h1", {});$$restProps['name']; }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial_with_any(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots-script/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots-script/expected.tsx
@@ -11,7 +11,7 @@
 <slot name="foo" />
 <slot name="dashed-name" />
 <slot /></>);
-return { props: {}, slots: {'foo': {}, 'dashed-name': {}, 'default': {}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'foo': {}, 'dashed-name': {}, 'default': {}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots-script/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots-script/expectedv2.ts
@@ -11,7 +11,7 @@ async () => {
  { __sveltets_createSlot("foo", {  });}
  { __sveltets_createSlot("dashed-name", {  });}
  { __sveltets_createSlot("default", {});}};
-return { props: {}, slots: {'foo': {}, 'dashed-name': {}, 'default': {}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'foo': {}, 'dashed-name': {}, 'default': {}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots/expected.tsx
@@ -7,7 +7,7 @@
 <slot name="foo" />
 <slot name="dashed-name" />
 <slot /></>
-return { props: {}, slots: {'foo': {}, 'dashed-name': {}, 'default': {}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'foo': {}, 'dashed-name': {}, 'default': {}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$$slots/expectedv2.ts
@@ -7,7 +7,7 @@ async () => { { svelteHTML.createElement("h1", {});$$slots.foo; }
  { __sveltets_createSlot("foo", {  });}
  { __sveltets_createSlot("dashed-name", {  });}
  { __sveltets_createSlot("default", {});}};
-return { props: {}, slots: {'foo': {}, 'dashed-name': {}, 'default': {}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'foo': {}, 'dashed-name': {}, 'default': {}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$property/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$property/expected.tsx
@@ -12,7 +12,7 @@
 	}
   ;
 () => (<></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$property/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$property/expectedv2.ts
@@ -12,7 +12,7 @@
 	}
   ;
 async () => {};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expected.tsx
@@ -2,7 +2,7 @@
 <></>;function render() {
 <><Component  />{/*Ωignore_startΩ*/new Component({target: __sveltets_1_any(''), props: {}})/*Ωignore_endΩ*/.$on('click', $check ? method1 : method2)}
 <button onclick={$check ? method1 : method2} >Bla</button></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-in-event-binding/expectedv2.ts
@@ -2,7 +2,7 @@
 ;function render() {
 async () => { { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); const $$_tnenopmoC0 = new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {   }});$$_tnenopmoC0.$on("click", $check ? method1 : method2);}
   { svelteHTML.createElement("button", {  "on:click":$check ? method1 : method2,});  }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/expected.tsx
@@ -18,7 +18,7 @@
 {$store8}
 {$store9}
 {$store10}</>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-multiple-variable-declaration/expectedv2.ts
@@ -18,7 +18,7 @@ $store7;
 $store8;
 $store9;
 $store10;};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expected.tsx
@@ -33,7 +33,7 @@ function render() {
 <button onclick={() => $count &= myvar}>AND</button>
 <button onclick={() => $count ^= myvar}>XOR</button>
 <button onclick={() => $count |= myvar}>OR</button></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-assignment-operators/expectedv2.ts
@@ -33,7 +33,7 @@ async () => {
  { svelteHTML.createElement("button", {  "on:click":() => $count &= myvar,});  }
  { svelteHTML.createElement("button", {  "on:click":() => $count ^= myvar,});  }
  { svelteHTML.createElement("button", {  "on:click":() => $count |= myvar,});  }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expected.tsx
@@ -13,7 +13,7 @@ function render() {
 <button onclick={() => ++$count}>add</button>
 <button onclick={() => $count--}>subtract</button>
 <button onclick={() => $count++}>add</button></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-increments/expectedv2.ts
@@ -13,7 +13,7 @@ async () => {
  { svelteHTML.createElement("button", {  "on:click":() => ++$count,});  }
  { svelteHTML.createElement("button", {  "on:click":() => $count--,});  }
  { svelteHTML.createElement("button", {  "on:click":() => $count++,});  }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-unary-operators/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-unary-operators/expected.tsx
@@ -16,7 +16,7 @@ function render() {
 <button onclick={() => +$count}>add</button>
 <button onclick={() => -$count}>add</button>
 <button onclick={() => ~$count}>add</button></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-unary-operators/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store-with-unary-operators/expectedv2.ts
@@ -16,7 +16,7 @@ async () => {
  { svelteHTML.createElement("button", {  "on:click":() => +$count,});  }
  { svelteHTML.createElement("button", {  "on:click":() => -$count,});  }
  { svelteHTML.createElement("button", {  "on:click":() => ~$count,});  }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expected.tsx
@@ -3,7 +3,7 @@
 $b=$b.concat(5);
 () => (<>
 <h1 onclick={() => $b=$b.concat(5)}>{$b}</h1></>);
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-$store/expectedv2.ts
@@ -3,7 +3,7 @@
 $b=$b.concat(5);
 async () => {
  { svelteHTML.createElement("h1", {  "on:click":() => $b=$b.concat(5),});$b; }};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components-let-forward/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components-let-forward/expected.tsx
@@ -9,7 +9,7 @@
 <sveltecomponent this={testComponent} >{() => { let {prop} = __sveltets_1_instanceOf(__sveltets_1_componentType()).$$slot_def['default'];<>
     <slot prop={__sveltets_ensureSlot("default","prop",prop)} />
 </>}}</sveltecomponent></>
-return { props: {}, slots: {'default': {prop:__sveltets_1_instanceOf(__sveltets_1_componentType()).$$slot_def['default'].prop}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {prop:__sveltets_1_instanceOf(__sveltets_1_componentType()).$$slot_def['default'].prop}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components-let-forward/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components-let-forward/expectedv2.ts
@@ -9,7 +9,7 @@ async () => {if(true){
  { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(testComponent); const $$_tnenopmoc_etlevs0 = new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {  }});{const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,prop,} = $$_tnenopmoc_etlevs0.$$slot_def.default;$$_$$;
      { __sveltets_createSlot("default", { prop,});}
  }}};
-return { props: {}, slots: {'default': {prop:__sveltets_1_instanceOf(__sveltets_1_componentType()).$$slot_def['default'].prop}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {prop:__sveltets_1_instanceOf(__sveltets_1_componentType()).$$slot_def['default'].prop}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected.tsx
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected.tsx
@@ -13,7 +13,7 @@
 </sveltehead>
 <svelteoptions />
 <sveltefragment /></>
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expectedv2.ts
@@ -13,7 +13,7 @@ async () => {if(true){
  }
  { svelteHTML.createElement("svelte:options", {});}
  { svelteHTML.createElement("svelte:fragment", {});}};
-return { props: {}, slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_1_createSvelte2TsxComponent(__sveltets_1_partial(__sveltets_1_with_any_event(render()))) {
 }


### PR DESCRIPTION
#1739
This is necessary because {} is roughly equal to the any type. It worked before because JSX makes an exception for this on components.