### PR TITLE
(feat) autoImportFileExcludePatterns config support

### DIFF
--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -4,6 +4,8 @@ import { VSCodeEmmetConfig } from '@vscode/emmet-helper';
 import { importPrettier } from './importPackage';
 import { Document } from './lib/documents';
 import { returnObjectIfHasKeys } from './utils';
+import path from 'path';
+import { FileMap } from './lib/documents/fileCollection';
 
 /**
  * Default config for the language server.
@@ -209,6 +211,8 @@ export interface TsUserPreferencesConfig {
     importModuleSpecifier: ts.UserPreferences['importModuleSpecifierPreference'];
     importModuleSpecifierEnding: ts.UserPreferences['importModuleSpecifierEnding'];
     quoteStyle: ts.UserPreferences['quotePreference'];
+    autoImportFileExcludePatterns: ts.UserPreferences['autoImportFileExcludePatterns'];
+
     /**
      * only in typescript config
      */
@@ -265,6 +269,7 @@ export class LSConfigManager {
             includeAutomaticOptionalChainCompletions: true
         }
     };
+    private resolvedAutoImportExcludeCache = new FileMap<string[]>();
     private tsFormatCodeOptions: Record<TsUserConfigLang, ts.FormatCodeSettings> = {
         typescript: this.getDefaultFormatCodeOptions(),
         javascript: this.getDefaultFormatCodeOptions()
@@ -373,6 +378,7 @@ export class LSConfigManager {
             }
         });
         this.listeners.forEach((listener) => listener(this));
+        this.resolvedAutoImportExcludeCache.clear();
     }
 
     /**
@@ -400,12 +406,47 @@ export class LSConfigManager {
                 config.suggest?.includeCompletionsForImportStatements ?? true,
             includeAutomaticOptionalChainCompletions:
                 config.suggest?.includeAutomaticOptionalChainCompletions ?? true,
-            includeCompletionsWithInsertText: true
+            includeCompletionsWithInsertText: true,
+            autoImportFileExcludePatterns: config.preferences?.autoImportFileExcludePatterns,
         };
     }
 
-    getTsUserPreferences(lang: TsUserConfigLang) {
-        return this.tsUserPreferences[lang];
+    getTsUserPreferences(lang: TsUserConfigLang, workspacePath: string | null): ts.UserPreferences {
+        const userPreferences = this.tsUserPreferences[lang];
+
+        if (!workspacePath || !userPreferences.autoImportFileExcludePatterns) {
+            return userPreferences;
+        }
+
+        let autoImportFileExcludePatterns = this.resolvedAutoImportExcludeCache.get(workspacePath);
+
+        if (!autoImportFileExcludePatterns) {
+            autoImportFileExcludePatterns = userPreferences.autoImportFileExcludePatterns.map(
+                (p) => {
+                    // Normalization rules: https://github.com/microsoft/TypeScript/pull/49578
+                    const slashNormalized = p.replace(/\\/g, '/');
+                    const isRelative = /^\.\.?($|\/)/.test(slashNormalized);
+                    if (path.isAbsolute(p)) {
+                        return p;
+                    }
+
+                    return path.join(
+                        workspacePath,
+                        p.startsWith('*')
+                            ? '/' + slashNormalized
+                            : isRelative
+                            ? p
+                            : '/**/' + slashNormalized
+                    );
+                }
+            );
+            this.resolvedAutoImportExcludeCache.set(workspacePath, autoImportFileExcludePatterns);
+        }
+
+        return {
+            ...userPreferences,
+            autoImportFileExcludePatterns
+        };
     }
 
     updateCssConfig(config: CssConfig | undefined): void {
@@ -522,5 +563,3 @@ export class LSConfigManager {
         };
     }
 }
-
-export const lsConfig = new LSConfigManager();

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -407,7 +407,7 @@ export class LSConfigManager {
             includeAutomaticOptionalChainCompletions:
                 config.suggest?.includeAutomaticOptionalChainCompletions ?? true,
             includeCompletionsWithInsertText: true,
-            autoImportFileExcludePatterns: config.preferences?.autoImportFileExcludePatterns,
+            autoImportFileExcludePatterns: config.preferences?.autoImportFileExcludePatterns
         };
     }
 

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -10,7 +10,7 @@ import {
     TextDocumentEdit
 } from 'vscode-languageserver';
 import { Document, DocumentManager } from '../../../../src/lib/documents';
-import { LSConfigManager, TSUserConfig } from '../../../../src/ls-config';
+import { LSConfigManager, TSUserConfig, TsUserPreferencesConfig } from '../../../../src/ls-config';
 import { CodeActionsProviderImpl } from '../../../../src/plugins/typescript/features/CodeActionsProvider';
 import { CompletionsProviderImpl } from '../../../../src/plugins/typescript/features/CompletionProvider';
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
@@ -18,7 +18,7 @@ import { pathToUrl } from '../../../../src/utils';
 
 const testFilesDir = join(__dirname, '..', 'testfiles', 'preferences');
 
-describe('ts user preferences', () => {
+describe.only('ts user preferences', () => {
     function setup(filename: string) {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text)
@@ -37,9 +37,9 @@ describe('ts user preferences', () => {
     function getPreferences(): TSUserConfig {
         return {
             preferences: {
+                ...getDefaultPreferences(),
                 importModuleSpecifier: 'non-relative',
-                importModuleSpecifierEnding: 'index',
-                quoteStyle: 'single'
+                importModuleSpecifierEnding: 'index'
             },
             suggest: {
                 autoImports: true,
@@ -59,6 +59,16 @@ describe('ts user preferences', () => {
             javascript: { ...getPreferences(), ...preferences }
         });
         return new LSAndTSDocResolver(docManager, [pathToUrl(testFilesDir)], configManager);
+    }
+
+    function getDefaultPreferences(): TsUserPreferencesConfig {
+        return {
+            autoImportFileExcludePatterns: undefined,
+            importModuleSpecifier: 'non-relative',
+            importModuleSpecifierEnding: undefined,
+            quoteStyle: 'single',
+            includePackageJsonAutoImports: undefined
+        };
     }
 
     it('provides auto import completion according to preferences', async () => {
@@ -148,9 +158,8 @@ describe('ts user preferences', () => {
         const { docManager, document } = setup('module-specifier-js.svelte');
         const lsAndTsDocResolver = createLSAndTSDocResolver(docManager, {
             preferences: {
-                importModuleSpecifier: 'non-relative',
-                importModuleSpecifierEnding: 'js',
-                quoteStyle: 'single'
+                ...getDefaultPreferences(),
+                importModuleSpecifierEnding: 'js'
             }
         });
 
@@ -226,5 +235,40 @@ describe('ts user preferences', () => {
             | TextDocumentEdit
             | undefined;
         assert.strictEqual(documentChange?.edits[0].newText.trim(), expectedComponentImportEdit);
+    });
+
+    async function testExcludeDefinitionDir(pattern: string) {
+        const { docManager, document } = setup('code-action.svelte');
+        const lsAndTsDocResolver = createLSAndTSDocResolver(docManager, {
+            preferences: {
+                ...getDefaultPreferences(),
+                autoImportFileExcludePatterns: [pattern]
+            }
+        });
+        const completionProvider = new CompletionsProviderImpl(
+            lsAndTsDocResolver,
+            new LSConfigManager()
+        );
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            Position.create(1, 14)
+        );
+
+        const item = completions?.items.find((item) => item.label === 'definition');
+
+        assert.equal(item, undefined);
+    }
+
+    it('exclude auto import', async () => {
+        await testExcludeDefinitionDir('definition')
+    });
+
+    it('exclude auto import (relative pattern)', async () => {
+        await testExcludeDefinitionDir('./definition')
+    });
+
+    it('exclude auto import (**/ pattern)', async () => {
+        await testExcludeDefinitionDir('**/definition')
     });
 });

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -261,14 +261,14 @@ describe.only('ts user preferences', () => {
     }
 
     it('exclude auto import', async () => {
-        await testExcludeDefinitionDir('definition')
+        await testExcludeDefinitionDir('definition');
     });
 
     it('exclude auto import (relative pattern)', async () => {
-        await testExcludeDefinitionDir('./definition')
+        await testExcludeDefinitionDir('./definition');
     });
 
     it('exclude auto import (**/ pattern)', async () => {
-        await testExcludeDefinitionDir('**/definition')
+        await testExcludeDefinitionDir('**/definition');
     });
 });

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -18,7 +18,7 @@ import { pathToUrl } from '../../../../src/utils';
 
 const testFilesDir = join(__dirname, '..', 'testfiles', 'preferences');
 
-describe.only('ts user preferences', () => {
+describe('ts user preferences', () => {
     function setup(filename: string) {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text)


### PR DESCRIPTION
added in typescript 4.8 https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#exclude-specific-files-from-auto-imports

The pattern normalization part is adopted from VSCode. But I found leading wildcard patterns don't work in Windows. It does work in Ubuntu WSL. So I changed it also to append workspace root. (Noted to self, should open an issue on either VSCode or TypeScript to ask about it)

Also, should we default some SvelteKit files with this config? Like `+error.{svelte,ts,js}`. Seen someone in the discord a few times accidentally trigger auto import when trying to throw an error. 

https://discord.com/channels/457912077277855764/1053932682955997234/1053932682955997234
