### PR TITLE
(fix) Added a single space to the console output

### DIFF
--- a/packages/svelte-check/src/writers.ts
+++ b/packages/svelte-check/src/writers.ts
@@ -101,7 +101,7 @@ export class HumanFriendlyWriter implements Writer {
         this.stream.write('====================================\n');
         const message = [
             'svelte-check found ',
-            `${errorCount} ${errorCount === 1 ? 'error' : 'errors'} and`,
+            `${errorCount} ${errorCount === 1 ? 'error' : 'errors'} and `,
             `${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'}\n`
         ].join('');
         if (errorCount !== 0) {


### PR DESCRIPTION
Fix for the issue #1808. Added a space next to the word 'add'.