### PR TITLE
(fix) check modified time for tsconfig watching

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -560,6 +560,7 @@ async function createLanguageService(
         }
 
         if (!configWatchers.has(tsconfigPath) && tsconfigPath) {
+            configFileModifiedTime.set(tsconfigPath, tsSystem.getModifiedTime?.(tsconfigPath));
             configWatchers.set(
                 tsconfigPath,
                 // for some reason setting the polling interval is necessary, else some error in TS is thrown
@@ -572,6 +573,7 @@ async function createLanguageService(
                 continue;
             }
 
+            configFileModifiedTime.set(config, tsSystem.getModifiedTime?.(config));
             extendedConfigWatchers.set(
                 config,
                 // for some reason setting the polling interval is necessary, else some error in TS is thrown
@@ -587,7 +589,7 @@ async function createLanguageService(
     ) {
         if (
             kind === ts.FileWatcherEventKind.Changed &&
-            configFileModified(fileName, modifiedTime)
+            !configFileModified(fileName, modifiedTime ?? tsSystem.getModifiedTime?.(fileName))
         ) {
             return;
         }
@@ -670,7 +672,10 @@ function createWatchExtendedConfigCallback(docContext: LanguageServiceDocumentCo
     ) => {
         if (
             kind === ts.FileWatcherEventKind.Changed &&
-            configFileModified(fileName, modifiedTime)
+            !configFileModified(
+                fileName,
+                modifiedTime ?? docContext.tsSystem.getModifiedTime?.(fileName)
+            )
         ) {
             return;
         }

--- a/packages/language-server/test/plugins/typescript/test-utils.ts
+++ b/packages/language-server/test/plugins/typescript/test-utils.ts
@@ -13,6 +13,7 @@ export function createVirtualTsSystem(currentDirectory: string): ts.System {
     const watchers = new FileMap<ts.FileWatcherCallback[]>();
     const watchTimeout = new FileMap<Array<ReturnType<typeof setTimeout>>>();
     const getCanonicalFileName = createGetCanonicalFileName(ts.sys.useCaseSensitiveFileNames);
+    const modifiedTime = new FileMap<Date>();
 
     function toAbsolute(path: string) {
         return isAbsolute(path) ? path : join(currentDirectory, path);
@@ -27,6 +28,7 @@ export function createVirtualTsSystem(currentDirectory: string): ts.System {
             const normalizedPath = normalizePath(toAbsolute(path));
             const existsBefore = virtualFs.has(normalizedPath);
             virtualFs.set(normalizedPath, data);
+            modifiedTime.set(normalizedPath, new Date());
             triggerWatch(
                 normalizedPath,
                 existsBefore ? ts.FileWatcherEventKind.Changed : ts.FileWatcherEventKind.Created
@@ -82,6 +84,9 @@ export function createVirtualTsSystem(currentDirectory: string): ts.System {
                     }
                 }
             };
+        },
+        getModifiedTime(path) {
+            return modifiedTime.get(normalizePath(toAbsolute(path)));
         }
     };
 


### PR DESCRIPTION
#1963 didn't go with the chokidar approach because we have a virtual file system test for config watching. 

@mpearce-bain It would be great if you could follow the [setup guide](https://github.com/sveltejs/language-tools/blob/master/README.md#setup) to test if this work for you. You can switch to this PR branch after cloning using the [GitHub Pull Requests and Issues](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension. 