### PR TITLE
(feat) only show SvelteKit files context menu in kit project

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -115,7 +115,7 @@
                         "never",
                         "always"
                     ],
-                    "description": "Show a context menu to generate SvelteKit files. \"always\" to always show it. \"never\" to always disable it. And \"auto\" to only opened in a SvelteKit project. "
+                    "description": "Show a context menu to generate SvelteKit files. \"always\" to always show it. \"never\" to always disable it. \"auto\" to show it when in a SvelteKit project. "
                 },
                 "svelte.plugin.typescript.enable": {
                     "type": "boolean",

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -107,6 +107,16 @@
                     "default": "off",
                     "description": "Traces the communication between VS Code and the Svelte Language Server."
                 },
+                "svelte.ui.showSvelteKitFilesCommand": {
+                    "type": "string",
+                    "default": "auto",
+                    "enum": [
+                        "off",
+                        "on",
+                        "auto"
+                    ],
+                    "description": "Show a context menu to generate SvelteKit files. \"on\" to always show it. \"off\" to always disable it. And \"auto\" to only opened in a SvelteKit project. "
+                },
                 "svelte.plugin.typescript.enable": {
                     "type": "boolean",
                     "default": true,
@@ -637,7 +647,7 @@
                     "group": "4_search"
                 },
                 {
-                    "when": "explorerResourceIsFolder",
+                    "when": "explorerResourceIsFolder && config.svelte.ui.showSvelteKitFilesCommand == on || explorerResourceIsFolder && svelte.uiContext.showSvelteKitFilesCommand",
                     "submenu": "sveltekit2files",
                     "group": "1_SvelteKit2files"
                 }

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -107,15 +107,15 @@
                     "default": "off",
                     "description": "Traces the communication between VS Code and the Svelte Language Server."
                 },
-                "svelte.ui.showSvelteKitFilesCommand": {
+                "svelte.ui.svelteKitFilesContextMenu.enable": {
                     "type": "string",
                     "default": "auto",
                     "enum": [
-                        "off",
-                        "on",
-                        "auto"
+                        "auto",
+                        "never",
+                        "always"
                     ],
-                    "description": "Show a context menu to generate SvelteKit files. \"on\" to always show it. \"off\" to always disable it. And \"auto\" to only opened in a SvelteKit project. "
+                    "description": "Show a context menu to generate SvelteKit files. \"always\" to always show it. \"never\" to always disable it. And \"auto\" to only opened in a SvelteKit project. "
                 },
                 "svelte.plugin.typescript.enable": {
                     "type": "boolean",
@@ -647,7 +647,7 @@
                     "group": "4_search"
                 },
                 {
-                    "when": "explorerResourceIsFolder && config.svelte.ui.showSvelteKitFilesCommand == on || explorerResourceIsFolder && svelte.uiContext.showSvelteKitFilesCommand",
+                    "when": "explorerResourceIsFolder && config.svelte.ui.svelteKitFilesContextMenu.enable == always || explorerResourceIsFolder && svelte.uiContext.svelteKitFilesContextMenu.enable",
                     "submenu": "sveltekit2files",
                     "group": "1_SvelteKit2files"
                 }

--- a/packages/svelte-vscode/src/sveltekit/index.ts
+++ b/packages/svelte-vscode/src/sveltekit/index.ts
@@ -2,7 +2,7 @@ import { TextDecoder } from 'util';
 import { ExtensionContext, commands, workspace } from 'vscode';
 import { addGenerateKitRouteFilesCommand } from './generateFiles';
 
-type ShowSvelteKitFilesCommandConfig = 'auto' | 'on' | 'off';
+type ShowSvelteKitFilesContextMenuConfig = 'auto' | 'always' | 'never';
 
 export function setupSvelteKit(context: ExtensionContext) {
     let contextMenuEnabled = false;
@@ -17,15 +17,15 @@ export function setupSvelteKit(context: ExtensionContext) {
 
     async function enableContextMenu() {
         const config = getConfig();
-        if (config === 'off') {
+        if (config === 'never') {
             if (contextMenuEnabled) {
                 setEnableContext(false);
             }
             return;
         }
 
-        if (config === 'on') {
-            // force on
+        if (config === 'always') {
+            // Force on. The condition is defined in the extension manifest
             return;
         }
 
@@ -39,8 +39,8 @@ export function setupSvelteKit(context: ExtensionContext) {
 function getConfig() {
     return (
         workspace
-            .getConfiguration('svelte.ui')
-            .get<ShowSvelteKitFilesCommandConfig>('showSvelteKitFilesCommand') ?? 'auto'
+            .getConfiguration('svelte.ui.svelteKitFilesContextMenu')
+            .get<ShowSvelteKitFilesContextMenuConfig>('enable') ?? 'auto'
     );
 }
 
@@ -67,5 +67,5 @@ async function detect() {
 }
 
 function setEnableContext(enable: boolean) {
-    commands.executeCommand('setContext', 'svelte.uiContext.showSvelteKitFilesCommand', enable);
+    commands.executeCommand('setContext', 'svelte.uiContext.svelteKitFilesContextMenu.enable', enable);
 }

--- a/packages/svelte-vscode/src/sveltekit/index.ts
+++ b/packages/svelte-vscode/src/sveltekit/index.ts
@@ -67,5 +67,9 @@ async function detect() {
 }
 
 function setEnableContext(enable: boolean) {
-    commands.executeCommand('setContext', 'svelte.uiContext.svelteKitFilesContextMenu.enable', enable);
+    commands.executeCommand(
+        'setContext',
+        'svelte.uiContext.svelteKitFilesContextMenu.enable',
+        enable
+    );
 }

--- a/packages/svelte-vscode/src/sveltekit/index.ts
+++ b/packages/svelte-vscode/src/sveltekit/index.ts
@@ -1,6 +1,71 @@
-import { ExtensionContext } from 'vscode';
+import { TextDecoder } from 'util';
+import { ExtensionContext, commands, workspace } from 'vscode';
 import { addGenerateKitRouteFilesCommand } from './generateFiles';
 
+type ShowSvelteKitFilesCommandConfig = 'auto' | 'on' | 'off';
+
 export function setupSvelteKit(context: ExtensionContext) {
+    let contextMenuEnabled = false;
+    context.subscriptions.push(
+        workspace.onDidChangeConfiguration(() => {
+            enableContextMenu();
+        })
+    );
+
     addGenerateKitRouteFilesCommand(context);
+    enableContextMenu();
+
+    async function enableContextMenu() {
+        const config = getConfig();
+        if (config === 'off') {
+            if (contextMenuEnabled) {
+                setEnableContext(false);
+            }
+            return;
+        }
+
+        if (config === 'on') {
+            // force on
+            return;
+        }
+
+        if (await detect()) {
+            setEnableContext(true);
+            contextMenuEnabled = true;
+        }
+    }
+}
+
+function getConfig() {
+    return (
+        workspace
+            .getConfiguration('svelte.ui')
+            .get<ShowSvelteKitFilesCommandConfig>('showSvelteKitFilesCommand') ?? 'auto'
+    );
+}
+
+async function detect() {
+    const packageJsonList = await workspace.findFiles('**/package.json', 'node_modules');
+
+    for (const fileUri of packageJsonList) {
+        try {
+            const text = new TextDecoder().decode(await workspace.fs.readFile(fileUri));
+            const pkg = JSON.parse(text);
+            const hasKit = Object.keys(pkg.devDependencies ?? {})
+                .concat(Object.keys(pkg.dependencies ?? {}))
+                .includes('@sveltejs/kit');
+
+            if (hasKit) {
+                return true;
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+
+    return false;
+}
+
+function setEnableContext(enable: boolean) {
+    commands.executeCommand('setContext', 'svelte.uiContext.showSvelteKitFilesCommand', enable);
 }


### PR DESCRIPTION
#1664 

Also adding a config to force enable and disable. One downside is that the command only shows until the extension is activated. i.e. any svelte, js, ts files are opened. That is also why there is a config to force it open. so it would be available before the extension is activated. 
