### PR TITLE
Resolve Prettier plugins relative to document path

### DIFF
--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -106,7 +106,12 @@ export class SveltePlugin
 
         const formattedCode = prettier.format(document.getText(), {
             ...config,
-            plugins: [...(config.plugins ?? []), ...getSveltePlugin()],
+            plugins: [
+                ...(config.plugins ?? []).map((id: string) =>
+                    require.resolve(id, { paths: [filePath] })
+                ),
+                ...getSveltePlugin()
+            ],
             parser: 'svelte' as any
         });
 


### PR DESCRIPTION
Fixes #1766

Prettier resolves plugins relative to process's current working directory. For the language server it is VSCode's open workspace directory. The CWD probably would be in the node_modules folder if Prettier were to be ran in a separate process (eg. in command line). So it doesn't find node_modules from a sub-directory. That's why it should be resolved relative to formatted file.