### PR TITLE
(fix) fix better html type fallback

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/generics/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/generics/expectedv2.json
@@ -6,7 +6,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Type '\"asd\"' is not assignable to type 'number | unique symbol | \"link\" | \"small\" | \"sub\" | \"sup\" | \"big\" | \"substring\" | \"anchor\" | \"toString\" | \"charAt\" | \"charCodeAt\" | \"concat\" | \"indexOf\" | \"lastIndexOf\" | \"localeCompare\" | ... 34 more ... | \"at\"'.",
+        "message": "Type '\"asd\"' is not assignable to type 'number | unique symbol | \"link\" | \"small\" | \"sub\" | \"sup\" | \"big\" | \"search\" | \"substring\" | \"anchor\" | \"toString\" | \"charAt\" | \"charCodeAt\" | \"concat\" | \"indexOf\" | \"lastIndexOf\" | ... 34 more ... | \"at\"'.",
         "code": 2322,
         "tags": []
     },

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element-error/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element-error/expectedv2.json
@@ -1,6 +1,6 @@
 [
     {
-        "range": { "start": { "line": 12, "character": 0 }, "end": { "line": 12, "character": 0 } },
+        "range": { "start": { "line": 4, "character": 0 }, "end": { "line": 4, "character": 0 } },
         "severity": 1,
         "source": "ts",
         "message": "<svelte:element> must have a 'this' attribute",

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element-error/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element-error/input.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+</script>
+
+<!-- error -->
+<svelte:element />

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element/expectedv2.json
@@ -1,9 +1,40 @@
 [
     {
-        "range": { "start": { "line": 12, "character": 0 }, "end": { "line": 12, "character": 0 } },
+        "range": { "start": { "line": 4, "character": 6 }, "end": { "line": 4, "character": 16 } },
+        "severity": 4,
+        "source": "ts",
+        "message": "'elementDiv' is declared but its value is never read.",
+        "code": 6133,
+        "tags": [1]
+    },
+    {
+        "range": { "start": { "line": 5, "character": 6 }, "end": { "line": 5, "character": 18 } },
+        "severity": 4,
+        "source": "ts",
+        "message": "'elementOther' is declared but its value is never read.",
+        "code": 6133,
+        "tags": [1]
+    },
+    {
+        "range": {
+            "start": { "line": 15, "character": 38 },
+            "end": { "line": 15, "character": 50 }
+        },
         "severity": 1,
         "source": "ts",
-        "message": "<svelte:element> must have a 'this' attribute",
-        "code": -1
+        "message": "Type 'HTMLDivElement' is not assignable to type 'HTMLButtonElement | HTMLAnchorElement'.\n  Type 'HTMLDivElement' is missing the following properties from type 'HTMLAnchorElement': charset, coords, download, hreflang, and 21 more.",
+        "code": 2322,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 16, "character": 27 },
+            "end": { "line": 16, "character": 42 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Argument of type '{ cellpadding: number; }' is not assignable to parameter of type 'HTMLProps<\"div\", HTMLAttributes<any>>'.\n  Object literal may only specify known properties, and '\"cellpadding\"' does not exist in type 'HTMLProps<\"div\", HTMLAttributes<any>>'.",
+        "code": 2345,
+        "tags": []
     }
 ]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element/input.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
-  let tag = 'div';
-  let element: HTMLAnchorElement | HTMLButtonElement;
+  import {} from 'svelte/elements'
+  let tag: 'div' = 'div';
+  let tagString: string = '';
+  let elementDiv: HTMLDivElement;
+  let elementOther: HTMLAnchorElement | HTMLButtonElement;
 </script>
 
 <!-- valid -->
 <svelte:element this={tag} />
 <svelte:element this={tag}>{tag}</svelte:element>
-<svelte:element this={tag} on:click={() => tag} />
-<svelte:element this={tag} bind:this={element} />
+<svelte:element this={tag} bind:this={elementDiv} on:click={() => tag} />
+<svelte:element this={tagString} bind:this={elementOther} on:click={e => e.currentTarget} />
 
-<!-- error -->
-<svelte:element />
+<!-- invalid -->
+<svelte:element this={tag} bind:this={elementOther} />
+<svelte:element this={tag} cellpadding="{1}" />

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -21,11 +21,11 @@ declare namespace svelteHTML {
    */
   function createElement<Elements extends IntrinsicElements, Key extends keyof Elements>(
     // "undefined | null" because of <svelte:element>
-    element: Key | undefined | null, attrs: Elements[Key]
+    element: Key | undefined | null, attrs: string extends Key ? import('svelte/elements').HTMLAttributes<any> : Elements[Key]
   ): Key extends keyof ElementTagNameMap ? ElementTagNameMap[Key] : Key extends keyof SVGElementTagNameMap ? SVGElementTagNameMap[Key] : any;
   function createElement<Elements extends IntrinsicElements, Key extends keyof Elements, T>(
     // "undefined | null" because of <svelte:element>
-    element: Key | undefined | null, attrsEnhancers: T, attrs: Elements[Key] & T
+    element: Key | undefined | null, attrsEnhancers: T, attrs: (string extends Key ? import('svelte/elements').HTMLAttributes<any> : Elements[Key]) & T
   ): Key extends keyof ElementTagNameMap ? ElementTagNameMap[Key] : Key extends keyof SVGElementTagNameMap ? SVGElementTagNameMap[Key] : any;
 
   // For backwards-compatibility and ease-of-use, in case someone enhanced the typings from import('svelte/elements').HTMLAttributes/SVGAttributes


### PR DESCRIPTION
When svelte:element has a this attribute that is type string, fall back to the common html attributes