### PR TITLE
(feat) in the svelte-check diagnostics, include the number of files containing errors or warnings

### DIFF
--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -108,7 +108,7 @@ The output concludes with a `COMPLETED` message that summarizes total numbers of
 ###### Example:
 
 ```
-1590680326807 COMPLETED 20 FILES 21 ERRORS 1 WARNINGS
+1590680326807 COMPLETED 20 FILES 21 ERRORS 1 WARNINGS 3 FILES_WITH_PROBLEMS
 ```
 
 If the application experiences a runtime error, this error will appear as a `FAILURE` record.

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -22,6 +22,7 @@ type Result = {
     fileCount: number;
     errorCount: number;
     warningCount: number;
+    fileCountWithProblems: number;
 };
 
 async function openAllDocuments(
@@ -60,7 +61,8 @@ async function getDiagnostics(
         const result: Result = {
             fileCount: diagnostics.length,
             errorCount: 0,
-            warningCount: 0
+            warningCount: 0,
+            fileCountWithProblems: 0
         };
 
         for (const diagnostic of diagnostics) {
@@ -71,16 +73,29 @@ async function getDiagnostics(
                 diagnostic.text
             );
 
+            let fileHasProblems = false;
+
             diagnostic.diagnostics.forEach((d: Diagnostic) => {
                 if (d.severity === DiagnosticSeverity.Error) {
                     result.errorCount += 1;
+                    fileHasProblems = true;
                 } else if (d.severity === DiagnosticSeverity.Warning) {
                     result.warningCount += 1;
+                    fileHasProblems = true;
                 }
             });
+
+            if (fileHasProblems) {
+                result.fileCountWithProblems += 1;
+            }
         }
 
-        writer.completion(result.fileCount, result.errorCount, result.warningCount);
+        writer.completion(
+            result.fileCount,
+            result.errorCount,
+            result.warningCount,
+            result.fileCountWithProblems
+        );
         return result;
     } catch (err: any) {
         writer.failure(err);

--- a/packages/svelte-check/src/writers.ts
+++ b/packages/svelte-check/src/writers.ts
@@ -174,7 +174,7 @@ export class MachineFriendlyWriter implements Writer {
                 `${fileCount} FILES`,
                 `${errorCount} ERRORS`,
                 `${warningCount} WARNINGS`,
-                `${fileCountWithProblems} FILES WITH PROBLEMS`
+                `${fileCountWithProblems} FILES_WITH_PROBLEMS`
             ].join(' ')
         );
     }

--- a/packages/svelte-check/src/writers.ts
+++ b/packages/svelte-check/src/writers.ts
@@ -7,7 +7,12 @@ import { offsetAt } from 'svelte-language-server';
 export interface Writer {
     start: (workspaceDir: string) => void;
     file: (d: Diagnostic[], workspaceDir: string, filename: string, text: string) => void;
-    completion: (fileCount: number, errorCount: number, warningCount: number) => void;
+    completion: (
+        fileCount: number,
+        errorCount: number,
+        warningCount: number,
+        fileCountWithProblems: number
+    ) => void;
     failure: (err: Error) => void;
 }
 
@@ -97,12 +102,18 @@ export class HumanFriendlyWriter implements Writer {
         );
     }
 
-    completion(_f: number, errorCount: number, warningCount: number) {
+    completion(
+        _f: number,
+        errorCount: number,
+        warningCount: number,
+        fileCountWithProblems: number
+    ) {
         this.stream.write('====================================\n');
         const message = [
             'svelte-check found ',
             `${errorCount} ${errorCount === 1 ? 'error' : 'errors'} and `,
-            `${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'}\n`
+            `${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'} in `,
+            `${fileCountWithProblems} ${fileCountWithProblems === 1 ? 'file' : 'files'}\n`
         ].join('');
         if (errorCount !== 0) {
             this.stream.write(pc.red(message));
@@ -151,13 +162,19 @@ export class MachineFriendlyWriter implements Writer {
         });
     }
 
-    completion(fileCount: number, errorCount: number, warningCount: number) {
+    completion(
+        fileCount: number,
+        errorCount: number,
+        warningCount: number,
+        fileCountWithProblems: number
+    ) {
         this.log(
             [
                 'COMPLETED',
                 `${fileCount} FILES`,
                 `${errorCount} ERRORS`,
-                `${warningCount} WARNINGS`
+                `${warningCount} WARNINGS`,
+                `${fileCountWithProblems} FILES WITH PROBLEMS`
             ].join(' ')
         );
     }


### PR DESCRIPTION
#1879

Changes the output of `svelte-check` to include the number of files containing errors or warnings. Before:

```
svelte-check found 38 errors and 0 warnings
```

after:

```
svelte-check found 38 errors and 0 warnings in 3 files
```