### PR TITLE
(breaking) svelte-check v3

### DIFF
--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -6,7 +6,7 @@ Provides CLI diagnostics checks for:
 -   Svelte A11y hints
 -   JavaScript/TypeScript compiler errors
 
-Requires Node 12 or later.
+Requires Node 16 or later.
 
 ### Usage:
 
@@ -50,19 +50,19 @@ Usage:
 
 ### Args:
 
-| Flag                                                            | Description                                                                                                                                                                                                                                                                                                      |
-| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--workspace <path>`                                            | Path to your workspace. All subdirectories except node_modules and those listed in `--ignore` are checked                                                                                                                                                                                                        |
+| Flag                                                            | Description                                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--workspace <path>`                                            | Path to your workspace. All subdirectories except node_modules and those listed in `--ignore` are checked                                                                                                                                                                                                                                                                                   |
 | `--output <human\|human-verbose\|machine>`                      |
-| `--watch`                                                       | Will not exit after one pass but keep watching files for changes and rerun diagnostics                                                                                                                                                                                                                           |
-| `--preserveWatchOutput`                                         | Do not clear the screen in watch mode                                                                                                                                                                                                                                                                            |
-| `--tsconfig <path>`                                             | Pass a path to a tsconfig or jsconfig file. The path can be relative to the workspace path or absolute. Doing this means that only files matched by the files/include/exclude pattern of the config file are diagnosed. It also means that errors from TypeScript and JavaScript files are reported.             |
-| `--ignore <path1,path2>`                                        | Files/folders to ignore - relative to workspace root, comma-separated, inside quotes. Example: `--ignore "dist,build"`. When used in conjunction with `--tsconfig`, this will only have effect on the files watched, not on the files that are diagnosed, which is then determined by the `tsconfig.json`        |
-| `--fail-on-warnings`                                            | Will also exit with error code when there are warnings                                                                                                                                                                                                                                                           |
-| `--fail-on-hints`                                               | Will also exit with error code when there are hints                                                                                                                                                                                                                                                              |
-| `--compiler-warnings <code1:error\|ignore,code2:error\|ignore>` | A list of Svelte compiler warning codes. Each entry defines whether that warning should be ignored or treated as an error. Warnings are comma-separated, between warning code and error level is a colon; all inside quotes. Example: `--compiler-warnings "css-unused-selector:ignore,unused-export-let:error"` |
-| `--diagnostic-sources <js,svelte,css>`                          | A list of diagnostic sources which should run diagnostics on your code. Possible values are `js` (includes TS), `svelte`, `css`. Comma-separated, inside quotes. By default all are active. Example: `--diagnostic-sources "js,svelte"`                                                                          |
-| `--threshold <error\|warning>`                                  | Filters the diagnostics to display. `error` will output only errors while `warning` will output warnings and errors.                                                                                                                                                                                             |
+| `--watch`                                                       | Will not exit after one pass but keep watching files for changes and rerun diagnostics                                                                                                                                                                                                                                                                                                      |
+| `--preserveWatchOutput`                                         | Do not clear the screen in watch mode                                                                                                                                                                                                                                                                                                                                                       |
+| `--tsconfig <path>`                                             | Pass a path to a tsconfig or jsconfig file. The path can be relative to the workspace path or absolute. Doing this means that only files matched by the files/include/exclude pattern of the config file are diagnosed. It also means that errors from TypeScript and JavaScript files are reported. If not given, will do an upwards traversal looking for the next jsconfig/tsconfig.json |
+| `--no-tsconfig`                                                 | Use this if you only want to check the Svelte files found in the current directory and below and ignore any JS/TS files (they will not be type-checked)                                                                                                                                                                                                                                     |
+| `--ignore <path1,path2>`                                        | Only has an effect when used in conjunction with `--no-tsconfig`. Files/folders to ignore - relative to workspace root, comma-separated, inside quotes. Example: `--ignore "dist,build"`. When used in conjunction with `--tsconfig`, this will only have effect on the files watched, not on the files that are diagnosed, which is then determined by the `tsconfig.json`                 |
+| `--fail-on-warnings`                                            | Will also exit with error code when there are warnings                                                                                                                                                                                                                                                                                                                                      |
+| `--compiler-warnings <code1:error\|ignore,code2:error\|ignore>` | A list of Svelte compiler warning codes. Each entry defines whether that warning should be ignored or treated as an error. Warnings are comma-separated, between warning code and error level is a colon; all inside quotes. Example: `--compiler-warnings "css-unused-selector:ignore,unused-export-let:error"`                                                                            |
+| `--diagnostic-sources <js,svelte,css>`                          | A list of diagnostic sources which should run diagnostics on your code. Possible values are `js` (includes TS), `svelte`, `css`. Comma-separated, inside quotes. By default all are active. Example: `--diagnostic-sources "js,svelte"`                                                                                                                                                     |
+| `--threshold <error\|warning>`                                  | Filters the diagnostics to display. `error` will output only errors while `warning` will output warnings and errors.                                                                                                                                                                                                                                                                        |
 
 ### FAQ
 
@@ -103,12 +103,12 @@ to the workspace directory. The filename and the message are both wrapped in quo
 1590680326778 WARNING "imported-file.svelte" 0:37 "Component has unused export property 'prop'. If it is for external reference only, please consider using `export const prop`"
 ```
 
-The output concludes with a `COMPLETED` message that summarizes total numbers of files, errors, warnings and hints that were encountered during the check.
+The output concludes with a `COMPLETED` message that summarizes total numbers of files, errors and warnings that were encountered during the check.
 
 ###### Example:
 
 ```
-1590680326807 COMPLETED 20 FILES 21 ERRORS 1 WARNINGS 0 HINTS
+1590680326807 COMPLETED 20 FILES 21 ERRORS 1 WARNINGS
 ```
 
 If the application experiences a runtime error, this error will appear as a `FAILURE` record.
@@ -121,4 +121,4 @@ If the application experiences a runtime error, this error will appear as a `FAI
 
 ### Credits
 
--   Vue's [VTI](https://github.com/vuejs/vetur/tree/master/vti) which lays the foundation for `svelte-check`
+-   Vue's [VTI](https://github.com/vuejs/vetur/tree/master/vti) which laid the foundation for `svelte-check`

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -22,7 +22,6 @@ type Result = {
     fileCount: number;
     errorCount: number;
     warningCount: number;
-    hintCount: number;
 };
 
 async function openAllDocuments(
@@ -61,8 +60,7 @@ async function getDiagnostics(
         const result: Result = {
             fileCount: diagnostics.length,
             errorCount: 0,
-            warningCount: 0,
-            hintCount: 0
+            warningCount: 0
         };
 
         for (const diagnostic of diagnostics) {
@@ -78,18 +76,11 @@ async function getDiagnostics(
                     result.errorCount += 1;
                 } else if (d.severity === DiagnosticSeverity.Warning) {
                     result.warningCount += 1;
-                } else if (d.severity === DiagnosticSeverity.Hint) {
-                    result.hintCount += 1;
                 }
             });
         }
 
-        writer.completion(
-            result.fileCount,
-            result.errorCount,
-            result.warningCount,
-            result.hintCount
-        );
+        writer.completion(result.fileCount, result.errorCount, result.warningCount);
         return result;
     } catch (err: any) {
         writer.failure(err);
@@ -202,8 +193,7 @@ parseOptions(async (opts) => {
             if (
                 result &&
                 result.errorCount === 0 &&
-                (!opts.failOnWarnings || result.warningCount === 0) &&
-                (!opts.failOnHints || result.hintCount === 0)
+                (!opts.failOnWarnings || result.warningCount === 0)
             ) {
                 process.exit(0);
             } else {

--- a/packages/svelte-check/src/options.ts
+++ b/packages/svelte-check/src/options.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import sade from 'sade';
 import { URI } from 'vscode-uri';
@@ -10,7 +11,6 @@ export interface SvelteCheckCliOptions {
     tsconfig?: string;
     filePathsToIgnore: string[];
     failOnWarnings: boolean;
-    failOnHints: boolean;
     compilerWarnings: Record<string, 'error' | 'ignore'>;
     diagnosticSources: DiagnosticSource[];
     threshold: Threshold;
@@ -21,7 +21,7 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
         .version(require('../../package.json').version) // ends up in dist/src, that's why we go two levels up
         .option(
             '--workspace',
-            'Path to your workspace. All subdirectories except node_modules and those listed in `--ignore` are checked'
+            'Path to your workspace. All subdirectories except node_modules and those listed in `--ignore` are checked. Defaults to current working directory.'
         )
         .option(
             '--output',
@@ -36,18 +36,22 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
         .option('--preserveWatchOutput', 'Do not clear the screen in watch mode', false)
         .option(
             '--tsconfig',
-            'Pass a path to a tsconfig or jsconfig file. The path can be relative to the workspace path or absolute. Doing this means that only files matched by the files/include/exclude pattern of the config file are diagnosed. It also means that errors from TypeScript and JavaScript files are reported.'
+            'Pass a path to a tsconfig or jsconfig file. The path can be relative to the workspace path or absolute. Doing this means that only files matched by the files/include/exclude pattern of the config file are diagnosed. It also means that errors from TypeScript and JavaScript files are reported. When not given, searches for the next upper tsconfig/jsconfig in the workspace path.'
+        )
+        .option(
+            '--no-tsconfig',
+            'Use this if you only want to check the Svelte files found in the current directory and below and ignore any JS/TS files (they will not be type-checked)',
+            false
         )
         .option(
             '--ignore',
-            'Files/folders to ignore - relative to workspace root, comma-separated, inside quotes. Example: `--ignore "dist,build"`'
+            'Only has an effect when ussing `--no-tsconfig` option. Files/folders to ignore - relative to workspace root, comma-separated, inside quotes. Example: `--ignore "dist,build"`'
         )
         .option(
             '--fail-on-warnings',
             'Will also exit with error code when there are warnings',
             false
         )
-        .option('--fail-on-hints', 'Will also exit with error code when there are hints', false)
         .option(
             '--compiler-warnings',
             'A list of Svelte compiler warning codes. Each entry defines whether that warning should be ignored or treated as an error. Warnings are comma-separated, between warning code and error level is a colon; all inside quotes. Example: `--compiler-warnings "css-unused-selector:ignore,unused-export-let:error"`'
@@ -59,7 +63,7 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
         .option(
             '--threshold',
             'Filters the diagnostics to display. `error` will output only errors while `warning` will output warnings and errors.',
-            'hint'
+            'warning'
         )
         .action((opts) => {
             const workspaceUri = getWorkspaceUri(opts);
@@ -71,7 +75,6 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
                 tsconfig: getTsconfig(opts, workspaceUri.fsPath),
                 filePathsToIgnore: getFilepathsToIgnore(opts),
                 failOnWarnings: !!opts['fail-on-warnings'],
-                failOnHints: !!opts['fail-on-hints'],
                 compilerWarnings: getCompilerWarnings(opts),
                 diagnosticSources: getDiagnosticSources(opts),
                 threshold: getThreshold(opts)
@@ -102,8 +105,34 @@ function getWorkspaceUri(opts: Record<string, any>) {
     return workspaceUri;
 }
 
+function findFile(searchPath: string, fileName: string) {
+    try {
+        for (;;) {
+            const filePath = path.join(searchPath, fileName);
+            if (fs.existsSync(filePath)) {
+                return filePath;
+            }
+            const parentPath = path.dirname(searchPath);
+            if (parentPath === searchPath) {
+                return;
+            }
+            searchPath = parentPath;
+        }
+    } catch (e) {
+        return;
+    }
+}
+
 function getTsconfig(myArgs: Record<string, any>, workspacePath: string) {
+    if (myArgs['no-tsconfig']) {
+        return undefined;
+    }
     let tsconfig: string | undefined = myArgs.tsconfig;
+    if (!tsconfig) {
+        const ts = findFile(workspacePath, 'tsconfig.json');
+        const js = findFile(workspacePath, 'jsconfig.json');
+        tsconfig = !!ts && (!js || ts.length >= js.length) ? ts : js;
+    }
     if (tsconfig && !path.isAbsolute(tsconfig)) {
         tsconfig = path.join(workspacePath, tsconfig);
     }
@@ -145,9 +174,14 @@ function getFilepathsToIgnore(opts: Record<string, any>): string[] {
     return opts.ignore?.split(',') || [];
 }
 
-const thresholds = ['hint', 'warning', 'error'] as const;
+const thresholds = ['warning', 'error'] as const;
 type Threshold = typeof thresholds[number];
 
 function getThreshold(opts: Record<string, any>): Threshold {
-    return thresholds.includes(opts.threshold) ? opts.threshold : 'hint';
+    if (thresholds.includes(opts.threshold)) {
+        return opts.threshold;
+    } else {
+        console.warn(`Invalid threshold "${opts.threshold}", using "warning" instead`);
+        return 'warning';
+    }
 }

--- a/packages/svelte-check/src/writers.ts
+++ b/packages/svelte-check/src/writers.ts
@@ -7,12 +7,7 @@ import { offsetAt } from 'svelte-language-server';
 export interface Writer {
     start: (workspaceDir: string) => void;
     file: (d: Diagnostic[], workspaceDir: string, filename: string, text: string) => void;
-    completion: (
-        fileCount: number,
-        errorCount: number,
-        warningCount: number,
-        hintCount: number
-    ) => void;
+    completion: (fileCount: number, errorCount: number, warningCount: number) => void;
     failure: (err: Error) => void;
 }
 
@@ -74,8 +69,6 @@ export class HumanFriendlyWriter implements Writer {
                 this.stream.write(`${pc.red('Error')}: ${msg}\n`);
             } else if (diagnostic.severity === DiagnosticSeverity.Warning) {
                 this.stream.write(`${pc.yellow('Warn')}: ${msg}\n`);
-            } else {
-                this.stream.write(`${pc.gray('Hint')}: ${msg}\n`);
             }
 
             this.stream.write('\n');
@@ -104,20 +97,17 @@ export class HumanFriendlyWriter implements Writer {
         );
     }
 
-    completion(_f: number, errorCount: number, warningCount: number, hintCount: number) {
+    completion(_f: number, errorCount: number, warningCount: number) {
         this.stream.write('====================================\n');
         const message = [
             'svelte-check found ',
-            `${errorCount} ${errorCount === 1 ? 'error' : 'errors'}, `,
-            `${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'}, and `,
-            `${hintCount} ${hintCount === 1 ? 'hint' : 'hints'}\n`
+            `${errorCount} ${errorCount === 1 ? 'error' : 'errors'} and`,
+            `${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'}\n`
         ].join('');
         if (errorCount !== 0) {
             this.stream.write(pc.red(message));
         } else if (warningCount !== 0) {
             this.stream.write(pc.yellow(message));
-        } else if (hintCount !== 0) {
-            this.stream.write(pc.gray(message));
         } else {
             this.stream.write(pc.green(message));
         }
@@ -161,14 +151,13 @@ export class MachineFriendlyWriter implements Writer {
         });
     }
 
-    completion(fileCount: number, errorCount: number, warningCount: number, hintCount: number) {
+    completion(fileCount: number, errorCount: number, warningCount: number) {
         this.log(
             [
                 'COMPLETED',
                 `${fileCount} FILES`,
                 `${errorCount} ERRORS`,
-                `${warningCount} WARNINGS`,
-                `${hintCount} HINTS`
+                `${warningCount} WARNINGS`
             ].join(' ')
         );
     }


### PR DESCRIPTION
- minimum required Node version is now 16
- remove hint diagnostics to align with tsc
- search for nearest tsconfig/jsconfig by default