### PR TITLE
(fix) custom autoCloseBefore settings

### DIFF
--- a/packages/svelte-vscode/language-configuration.json
+++ b/packages/svelte-vscode/language-configuration.json
@@ -19,6 +19,7 @@
         { "open": "<!--", "close": "-->", "notIn": ["comment", "string"] },
         { "open": "/**", "close": "*/", "notIn": ["string"] }
     ],
+    "autoCloseBefore": ";:.,=}])><`/ \n\t",
     "surroundingPairs": [
         { "open": "'", "close": "'" },
         { "open": "\"", "close": "\"" },


### PR DESCRIPTION
This uses the default autoCloseBefore and additionally / and < This setting controls when an opening bracket pair will be autoclosed. Adding these two should help get more autocloses for { in situations like `<div>|</div>`, in return leading to less situations where the AST cannot be created due to a parser error