### PR TITLE
Fix anchor missing attribute code action duplicate rel attribute

### DIFF
--- a/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
@@ -108,7 +108,6 @@ async function createQuickfixActions(
 
     return codeActions;
 }
-
 function createSvelteAnchorMissingAttributeQuickfixAction(
     textDocument: OptionalVersionedTextDocumentIdentifier,
     transpiled: ITranspiledSvelteDocument,
@@ -118,16 +117,24 @@ function createSvelteAnchorMissingAttributeQuickfixAction(
 ): CodeAction {
     // Assert non-null because the node target attribute is required for 'security-anchor-rel-noreferrer'
     const targetAttribute = node.attributes.find((i: any) => i.name == 'target')!;
-    const targetAttributePosition = positionAt(targetAttribute.end, content, lineOffsets);
+    const relAttribute = node.attributes.find((i: any) => i.name == 'rel');
 
-    const relNoReferrerTextEdit = TextEdit.insert(targetAttributePosition, ' rel="noreferrer"');
+    const codeActionTextEdit = relAttribute
+        ? TextEdit.insert(
+              positionAt(relAttribute.value[0].start, content, lineOffsets),
+              'noreferrer '
+          )
+        : TextEdit.insert(
+              positionAt(targetAttribute.end, content, lineOffsets),
+              ' rel="noreferrer"'
+          );
 
     return CodeAction.create(
         '(svelte) Add missing attribute rel="noreferrer"',
         {
             documentChanges: [
                 TextDocumentEdit.create(textDocument, [
-                    mapObjWithRangeToOriginal(transpiled, relNoReferrerTextEdit)
+                    mapObjWithRangeToOriginal(transpiled, codeActionTextEdit)
                 ])
             ]
         },

--- a/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
@@ -184,6 +184,88 @@ describe('SveltePlugin#getCodeAction', () => {
                 }
             ]);
         });
+
+        const svelteAnchorMissingAttributeCodeActionRel =
+            'svelte-anchor-missing-attribute-code-action-rel.svelte';
+
+        it('Should not duplicate rel attribute', async () => {
+            (
+                await expectCodeActionFor(svelteAnchorMissingAttributeCodeActionRel, {
+                    diagnostics: [
+                        {
+                            severity: DiagnosticSeverity.Warning,
+                            code: 'security-anchor-rel-noreferrer',
+                            range: Range.create(
+                                { line: 0, character: 0 },
+                                { line: 0, character: 70 }
+                            ),
+                            message:
+                                'Security: Anchor with "target=_blank" should have rel attribute containing the value "noreferrer"',
+                            source: 'svelte'
+                        }
+                    ]
+                })
+            ).toEqual([
+                {
+                    edit: {
+                        documentChanges: [
+                            {
+                                edits: [
+                                    {
+                                        newText: 'noreferrer ',
+                                        range: {
+                                            end: {
+                                                character: 50,
+                                                line: 0
+                                            },
+                                            start: {
+                                                character: 50,
+                                                line: 0
+                                            }
+                                        }
+                                    }
+                                ],
+                                textDocument: {
+                                    uri: getUri(svelteAnchorMissingAttributeCodeActionRel),
+                                    version: null
+                                }
+                            }
+                        ]
+                    },
+                    title: '(svelte) Add missing attribute rel="noreferrer"',
+                    kind: 'quickfix'
+                },
+                {
+                    edit: {
+                        documentChanges: [
+                            {
+                                edits: [
+                                    {
+                                        newText: `<!-- svelte-ignore security-anchor-rel-noreferrer -->${EOL}`,
+                                        range: {
+                                            end: {
+                                                character: 0,
+                                                line: 0
+                                            },
+                                            start: {
+                                                character: 0,
+                                                line: 0
+                                            }
+                                        }
+                                    }
+                                ],
+                                textDocument: {
+                                    uri: getUri(svelteAnchorMissingAttributeCodeActionRel),
+                                    version: null
+                                }
+                            }
+                        ]
+                    },
+                    title: '(svelte) Disable security-anchor-rel-noreferrer for this line',
+                    kind: 'quickfix'
+                }
+            ]);
+        });
     });
 
     describe('It should provide svelte ignore code actions ', () => {

--- a/packages/language-server/test/plugins/svelte/testfiles/svelte-anchor-missing-attribute-code-action-rel.svelte
+++ b/packages/language-server/test/plugins/svelte/testfiles/svelte-anchor-missing-attribute-code-action-rel.svelte
@@ -1,0 +1,1 @@
+<a href="https://svelte.dev" target="_blank" rel="noopener">Svelte</a>


### PR DESCRIPTION
Fixes #1811

![svelte-anchor-missing-attribute-code-action-duplicate-rel-fix](https://user-images.githubusercontent.com/43595566/209607369-dd86000b-fd06-4624-b93d-aeaad015d867.gif)
