### PR TITLE
Add -replacestate/-keepfocus to SvelteKit anchor tag props

### DIFF
--- a/packages/language-server/src/plugins/html/dataProvider.ts
+++ b/packages/language-server/src/plugins/html/dataProvider.ts
@@ -97,6 +97,12 @@ const sveltekitAttributes: IAttributeData[] = [
         description:
             'SvelteKit-specific attribute. Will cause SvelteKit to do a normal browser navigation which results in a full page reload.',
         valueSet: 'v'
+    },
+    {
+        name: 'data-sveltekit-replacestate',
+        description:
+            'SvelteKit-specific attribute. Will replace the current `history` entry rather than creating a new one with `pushState` when the link is clicked.',
+        valueSet: 'v'
     }
 ];
 

--- a/packages/language-server/src/plugins/html/dataProvider.ts
+++ b/packages/language-server/src/plugins/html/dataProvider.ts
@@ -67,6 +67,12 @@ const svelteAttributes: IAttributeData[] = [
 ];
 const sveltekitAttributes: IAttributeData[] = [
     {
+        name: 'data-sveltekit-keepfocus',
+        description:
+            'SvelteKit-specific attribute. Currently focused element will retain focus after navigation. Otherwise, focus will be reset to the body.',
+        valueSet: 'v'
+    },
+    {
         name: 'data-sveltekit-noscroll',
         description:
             'SvelteKit-specific attribute. Will prevent scrolling after the link is clicked.',

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -895,6 +895,7 @@ declare namespace svelte.JSX {
     security?: string | undefined | null;
     unselectable?: boolean | undefined | null;
 
+    'data-sveltekit-keepfocus'?: true | '' | 'off' | undefined | null;
     'data-sveltekit-noscroll'?: true | '' | 'off' | undefined | null;
     'data-sveltekit-preload-code'?: true | '' | 'eager' | 'viewport' | 'hover' | 'tap' | 'off' | undefined | null;
     'data-sveltekit-preload-data'?: true | '' | 'hover' | 'tap' | 'off' | undefined | null;

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -293,7 +293,7 @@ declare namespace svelte.JSX {
   type MessageEventHandler<T extends EventTarget> = EventHandler<MessageEvent, T>;
 
   /** @deprecated DO NOT USE, WILL BE REMOVED SOON */
-  type AttributeNames = 
+  type AttributeNames =
   |'oncopy'
   |'oncut'
   |'onpaste'
@@ -894,13 +894,14 @@ declare namespace svelte.JSX {
     results?: number | undefined | null;
     security?: string | undefined | null;
     unselectable?: boolean | undefined | null;
-    
+
     'data-sveltekit-noscroll'?: true | '' | 'off' | undefined | null;
     'data-sveltekit-preload-code'?: true | '' | 'eager' | 'viewport' | 'hover' | 'tap' | 'off' | undefined | null;
     'data-sveltekit-preload-data'?: true | '' | 'hover' | 'tap' | 'off' | undefined | null;
     'data-sveltekit-reload'?: true | '' | 'off' | undefined | null;
+    'data-sveltekit-replacestate'?: true | '' | 'off' | undefined | null;
   }
-  
+
   /**
    * @deprecated use the types from `svelte/elements` instead, or the .
    * For more info see https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#im-getting-deprecation-warnings-for-sveltejsx--i-want-to-migrate-to-the-new-typings

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expectedv2.js
@@ -1,3 +1,4 @@
+ { svelteHTML.createElement("a", {"data-sveltekit-keepfocus":true,}); }
  { svelteHTML.createElement("a", {"data-sveltekit-noscroll":true,}); }
  { svelteHTML.createElement("a", {"data-sveltekit-preload-code":true,}); }
  { svelteHTML.createElement("a", {"data-sveltekit-preload-data":true,}); }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expectedv2.js
@@ -4,4 +4,4 @@
  { svelteHTML.createElement("a", {"data-sveltekit-preload-data":true,}); }
  { svelteHTML.createElement("a", {"data-sveltekit-reload":true,}); }
  { svelteHTML.createElement("a", {"data-sveltekit-replacestate":true,}); }
- { svelteHTML.createElement("a", {"data-sveltekit-preload-data":true,}); }
+ { svelteHTML.createElement("a", { "data-sveltekit-preload-data":true,}); }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/expectedv2.js
@@ -2,4 +2,5 @@
  { svelteHTML.createElement("a", {"data-sveltekit-preload-code":true,}); }
  { svelteHTML.createElement("a", {"data-sveltekit-preload-data":true,}); }
  { svelteHTML.createElement("a", {"data-sveltekit-reload":true,}); }
- { svelteHTML.createElement("a", { "data-sveltekit-preload-data":true,}); }
+ { svelteHTML.createElement("a", {"data-sveltekit-replacestate":true,}); }
+ { svelteHTML.createElement("a", {"data-sveltekit-preload-data":true,}); }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/input.svelte
@@ -1,3 +1,4 @@
+<a data-sveltekit-keepfocus></a>
 <a data-sveltekit-noscroll></a>
 <a data-sveltekit-preload-code></a>
 <a data-sveltekit-preload-data></a>

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/sveltekit-anchor-attrs/input.svelte
@@ -2,4 +2,5 @@
 <a data-sveltekit-preload-code></a>
 <a data-sveltekit-preload-data></a>
 <a data-sveltekit-reload></a>
+<a data-sveltekit-replacestate></a>
 <svelte:element this="a" data-sveltekit-preload-data></svelte:element>


### PR DESCRIPTION
Corresponding changes for `data-sveltekit-replacestate` addition within SvelteKit: https://github.com/sveltejs/kit/pull/9019