### PR TITLE
(feat) add svelte files to path completion in the ts plugin

### DIFF
--- a/packages/language-server/src/plugins/typescript/svelte-sys.ts
+++ b/packages/language-server/src/plugins/typescript/svelte-sys.ts
@@ -25,7 +25,7 @@ export function createSvelteSys(
             return snapshot.getText(0, snapshot.getLength());
         },
         readDirectory(path, extensions, exclude, include, depth) {
-            const extensionsWithSvelte = (extensions ?? []).concat('.svelte');
+            const extensionsWithSvelte = extensions ? [...extensions, '.svelte'] : undefined;
 
             return tsSystem.readDirectory(path, extensionsWithSvelte, exclude, include, depth);
         },

--- a/packages/typescript-plugin/src/language-service/host.ts
+++ b/packages/typescript-plugin/src/language-service/host.ts
@@ -1,0 +1,12 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+
+export function decorateLanguageServiceHost(host: ts.LanguageServiceHost) {
+    const originalReadDirectory = host.readDirectory?.bind(host);
+    host.readDirectory = originalReadDirectory
+        ? (path, extensions, exclude, include, depth) => {
+              const extensionsWithSvelte = extensions ? [...extensions, '.svelte'] : undefined;
+
+              return originalReadDirectory(path, extensionsWithSvelte, exclude, include, depth);
+          }
+        : undefined;
+}

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -13,6 +13,7 @@ import { decorateGetImplementation } from './implementation';
 import { decorateInlayHints } from './inlay-hints';
 import { decorateRename } from './rename';
 import { decorateUpdateImports } from './update-imports';
+import { decorateLanguageServiceHost } from './host';
 
 const sveltePluginPatchSymbol = Symbol('sveltePluginPatchSymbol');
 
@@ -31,7 +32,9 @@ export function decorateLanguageService(
     // Decorate using a proxy so we can dynamically enable/disable method
     // patches depending on the enabled state of our config
     const proxy = new Proxy(ls, createProxyHandler(configManager));
+    decorateLanguageServiceHost(info.languageServiceHost);
     decorateLanguageServiceInner(proxy, snapshotManager, logger, info, typescript);
+
     return proxy;
 }
 

--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -607,11 +607,14 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
 
         // needed for path auto completions
         readDirectory = originalLanguageServiceHost.readDirectory
-            ? (...args: any[]) => {
-                  return originalLanguageServiceHost.readDirectory!(
-                      // @ts-ignore
-                      ...args
-                  );
+            ? (...args: Parameters<NonNullable<ts.LanguageServiceHost['readDirectory']>>) => {
+                  return originalLanguageServiceHost.readDirectory!(...args);
+              }
+            : undefined;
+
+        getDirectories = originalLanguageServiceHost.getDirectories
+            ? (...args: Parameters<NonNullable<ts.LanguageServiceHost['getDirectories']>>) => {
+                  return originalLanguageServiceHost.getDirectories!(...args);
               }
             : undefined;
 


### PR DESCRIPTION
TypeScript 5.0 will have path completion for *.ext ambient modules. We'll lose these completions when the ts plugin is enabled. Adding the `.svelte` extension to readDirectory as we do in the language server in this PR. 

I also change the null check because if this parameter is falsy in the TypeScript source code, TypeScript won't filter files. So this null check is wrong, but I don't know if there are any places where it would be null. 

The last change is also patching `getDirectories` in sveltekit language service host proxy. This is used for the directories in the path completion.  