### PR TITLE
(chore) typescript plugin debugger config for WSL

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
             "outFiles": ["${workspaceRoot}/packages/svelte-vscode/dist/**/*.js"],
             "preLaunchTask": "npm: watch",
             "env": {
-                "TSS_DEBUG": "5859"
+                "TSS_DEBUG": "5859",
+                "TSS_REMOTE_DEBUG": "5859"
             }
         },
         {


### PR DESCRIPTION
The environment variable used in the remote server is different. It's probably because of how the remote extensions decide which environment variable to pass to WSL. 

And about how to debug in WSL. The way I currently got it to work is to clone the repo in WSL.  And use that for development with the [WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) for VSCode. The testing workspace will also have to be in WSL.