### PR TITLE
Align types with Svelte v3.58.0

### DIFF
--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -65,7 +65,7 @@ interface Svelte2TsxComponentConstructorParameters<Props extends {}> {
     /**
      * An HTMLElement to render to. This option is required.
      */
-    target: Element | ShadowRoot;
+    target: Element | Document | ShadowRoot;
     /**
      * A child of `target` to render the component immediately before.
      */


### PR DESCRIPTION
Makes `target` property match type change from:
- https://github.com/sveltejs/svelte/pull/7554