### PR TITLE
Make bug template package selection `multiple`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,6 +53,7 @@ body:
     id: package
     attributes:
       label: Which package is the issue about?
+      multiple: true
       options:
         - Svelte for VS Code extension
         - svelte-language-server


### PR DESCRIPTION
Type issues commonly affect the editor experience via the extension and `svelte-check`, so it is helpful if both can be selected directly.