### PR TITLE
(fix) move fs watcher config to language-server

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -21,7 +21,8 @@ import {
     CallHierarchyOutgoingCallsRequest,
     InlayHintRequest,
     SemanticTokensRefreshRequest,
-    InlayHintRefreshRequest
+    InlayHintRefreshRequest,
+    DidChangeWatchedFilesNotification
 } from 'vscode-languageserver';
 import { IPCMessageReader, IPCMessageWriter, createConnection } from 'vscode-languageserver/node';
 import { DiagnosticsManager } from './lib/DiagnosticsManager';
@@ -294,6 +295,22 @@ export function startServer(options?: LSOptions) {
                 callHierarchyProvider: true
             }
         };
+    });
+
+    connection.onInitialized(() => {
+        if (
+            !watcher &&
+            configManager.getClientCapabilities()?.workspace?.didChangeWatchedFiles
+                ?.dynamicRegistration
+        ) {
+            connection?.client.register(DidChangeWatchedFilesNotification.type, {
+                watchers: [
+                    {
+                        globPattern: '**/*.{ts,js,mts,mjs,cjs,cts,json}'
+                    }
+                ]
+            });
+        }
     });
 
     function notifyTsServiceExceedSizeLimit() {

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -151,8 +151,7 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
                 'less',
                 'scss',
                 'html'
-            ],
-            fileEvents: workspace.createFileSystemWatcher('{**/*.js,**/*.ts}', false, false, false)
+            ]
         },
         initializationOptions: {
             configuration: {


### PR DESCRIPTION
#2008 

The problem seems to be becuase neovim recently added the `didChangeWatchedFiles` support. But they didn't have a watcher config on their side. This PR move the watcher config to the language server with dynamic registration. It was on the client side because it can't be set in the server as a capability. 

Existing clients with the config I know of are VSCode, coc-svelte, visual studio and emacs-lsp. I tested with them to see if moving to the server side would cause any problems. VSCode and coc-svelte can handle both and will not trigger twice. Visual Studio doesn't support dynamic registration this won't affect it. I didn't manage to install emacs-lsp successfully. But the Volar client in emacs does have this double registration problem, and it doesn't seem to have an existing issue, so it's probably fine. 

I also added json to the watcher config. So this should fix #1613 as well. In resolveJsonModule, json file is just like ts, js files and in normal mode, We'll still cache some JSON files because TypeScript reads them through `languageServiceHost.readFile`. We can refresh those in the file watch as well. 