### PR TITLE
(fix): add "off" to `data-sveltekit-noscroll` and `data-sveltekit-reload` props definitions

### DIFF
--- a/packages/svelte2tsx/svelte-html-do-not-use.d.ts
+++ b/packages/svelte2tsx/svelte-html-do-not-use.d.ts
@@ -559,10 +559,10 @@ export interface HTMLAnchorAttributes extends HTMLAttributes<HTMLAnchorElement> 
 	referrerpolicy?: ReferrerPolicy | undefined | null;
 
 	// SvelteKit
-	'data-sveltekit-noscroll'?: true | undefined | null;
+	'data-sveltekit-noscroll'?: true | 'off' | undefined | null;
 	'data-sveltekit-preload-code'?: true | 'eager' | 'viewport' | 'hover' | 'tap' | 'off' | undefined | null;
 	'data-sveltekit-preload-data'?: true | 'hover' | 'tap' | 'off' | undefined | null;
-	'data-sveltekit-reload'?: true | undefined | null;
+	'data-sveltekit-reload'?: true | 'off' | undefined | null;
 
 	// Sapper
 	'sapper:noscroll'?: true | undefined | null;

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -1176,10 +1176,10 @@ declare namespace svelte.JSX {
     }
 
     interface SvelteKitAnchorProps {
-        'data-sveltekit-noscroll'?: true | undefined | null;
+        'data-sveltekit-noscroll'?: true | 'off' | undefined | null;
         'data-sveltekit-preload-code'?: true | 'eager' | 'viewport' | 'hover' | 'tap' | 'off' | undefined | null;
         'data-sveltekit-preload-data'?: true | 'hover' | 'tap' | 'off' | undefined | null;
-        'data-sveltekit-reload'?: true | undefined | null;
+        'data-sveltekit-reload'?: true | 'off' | undefined | null;
     }
 
     interface SvelteMediaTimeRange {


### PR DESCRIPTION
The `data-sveltekit-noscroll` and `data-sveltekit-reload` props should be allowed to be "off".

Definition of `data-sveltekit-noscroll`
https://github.com/sveltejs/kit/blob/e2c74b7278ed75de681dfbbe84969c6cc318660c/packages/kit/src/runtime/client/utils.js#L34

Definition of `data-sveltekit-reload`
https://github.com/sveltejs/kit/blob/e2c74b7278ed75de681dfbbe84969c6cc318660c/packages/kit/src/runtime/client/utils.js#L35