### PR TITLE
(feat) object/class member snippet

### DIFF
--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -223,6 +223,9 @@ export interface TSSuggestConfig {
     autoImports: ts.UserPreferences['includeCompletionsForModuleExports'];
     includeAutomaticOptionalChainCompletions: boolean | undefined;
     includeCompletionsForImportStatements: boolean | undefined;
+    classMemberSnippets: { enabled: boolean } | undefined;
+    objectLiteralMethodSnippets: { enabled: boolean } | undefined;
+    includeCompletionsWithSnippetText: boolean | undefined;
 }
 
 export type TsFormatConfig = Omit<
@@ -252,18 +255,9 @@ export class LSConfigManager {
     private config: LSConfig = defaultLSConfig;
     private listeners: Array<(config: LSConfigManager) => void> = [];
     private tsUserPreferences: Record<TsUserConfigLang, ts.UserPreferences> = {
-        typescript: {
-            includeCompletionsForModuleExports: true,
-            includeCompletionsForImportStatements: true,
-            includeCompletionsWithInsertText: true,
-            includeAutomaticOptionalChainCompletions: true
-        },
-        javascript: {
-            includeCompletionsForModuleExports: true,
-            includeCompletionsForImportStatements: true,
-            includeCompletionsWithInsertText: true,
-            includeAutomaticOptionalChainCompletions: true
-        }
+        // populate default with _updateTsUserPreferences
+        typescript: {},
+        javascript: {}
     };
     private tsFormatCodeOptions: Record<TsUserConfigLang, ts.FormatCodeSettings> = {
         typescript: this.getDefaultFormatCodeOptions(),
@@ -275,6 +269,11 @@ export class LSConfigManager {
     private scssConfig: CssConfig | undefined;
     private lessConfig: CssConfig | undefined;
     private isTrusted = true;
+
+    constructor() {
+        this._updateTsUserPreferences('javascript', {});
+        this._updateTsUserPreferences('typescript', {});
+    }
 
     /**
      * Updates config.
@@ -400,7 +399,13 @@ export class LSConfigManager {
                 config.suggest?.includeCompletionsForImportStatements ?? true,
             includeAutomaticOptionalChainCompletions:
                 config.suggest?.includeAutomaticOptionalChainCompletions ?? true,
-            includeCompletionsWithInsertText: true
+            includeCompletionsWithInsertText: true,
+            includeCompletionsWithSnippetText:
+                config.suggest?.includeCompletionsWithSnippetText ?? true,
+            includeCompletionsWithClassMemberSnippets:
+                config.suggest?.classMemberSnippets?.enabled ?? true,
+            includeCompletionsWithObjectLiteralMethodSnippets:
+                config.suggest?.objectLiteralMethodSnippets?.enabled ?? true
         };
     }
 

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -7,6 +7,7 @@ import {
     CompletionItemKind,
     CompletionList,
     CompletionTriggerKind,
+    InsertTextFormat,
     MarkupContent,
     MarkupKind,
     Position,
@@ -463,6 +464,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             // Make sure svelte component takes precedence
             sortText: isSvelteComp ? '-1' : comp.sortText,
             preselect: isSvelteComp ? true : comp.isRecommended,
+            insertTextFormat: comp.isSnippet ? InsertTextFormat.Snippet : undefined,
             textEdit,
             // pass essential data for resolving completion
             data: {
@@ -510,6 +512,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
 
         return {
             label: name,
+            insertText,
             isSvelteComp
         };
     }

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1418,7 +1418,7 @@ function test(useNewTransformation: boolean) {
             assert.strictEqual(detail, 'Auto import from random-package2\nfunction foo(): string');
         });
 
-        it('provides completions for object literal member',async () => {
+        it('provides completions for object literal member', async () => {
             const { completionProvider, document } = setup('object-member.svelte');
 
             const completions = await completionProvider.getCompletions(
@@ -1432,13 +1432,18 @@ function test(useNewTransformation: boolean) {
                 }
             );
 
-            const item = completions?.items.find((item) => item.label === 'hi(name)');
-            item!.insertText = harmonizeNewLines(item!.insertText)
+            const item = completions?.items.find(
+                (item) => item.label === 'hi' && item.labelDetails?.detail === '(name)'
+            );
+            item!.insertText = harmonizeNewLines(item!.insertText);
 
             delete item?.data;
 
             assert.deepStrictEqual(item, {
-                label: 'hi(name)',
+                label: 'hi',
+                labelDetails: {
+                    detail: '(name)'
+                },
                 kind: CompletionItemKind.Method,
                 sortText: '11\u0000hi\u00001',
                 preselect: undefined,
@@ -1447,9 +1452,9 @@ function test(useNewTransformation: boolean) {
                 commitCharacters: ['.', ',', ';', '('],
                 textEdit: undefined
             });
-        })
+        });
 
-        it('provides completions for class member',async () => {
+        it('provides completions for class member', async () => {
             const { completionProvider, document } = setup('object-member.svelte');
 
             const completions = await completionProvider.getCompletions(
@@ -1464,7 +1469,7 @@ function test(useNewTransformation: boolean) {
             );
 
             const item = completions?.items.find((item) => item.label === 'hi');
-            item!.insertText = harmonizeNewLines(item!.insertText)
+            item!.insertText = harmonizeNewLines(item!.insertText);
 
             delete item?.data;
 
@@ -1476,9 +1481,10 @@ function test(useNewTransformation: boolean) {
                 insertText: `hi(name: string): string {${newLine}${indent}$0${newLine}}`,
                 insertTextFormat: 2,
                 commitCharacters: undefined,
-                textEdit: undefined
+                textEdit: undefined,
+                labelDetails: undefined
             });
-        })
+        });
 
         // Hacky, but it works. Needed due to testing both new and old transformation
         after(() => {

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -83,6 +83,7 @@ function test(useNewTransformation: boolean) {
             assert.deepStrictEqual(first, <CompletionItem>{
                 label: 'b',
                 insertText: undefined,
+                insertTextFormat: undefined,
                 kind: CompletionItemKind.Method,
                 sortText: '11',
                 commitCharacters: ['.', ',', ';', '('],
@@ -109,6 +110,7 @@ function test(useNewTransformation: boolean) {
             assert.deepStrictEqual(first, <CompletionItem>{
                 label: 'b',
                 insertText: undefined,
+                insertTextFormat: undefined,
                 kind: CompletionItemKind.Field,
                 sortText: '11',
                 commitCharacters: ['.', ',', ';', '('],
@@ -1164,13 +1166,14 @@ function test(useNewTransformation: boolean) {
                     }
                 ],
                 label: 'blubb',
-                insertText: 'import { blubb } from "../definitions";',
+                insertText: 'import { blubb$1 } from "../definitions";',
+                insertTextFormat: 2,
                 kind: CompletionItemKind.Function,
                 sortText: '11',
                 commitCharacters: undefined,
                 preselect: undefined,
                 textEdit: {
-                    newText: '{ blubb } from "../definitions";',
+                    newText: '{ blubb$1 } from "../definitions";',
                     range: {
                         end: {
                             character: 15,
@@ -1223,6 +1226,7 @@ function test(useNewTransformation: boolean) {
                 ],
                 label: 'toString',
                 insertText: '?.toString',
+                insertTextFormat: undefined,
                 kind: CompletionItemKind.Method,
                 sortText: '11',
                 commitCharacters: ['.', ',', ';', '('],
@@ -1267,6 +1271,7 @@ function test(useNewTransformation: boolean) {
                 sortText: '11',
                 preselect: undefined,
                 insertText: undefined,
+                insertTextFormat: undefined,
                 commitCharacters: ['.', ',', ';', '('],
                 textEdit: {
                     newText: '@hi',
@@ -1412,6 +1417,68 @@ function test(useNewTransformation: boolean) {
 
             assert.strictEqual(detail, 'Auto import from random-package2\nfunction foo(): string');
         });
+
+        it('provides completions for object literal member',async () => {
+            const { completionProvider, document } = setup('object-member.svelte');
+
+            const completions = await completionProvider.getCompletions(
+                document,
+                {
+                    line: 6,
+                    character: 9
+                },
+                {
+                    triggerKind: CompletionTriggerKind.Invoked
+                }
+            );
+
+            const item = completions?.items.find((item) => item.label === 'hi(name)');
+            item!.insertText = harmonizeNewLines(item!.insertText)
+
+            delete item?.data;
+
+            assert.deepStrictEqual(item, {
+                label: 'hi(name)',
+                kind: CompletionItemKind.Method,
+                sortText: '11\u0000hi\u00001',
+                preselect: undefined,
+                insertText: `hi(name) {${newLine}${indent}$0${newLine}},`,
+                insertTextFormat: 2,
+                commitCharacters: ['.', ',', ';', '('],
+                textEdit: undefined
+            });
+        })
+
+        it('provides completions for class member',async () => {
+            const { completionProvider, document } = setup('object-member.svelte');
+
+            const completions = await completionProvider.getCompletions(
+                document,
+                {
+                    line: 10,
+                    character: 9
+                },
+                {
+                    triggerKind: CompletionTriggerKind.Invoked
+                }
+            );
+
+            const item = completions?.items.find((item) => item.label === 'hi');
+            item!.insertText = harmonizeNewLines(item!.insertText)
+
+            delete item?.data;
+
+            assert.deepStrictEqual(item, {
+                label: 'hi',
+                kind: CompletionItemKind.Method,
+                sortText: '17',
+                preselect: undefined,
+                insertText: `hi(name: string): string {${newLine}${indent}$0${newLine}}`,
+                insertTextFormat: 2,
+                commitCharacters: undefined,
+                textEdit: undefined
+            });
+        })
 
         // Hacky, but it works. Needed due to testing both new and old transformation
         after(() => {

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -44,7 +44,10 @@ describe('ts user preferences', () => {
             suggest: {
                 autoImports: true,
                 includeAutomaticOptionalChainCompletions: undefined,
-                includeCompletionsForImportStatements: undefined
+                includeCompletionsForImportStatements: undefined,
+                classMemberSnippets: undefined,
+                objectLiteralMethodSnippets: undefined,
+                includeCompletionsWithSnippetText: undefined
             }
         };
     }
@@ -125,7 +128,10 @@ describe('ts user preferences', () => {
             suggest: {
                 autoImports: false,
                 includeAutomaticOptionalChainCompletions: undefined,
-                includeCompletionsForImportStatements: undefined
+                includeCompletionsForImportStatements: undefined,
+                classMemberSnippets: undefined,
+                objectLiteralMethodSnippets: undefined,
+                includeCompletionsWithSnippetText: undefined
             }
         });
         const completionProvider = new CompletionsProviderImpl(

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/object-member.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/object-member.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+    interface SayHi {
+        hi(name: string): string
+    }
+
+    const a: SayHi = {
+        h
+    }
+
+    class A implements SayHi {
+        h
+    }
+</script>


### PR DESCRIPTION
class member in 4.5
https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#subclass-method-snippets

object literal in 4.7
https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#object-method-snippet-completions

this should be merged after #1816 because the test will only pass with label detail.