### PR TITLE
Remove JS and TS from activationEvents

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -41,9 +41,7 @@
     },
     "activationEvents": [
         "onLanguage:svelte",
-        "onCommand:svelte.restartLanguageServer",
-        "onLanguage:javascript",
-        "onLanguage:typescript"
+        "onCommand:svelte.restartLanguageServer"
     ],
     "capabilities": {
         "untrustedWorkspaces": {


### PR DESCRIPTION
I noticed the Svelte extension was loaded even when using some other framework (React for example).
This is likely because of the JS/TS language trigger, as it is not loaded on other languages.
Are those triggers really required?