### PR TITLE
(fix) use closest config file

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -91,13 +91,23 @@ export async function getService(
         return getServiceForTsconfig(tsconfigPath, dirname(tsconfigPath), docContext);
     }
 
+    // Find closer boundary: workspace uri or node_modules
     const nearestWorkspaceUri = workspaceUris.find((workspaceUri) =>
         isSubPath(workspaceUri, path, getCanonicalFileName)
     );
+    const lastNodeModulesIdx = path.split('/').lastIndexOf('node_modules') + 2;
+    const nearestNodeModulesBoundary =
+        lastNodeModulesIdx === 1
+            ? undefined
+            : path.split('/').slice(0, lastNodeModulesIdx).join('/');
+    const nearestBoundary =
+        (nearestNodeModulesBoundary?.length ?? 0) > (nearestWorkspaceUri?.length ?? 0)
+            ? nearestNodeModulesBoundary
+            : nearestWorkspaceUri;
 
     return getServiceForTsconfig(
         tsconfigPath,
-        (nearestWorkspaceUri && urlToPath(nearestWorkspaceUri)) ??
+        (nearestBoundary && urlToPath(nearestBoundary)) ??
             docContext.tsSystem.getCurrentDirectory(),
         docContext
     );

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -137,8 +137,13 @@ export function findTsConfigPath(
     // Prefer closest config file
     const config = tsconfig.length >= jsconfig.length ? tsconfig : jsconfig;
 
-    // Don't return config files that exceed the current workspace context
-    return !!config && rootUris.some((rootUri) => isSubPath(rootUri, config, getCanonicalFileName))
+    // Don't return config files that exceed the current workspace context or cross a node_modules folder
+    return !!config &&
+        rootUris.some((rootUri) => isSubPath(rootUri, config, getCanonicalFileName)) &&
+        !fileName
+            .substring(config.length - 13)
+            .split('/')
+            .includes('node_modules')
         ? config
         : '';
 }

--- a/packages/language-server/src/plugins/typescript/utils.ts
+++ b/packages/language-server/src/plugins/typescript/utils.ts
@@ -132,13 +132,14 @@ export function findTsConfigPath(
 ) {
     const searchDir = dirname(fileName);
 
-    const path =
-        ts.findConfigFile(searchDir, fileExists, 'tsconfig.json') ||
-        ts.findConfigFile(searchDir, fileExists, 'jsconfig.json') ||
-        '';
-    // Don't return config files that exceed the current workspace context.
-    return !!path && rootUris.some((rootUri) => isSubPath(rootUri, path, getCanonicalFileName))
-        ? path
+    const tsconfig = ts.findConfigFile(searchDir, fileExists, 'tsconfig.json') || '';
+    const jsconfig = ts.findConfigFile(searchDir, fileExists, 'jsconfig.json') || '';
+    // Prefer closest config file
+    const config = tsconfig.length >= jsconfig.length ? tsconfig : jsconfig;
+
+    // Don't return config files that exceed the current workspace context
+    return !!config && rootUris.some((rootUri) => isSubPath(rootUri, config, getCanonicalFileName))
+        ? config
         : '';
 }
 


### PR DESCRIPTION
Not any tsconfig over a closer jsconfig. This aligns with TS VS Code behavior.

@jasonlyu123 could you double-check if that's the correct behavior?
