### PR TITLE
chore: move `typescript` to `svelte-check`'s peer dependency

### DIFF
--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -29,11 +29,11 @@
         "fast-glob": "^3.2.7",
         "import-fresh": "^3.2.1",
         "sade": "^1.7.4",
-        "svelte-preprocess": "^5.0.0",
-        "typescript": "^4.9.4"
+        "svelte-preprocess": "^5.0.0"
     },
     "peerDependencies": {
-        "svelte": "^3.55.0"
+        "svelte": "^3.55.0",
+        "typescript": "^4.9.0"
     },
     "scripts": {
         "build": "rollup -c && node ./dist/src/index.js --workspace ./test --tsconfig ./tsconfig.json",
@@ -52,6 +52,7 @@
         "rollup-plugin-cleanup": "^3.2.0",
         "rollup-plugin-copy": "^3.4.0",
         "svelte-language-server": "*",
+        "typescript": "^4.9.4",
         "vscode-languageserver": "8.0.2",
         "vscode-languageserver-protocol": "3.17.2",
         "vscode-languageserver-types": "3.17.2",


### PR DESCRIPTION
It is kinda debatable but I feel that it's better to use the installed version of `typescript`. I just had to go through a surprising debugging session since my IDE was using TypeScript 4.8 but `svelte-check` was using TypeScript 4.5 (I had an old version that had the `*` range declared on typescript and TS 4.5 was left in the lockfile from before the rest of the monorepo bumped TS to TS 4.8.

I understand that this might create a different problem though - now the `svelte-check` might run with a different version of TS than the VS Code extension. However, this isn't a new problem - it already exists.