### PR TITLE
feat: Auto-typing support for `entries`

### DIFF
--- a/packages/svelte2tsx/src/helpers/sveltekit.ts
+++ b/packages/svelte2tsx/src/helpers/sveltekit.ts
@@ -171,6 +171,23 @@ function upserKitRouteFile(
         insert(pos, inserted);
     }
 
+    // add type to entries function if not explicitly typed
+    const entries = exports.get('entries');
+    if (
+        entries?.type === 'function' &&
+        entries.node.parameters.length === 0 &&
+        !entries.hasTypeDefinition &&
+        !basename.includes('layout')
+    ) {
+        if (!entries.node.type && entries.node.body) {
+            const returnPos = ts.isArrowFunction(entries.node)
+                ? entries.node.equalsGreaterThanToken.getStart()
+                : entries.node.body.getStart();
+            const returnInsertion = surround(`: Array<import('./$types.js').RouteParams> `);
+            insert(returnPos, returnInsertion);
+        }
+    }
+
     // add type to actions variable if not explicitly typed
     const actions = exports.get('actions');
     if (actions?.type === 'var' && !actions.hasTypeDefinition && actions.node.initializer) {

--- a/packages/svelte2tsx/src/helpers/sveltekit.ts
+++ b/packages/svelte2tsx/src/helpers/sveltekit.ts
@@ -183,9 +183,7 @@ function upserKitRouteFile(
             const returnPos = ts.isArrowFunction(entries.node)
                 ? entries.node.equalsGreaterThanToken.getStart()
                 : entries.node.body.getStart();
-            const returnInsertion = surround(
-                `: ReturnType<import('./$types.js').EntryGenerator> `
-            );
+            const returnInsertion = surround(`: ReturnType<import('./$types.js').EntryGenerator> `);
             insert(returnPos, returnInsertion);
         }
     }

--- a/packages/svelte2tsx/src/helpers/sveltekit.ts
+++ b/packages/svelte2tsx/src/helpers/sveltekit.ts
@@ -184,7 +184,7 @@ function upserKitRouteFile(
                 ? entries.node.equalsGreaterThanToken.getStart()
                 : entries.node.body.getStart();
             const returnInsertion = surround(
-                `: Promise<Array<import('./$types.js').RouteParams>> | Array<import('./$types.js').RouteParams> `
+                `: Promise<Array<ReturnType<import('./$types.js').EntryGenerator>>> | Array<ReturnType<import('./$types.js').EntryGenerator>> `
             );
             insert(returnPos, returnInsertion);
         }

--- a/packages/svelte2tsx/src/helpers/sveltekit.ts
+++ b/packages/svelte2tsx/src/helpers/sveltekit.ts
@@ -184,7 +184,7 @@ function upserKitRouteFile(
                 ? entries.node.equalsGreaterThanToken.getStart()
                 : entries.node.body.getStart();
             const returnInsertion = surround(
-                `: Promise<Array<ReturnType<import('./$types.js').EntryGenerator>>> | Array<ReturnType<import('./$types.js').EntryGenerator>> `
+                `: ReturnType<import('./$types.js').EntryGenerator> `
             );
             insert(returnPos, returnInsertion);
         }

--- a/packages/svelte2tsx/src/helpers/sveltekit.ts
+++ b/packages/svelte2tsx/src/helpers/sveltekit.ts
@@ -183,7 +183,9 @@ function upserKitRouteFile(
             const returnPos = ts.isArrowFunction(entries.node)
                 ? entries.node.equalsGreaterThanToken.getStart()
                 : entries.node.body.getStart();
-            const returnInsertion = surround(`: Array<import('./$types.js').RouteParams> `);
+            const returnInsertion = surround(
+                `: Promise<Array<import('./$types.js').RouteParams>> | Array<import('./$types.js').RouteParams> `
+            );
             insert(returnPos, returnInsertion);
         }
     }


### PR DESCRIPTION
See https://github.com/sveltejs/kit/pull/9571. This adds auto-typing support for that. I think?

The behavior should be:
- `entries` is a function returning `Array<RouteParam>`
- `entries` can be returned from any Kit file except `Layout` files

But I can't seem to get the host to work locally, so I'm not sure if this works or not... 👀 