### PR TITLE
(fix) don't rename props name when triggered in shorthand

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/RenameProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/RenameProvider.test.ts
@@ -353,6 +353,46 @@ describe('RenameProvider', () => {
         });
     });
 
+    it('should do rename of prop without type of component A in component B', async () => {
+        const { provider, renameDoc2 } = await setup();
+        const result = await provider.rename(renameDoc2, Position.create(6, 11), 'newName');
+
+        assert.deepStrictEqual(result, {
+            changes: {
+                [getUri('rename2.svelte')]: [
+                    {
+                        newText: 'newName',
+                        range: {
+                            start: {
+                                character: 9,
+                                line: 6
+                            },
+                            end: {
+                                character: 27,
+                                line: 6
+                            }
+                        }
+                    }
+                ],
+                [getUri('rename3.svelte')]: [
+                    {
+                        newText: 'newName',
+                        range: {
+                            start: {
+                                character: 15,
+                                line: 1
+                            },
+                            end: {
+                                character: 33,
+                                line: 1
+                            }
+                        }
+                    }
+                ]
+            }
+        });
+    });
+
     it('should do rename of svelte component', async () => {
         const { provider, renameDoc4 } = await setup();
         const result = await provider.rename(renameDoc4, Position.create(1, 12), 'ChildNew');
@@ -701,9 +741,17 @@ describe('RenameProvider', () => {
     });
 
     it('can rename shorthand props without breaking value-passing', async () => {
+        await testShorthand(Position.create(3, 16));
+    });
+
+    it('can rename shorthand props without breaking value-passing (triggers from shorthand)', async () => {
+        await testShorthand(Position.create(7, 9));
+    });
+
+    async function testShorthand(position: Position) {
         const { provider, renameDocShorthand } = await setup();
 
-        const result = await provider.rename(renameDocShorthand, Position.create(3, 16), 'newName');
+        const result = await provider.rename(renameDocShorthand, position, 'newName');
 
         assert.deepStrictEqual(result, {
             changes: {
@@ -776,7 +824,7 @@ describe('RenameProvider', () => {
                 ]
             }
         });
-    });
+    }
 
     it('can rename slot let to an alias', async () => {
         const { provider, renameSlotLet } = await setup();


### PR DESCRIPTION
Found this while figuring out #1863 

If you trigger the rename in the shorthand of ComponentB in ComponentA, we'll check the props rename for ComponentA. And if they have the same name, for example

```svelte
<script>
import ComponentB from './ComponentB.svelte'
export let name;
</script>

<ComponentB {name} /> <!--trigger here in {name} -->
```

Because there might be two edits to the exact shorthand location. It sometimes became `name={name}` and sometimes became `na={nameme}`.

I also fixed a problem when the rename is triggered in `export let` without type annotation or default. Rename won't update props usage. This is done in the same PR because this problem prevents the main issue from happening. Thus the added test won't fail even without the fix. 

```svelte
<script>
import ComponentB from './ComponentB.svelte'
export let name; // trigger here
</script>
```

