### PR TITLE
(fix) replace removed content with whitespace

### DIFF
--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -60,8 +60,9 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
                 const snapshot = getScriptSnapshot(fileName);
                 if (snapshot) {
                     const originalText = snapshot.getText(0, snapshot.getLength());
+                    const toReplace = '/// <reference lib="dom" />';
                     return modules.typescript.ScriptSnapshot.fromString(
-                        originalText.replace('/// <reference lib="dom" />', '')
+                        originalText.replace(toReplace, ' '.repeat(toReplace.length))
                     );
                 }
                 return snapshot;
@@ -72,14 +73,12 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
                     if (!originalText.includes('// -- start svelte-ls-remove --')) {
                         return snapshot; // uses an older version of svelte2tsx or is already patched
                     }
+                    const startIdx = originalText.indexOf('// -- start svelte-ls-remove --');
+                    const endIdx = originalText.indexOf('// -- end svelte-ls-remove --');
                     originalText =
-                        originalText.substring(
-                            0,
-                            originalText.indexOf('// -- start svelte-ls-remove --')
-                        ) +
-                        originalText.substring(
-                            originalText.indexOf('// -- end svelte-ls-remove --')
-                        );
+                        originalText.substring(0, startIdx) +
+                        ' '.repeat(endIdx - startIdx) +
+                        originalText.substring(endIdx);
                     return modules.typescript.ScriptSnapshot.fromString(originalText);
                 }
                 return snapshot;

--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -347,20 +347,19 @@ export class SvelteSnapshotManager {
                     // the user has a tsconfig.json with different lib settings like in
                     // https://github.com/sveltejs/language-tools/issues/1733
                     const originalText = readFile(path) || '';
-                    return originalText.replace('/// <reference lib="dom" />', '');
+                    const toReplace = '/// <reference lib="dom" />';
+                    return originalText.replace(toReplace, ' '.repeat(toReplace.length));
                 } else if (normalizedPath.endsWith('svelte2tsx/svelte-shims.d.ts')) {
                     let originalText = readFile(path) || '';
                     if (!originalText.includes('// -- start svelte-ls-remove --')) {
                         return originalText; // uses an older version of svelte2tsx or is already patched
                     }
+                    const startIdx = originalText.indexOf('// -- start svelte-ls-remove --');
+                    const endIdx = originalText.indexOf('// -- end svelte-ls-remove --');
                     originalText =
-                        originalText.substring(
-                            0,
-                            originalText.indexOf('// -- start svelte-ls-remove --')
-                        ) +
-                        originalText.substring(
-                            originalText.indexOf('// -- end svelte-ls-remove --')
-                        );
+                        originalText.substring(0, startIdx) +
+                        ' '.repeat(endIdx - startIdx) +
+                        originalText.substring(endIdx);
                     return originalText;
                 } else if (isSvelteFilePath(path)) {
                     this.logger.debug('Read Svelte file:', path);


### PR DESCRIPTION
When working with the files that are replaced errors show up in the wrong places, which is annoying - this should help with that