### PR TITLE
(feat) completion label detail support

### DIFF
--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -400,7 +400,8 @@ export class LSConfigManager {
                 config.suggest?.includeCompletionsForImportStatements ?? true,
             includeAutomaticOptionalChainCompletions:
                 config.suggest?.includeAutomaticOptionalChainCompletions ?? true,
-            includeCompletionsWithInsertText: true
+            includeCompletionsWithInsertText: true,
+            useLabelDetailsInCompletionEntries: true
         };
     }
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -636,8 +636,8 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
                 this.getCompletionDocument(detail, is$typeImport);
 
             // VSCode + tsserver won't have this pop-in effect
-            // because it's resolved during the incomplete trigger
-            // which requires typescript internal api IncompleteCompletionsCache
+            // because tsserver has internal APIs for caching
+            // TODO: consider if we should adopt the internal APIs
             if (detail.sourceDisplay && !completionItem.labelDetails) {
                 completionItem.labelDetails = {
                     description: ts.displayPartsToString(detail.sourceDisplay)

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -679,16 +679,18 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
 
     private getCompletionDocument(compDetail: ts.CompletionEntryDetails, is$typeImport: boolean) {
         const { sourceDisplay, documentation: tsDocumentation, displayParts, tags } = compDetail;
-        let detail: string = changeSvelteComponentName(ts.displayPartsToString(displayParts));
+        let parts = compDetail.codeActions?.map((codeAction) => codeAction.description) ?? [];
 
-        if (sourceDisplay) {
-            let importPath = ts.displayPartsToString(sourceDisplay);
-            if (is$typeImport) {
-                // Take into account Node16 moduleResolution
-                importPath = `'./$types${importPath.endsWith('.js') ? '.js' : ''}'`;
-            }
-            detail = `Auto import from ${importPath}\n${detail}`;
+        if (sourceDisplay && is$typeImport) {
+            const importPath = ts.displayPartsToString(sourceDisplay);
+
+            // Take into account Node16 moduleResolution
+            parts = parts.map((detail) =>
+                detail.replace(importPath, `'./$types${importPath.endsWith('.js') ? '.js' : ''}'`)
+            );
         }
+
+        parts.push(changeSvelteComponentName(ts.displayPartsToString(displayParts)));
 
         const markdownDoc = getMarkdownDocumentation(tsDocumentation, tags);
         const documentation: MarkupContent | undefined = markdownDoc
@@ -697,7 +699,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
 
         return {
             documentation,
-            detail
+            detail: parts.filter(Boolean).join('\n\n')
         };
     }
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -222,7 +222,10 @@ export function startServer(options?: LSOptions) {
                         // Svelte
                         ':',
                         '|'
-                    ]
+                    ],
+                    completionItem: {
+                        labelDetailsSupport: true
+                    }
                 },
                 documentFormattingProvider: true,
                 colorProvider: true,

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -87,7 +87,8 @@ function test(useNewTransformation: boolean) {
                 sortText: '11',
                 commitCharacters: ['.', ',', ';', '('],
                 preselect: undefined,
-                textEdit: undefined
+                textEdit: undefined,
+                labelDetails: undefined
             });
         });
 
@@ -113,7 +114,8 @@ function test(useNewTransformation: boolean) {
                 sortText: '11',
                 commitCharacters: ['.', ',', ';', '('],
                 preselect: undefined,
-                textEdit: undefined
+                textEdit: undefined,
+                labelDetails: undefined
             });
         });
 
@@ -1169,6 +1171,9 @@ function test(useNewTransformation: boolean) {
                 sortText: '11',
                 commitCharacters: undefined,
                 preselect: undefined,
+                labelDetails: {
+                    description: '../definitions'
+                },
                 textEdit: {
                     newText: '{ blubb } from "../definitions";',
                     range: {
@@ -1227,6 +1232,7 @@ function test(useNewTransformation: boolean) {
                 sortText: '11',
                 commitCharacters: ['.', ',', ';', '('],
                 preselect: undefined,
+                labelDetails: undefined,
                 textEdit: {
                     newText: '.toString',
                     range: {
@@ -1267,6 +1273,7 @@ function test(useNewTransformation: boolean) {
                 sortText: '11',
                 preselect: undefined,
                 insertText: undefined,
+                labelDetails: undefined,
                 commitCharacters: ['.', ',', ';', '('],
                 textEdit: {
                     newText: '@hi',

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -637,7 +637,7 @@ function test(useNewTransformation: boolean) {
 
             assert.strictEqual(
                 detail,
-                'Auto import from ../definitions\nfunction blubb(): boolean'
+                'Add import from "../definitions"\n\nfunction blubb(): boolean'
             );
 
             assert.strictEqual(
@@ -673,7 +673,7 @@ function test(useNewTransformation: boolean) {
 
             assert.strictEqual(
                 detail,
-                'Auto import from ../definitions\nfunction blubb(): boolean'
+                'Add import from "../definitions"\n\nfunction blubb(): boolean'
             );
 
             assert.strictEqual(
@@ -708,7 +708,7 @@ function test(useNewTransformation: boolean) {
 
             assert.strictEqual(
                 detail,
-                'Auto import from ../definitions\nfunction blubb(): boolean'
+                'Add import from "../definitions"\n\nfunction blubb(): boolean'
             );
 
             assert.strictEqual(
@@ -739,7 +739,7 @@ function test(useNewTransformation: boolean) {
 
             assert.strictEqual(
                 detail,
-                'Auto import from svelte\nfunction onMount(fn: () => any): void'
+                'Add import from "svelte"\n\nfunction onMount(fn: () => any): void'
             );
 
             assert.strictEqual(
@@ -844,7 +844,7 @@ function test(useNewTransformation: boolean) {
 
             assert.strictEqual(
                 detail,
-                'Auto import from ../imported-file.svelte\nclass ImportedFile'
+                'Add import from "../imported-file.svelte"\n\nclass ImportedFile'
             );
 
             assert.strictEqual(
@@ -882,7 +882,7 @@ function test(useNewTransformation: boolean) {
 
             assert.strictEqual(
                 detail,
-                'Auto import from ../imported-file.svelte\nclass ImportedFile'
+                'Add import from "../imported-file.svelte"\n\nclass ImportedFile'
             );
 
             assert.strictEqual(
@@ -1417,7 +1417,10 @@ function test(useNewTransformation: boolean) {
 
             const { detail } = await completionProvider.resolveCompletion(document, item!);
 
-            assert.strictEqual(detail, 'Auto import from random-package2\nfunction foo(): string');
+            assert.strictEqual(
+                detail,
+                'Add import from "random-package2"\n\nfunction foo(): string'
+            );
         });
 
         // Hacky, but it works. Needed due to testing both new and old transformation


### PR DESCRIPTION
![圖片](https://user-images.githubusercontent.com/36730922/209914029-feef2964-4339-4725-8f8d-b998d63044b8.png)

I also changed the `Auto import from ...` message to the message provided by typescript. Making it consistent with VSCode's built-in typescript feature. 

![圖片](https://user-images.githubusercontent.com/36730922/209914124-b94b5149-cf4d-417d-a28f-9eb7808e8c53.png)

One thing that differs from VSCode+tsserver is that tsserver has some internal APIs for caching auto-import-related info. So the source of the auto-import entry would be calculated at the completion list stage. Without the caching, it would only resolve some of it and the rest would need to be resolved at the resolve completion detail stage. Causing the label detail to be pop-in afterwards.

ours:

![圖片](https://user-images.githubusercontent.com/36730922/209915377-037c4fa1-87dc-4e4b-88c6-34d4c93d5b8d.png)

ts
![圖片](https://user-images.githubusercontent.com/36730922/209915504-98048d1a-8475-4dab-8318-5cba560cffef.png)

Volar has a [package](https://github.com/johnsoncodehk/volar/tree/master/packages/typescript-faster) for patching the internal API. We can consider adding that. It would also help #1792. I tested it with cache, the global completion can improve from 800ms to 100-200ms in one of my projects. But even if we use their package we'll still have to access the internal API for cache invalidation. Left the internal API testing branch here https://github.com/jasonlyu123/language-tools/tree/label-detail-internal for comparison. 