### PR TITLE
fix(emitDts): set rootDir for consistent output structure

### DIFF
--- a/packages/svelte2tsx/src/emitDts.ts
+++ b/packages/svelte2tsx/src/emitDts.ts
@@ -52,7 +52,7 @@ function loadTsconfig(config: EmitDtsConfig, svelteMap: SvelteMap) {
         tsConfig,
         ts.sys,
         basepath,
-        { sourceMap: false },
+        { sourceMap: false, rootDir: config.libRoot },
         tsconfigFile,
         undefined,
         [{ extension: 'svelte', isMixedContent: true, scriptKind: ts.ScriptKind.Deferred }]
@@ -81,7 +81,7 @@ function loadTsconfig(config: EmitDtsConfig, svelteMap: SvelteMap) {
             declaration: true, // Needed for d.ts file generation
             emitDeclarationOnly: true, // We only want d.ts file generation
             declarationDir: config.declarationDir, // Where to put the declarations
-            allowNonTsExtensions: true
+            allowNonTsExtensions: true,
         },
         filenames
     };

--- a/packages/svelte2tsx/src/emitDts.ts
+++ b/packages/svelte2tsx/src/emitDts.ts
@@ -81,7 +81,7 @@ function loadTsconfig(config: EmitDtsConfig, svelteMap: SvelteMap) {
             declaration: true, // Needed for d.ts file generation
             emitDeclarationOnly: true, // We only want d.ts file generation
             declarationDir: config.declarationDir, // Where to put the declarations
-            allowNonTsExtensions: true,
+            allowNonTsExtensions: true
         },
         filenames
     };


### PR DESCRIPTION
Ref https://github.com/sveltejs/kit/issues/9118#issuecomment-1437141020 and https://github.com/microsoft/TypeScript/issues/52889

Marking as draft cause, should it be a hard error or a warning and who is responsible for logging it: emitDts or the caller?