### PR TITLE
(fix) more host proxy for kit language service

### DIFF
--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -643,6 +643,11 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
         useCaseSensitiveFileNames = originalLanguageServiceHost.useCaseSensitiveFileNames
             ? () => originalLanguageServiceHost.useCaseSensitiveFileNames!()
             : undefined;
+
+        realpath = originalLanguageServiceHost.realpath
+            ? (...args: Parameters<NonNullable<ts.LanguageServiceHost['realpath']>>) =>
+                  originalLanguageServiceHost.realpath!(...args)
+            : undefined;
     }
 
     // Ideally we'd create a full Proxy of the language service, but that seems to have cache issues

--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -631,6 +631,18 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
                 originalLanguageServiceHost.fileExists(fileName)
             );
         }
+
+        getCancellationToken = originalLanguageServiceHost.getCancellationToken
+            ? () => originalLanguageServiceHost.getCancellationToken!()
+            : undefined;
+
+        getNewLine = originalLanguageServiceHost.getNewLine
+            ? () => originalLanguageServiceHost.getNewLine!()
+            : undefined;
+
+        useCaseSensitiveFileNames = originalLanguageServiceHost.useCaseSensitiveFileNames
+            ? () => originalLanguageServiceHost.useCaseSensitiveFileNames!()
+            : undefined;
     }
 
     // Ideally we'd create a full Proxy of the language service, but that seems to have cache issues


### PR DESCRIPTION
#1945

These are the safer ones. We can test out the rest later or even internal APIs. The proxyRegistry crash in Linux also seems to be because we didn't implement `useCaseSensitiveFileNames`. We can test it more and do it in another PR. 