### PR TITLE
(fix) use ts only through injection

### DIFF
--- a/packages/typescript-plugin/src/language-service/completions.ts
+++ b/packages/typescript-plugin/src/language-service/completions.ts
@@ -1,11 +1,13 @@
 import { basename, dirname, extname } from 'path';
-import ts from 'typescript/lib/tsserverlibrary';
+import type ts from 'typescript';
 import { Logger } from '../logger';
 import { isSvelteFilePath, replaceDeep } from '../utils';
 
+type _ts = typeof ts;
+
 const componentPostfix = '__SvelteComponent_';
 
-export function decorateCompletions(ls: ts.LanguageService, logger: Logger): void {
+export function decorateCompletions(ls: ts.LanguageService, ts: _ts, logger: Logger): void {
     const getCompletionsAtPosition = ls.getCompletionsAtPosition;
     ls.getCompletionsAtPosition = (fileName, position, options) => {
         const completions = getCompletionsAtPosition(fileName, position, options);

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -42,7 +42,7 @@ function decorateLanguageServiceInner(
     decorateRename(ls, snapshotManager, logger);
     decorateDiagnostics(ls, logger);
     decorateFindReferences(ls, snapshotManager, logger);
-    decorateCompletions(ls, logger);
+    decorateCompletions(ls, typescript, logger);
     decorateGetDefinition(ls, snapshotManager, logger);
     decorateGetImplementation(ls, snapshotManager, logger);
     decorateUpdateImports(ls, snapshotManager, logger);

--- a/packages/typescript-plugin/src/module-loader.ts
+++ b/packages/typescript-plugin/src/module-loader.ts
@@ -102,7 +102,7 @@ export function patchModuleLoader(
     project: ts.server.Project,
     configManager: ConfigManager
 ): void {
-    const svelteSys = createSvelteSys(logger);
+    const svelteSys = createSvelteSys(typescript, logger);
     const moduleCache = new ModuleResolutionCache(project.projectService);
     const origResolveModuleNames = lsHost.resolveModuleNames?.bind(lsHost);
     const origResolveModuleNamLiterals = lsHost.resolveModuleNameLiterals?.bind(lsHost);

--- a/packages/typescript-plugin/src/svelte-sys.ts
+++ b/packages/typescript-plugin/src/svelte-sys.ts
@@ -1,11 +1,13 @@
-import ts from 'typescript';
+import type ts from 'typescript';
 import { Logger } from './logger';
 import { ensureRealSvelteFilePath, isVirtualSvelteFilePath, toRealSvelteFilePath } from './utils';
+
+type _ts = typeof ts;
 
 /**
  * This should only be accessed by TS svelte module resolution.
  */
-export function createSvelteSys(logger: Logger) {
+export function createSvelteSys(ts: _ts, logger: Logger) {
     const svelteSys: ts.System = {
         ...ts.sys,
         fileExists(path: string) {


### PR DESCRIPTION
There were two ts usages through imports, one of them using an import that is no longer available which broke the plugin. Guard against that by only using the ts version that is passed to the plugin, which is more correct anyway #1897