### PR TITLE
(fix) remove dom lib reference from ts plugin

### DIFF
--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -301,6 +301,12 @@ export class SvelteSnapshotManager {
                 const normalizedPath = path.replace(/\\/g, '/');
                 if (normalizedPath.endsWith('node_modules/svelte/types/runtime/ambient.d.ts')) {
                     return '';
+                } else if (normalizedPath.endsWith('svelte2tsx/svelte-jsx.d.ts')) {
+                    // Remove the dom lib reference to not load these ambient types in case
+                    // the user has a tsconfig.json with different lib settings like in
+                    // https://github.com/sveltejs/language-tools/issues/1733
+                    const originalText = readFile(path) || '';
+                    return originalText.replace('/// <reference lib="dom" />', '');
                 } else if (normalizedPath.endsWith('svelte2tsx/svelte-shims.d.ts')) {
                     let originalText = readFile(path) || '';
                     if (!originalText.includes('// -- start svelte-ls-remove --')) {


### PR DESCRIPTION
#1733
not needed for the plugin to function as the lib is only needed within Svelte files, not for the outer API surface in ts/js file . Does this make sense to you @jasonlyu123 ?