### PR TITLE
(fix) patch snapshots

### DIFF
--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -107,7 +107,7 @@ export class SvelteSnapshot {
 
     setAndPatchScriptInfo(scriptInfo: ts.server.ScriptInfo) {
         // @ts-expect-error
-        scriptInfo.scriptKind = this.typescript.ScriptKind.TSX;
+        scriptInfo.scriptKind = this.typescript.ScriptKind.TS;
 
         const positionToLineOffset = scriptInfo.positionToLineOffset.bind(scriptInfo);
         scriptInfo.positionToLineOffset = (position) => {


### PR DESCRIPTION
For some reason it's no longer enough to patch this at the projectService level, so we do it in getScriptSnapshot, too #1897