### PR TITLE
(fix) highlight destructuring in const tag

### DIFF
--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
@@ -178,6 +178,16 @@ repository:
     - { begin: '(?=\[)', end: '(?<=\])',
         name: meta.embedded.expression.svelte source.ts,
         patterns: [include: source.ts#array-binding-pattern] }
+  destructuring-const:
+    patterns:
+    # {...}
+    - { begin: '(?={)', end: '(?<=})',
+        name: meta.embedded.expression.svelte source.ts,
+        patterns: [include: source.ts#object-binding-pattern-const] }
+    # [...]
+    - { begin: '(?=\[)', end: '(?<=\])',
+        name: meta.embedded.expression.svelte source.ts,
+        patterns: [include: source.ts#array-binding-pattern-const] }
 
   # Plain old interpolation between `{...}` blocks.
   interpolation:
@@ -231,12 +241,14 @@ repository:
     - begin: (?<=const.*?)\G
       end: (?=})
       patterns:
+      - include: '#destructuring-const'
       # Variable.
       - begin: \G\s*([_$[:alpha:]][_$[:alnum:]]+)\s*
         end: (?=\=)
         beginCaptures: { 1: { name: variable.other.constant.svelte } }
       # Expression (starting with "=").
       - begin: (?=\=)
+        name: meta.embedded.expression.svelte source.ts
         end: (?=})
         patterns: [ include: source.ts ]
 

--- a/packages/svelte-vscode/test/grammar/dummy/ts.tmLanguage-dummy.json
+++ b/packages/svelte-vscode/test/grammar/dummy/ts.tmLanguage-dummy.json
@@ -1,4 +1,26 @@
 {
     "comment": "Dummy TS TextMate grammar for use in testing",
-    "scopeName": "source.ts"
+    "scopeName": "source.ts",
+    "repository": {
+        "object-binding-pattern": {
+            "comment": "Referenced in source.svelte#destructuring, needed to be defined here so that matching won't end at the } of destructuring",
+            "begin": "(?:(\\.\\.\\.)\\s*)?(\\{)",
+            "end": "\\}"
+        },
+        "object-binding-pattern-const": {
+            "comment": "Referenced in source.svelte#destructuring-const",
+			"begin": "(?:(\\.\\.\\.)\\s*)?(\\{)",
+			"end": "\\}"
+		},
+        "array-binding-pattern": {
+            "comment": "Referenced in source.svelte#destructuring",
+            "begin": "(?:(\\.\\.\\.)\\s*)?(\\[)",
+            "end": "\\]"
+        },
+		"array-binding-pattern-const": {
+            "comment": "Referenced in source.svelte#destructuring-const",
+			"begin": "(?:(\\.\\.\\.)\\s*)?(\\[)",
+			"end": "\\]"
+		}
+    }
 }

--- a/packages/svelte-vscode/test/grammar/dummy/ts.tmLanguage-dummy.json
+++ b/packages/svelte-vscode/test/grammar/dummy/ts.tmLanguage-dummy.json
@@ -9,18 +9,18 @@
         },
         "object-binding-pattern-const": {
             "comment": "Referenced in source.svelte#destructuring-const",
-			"begin": "(?:(\\.\\.\\.)\\s*)?(\\{)",
-			"end": "\\}"
-		},
+            "begin": "(?:(\\.\\.\\.)\\s*)?(\\{)",
+            "end": "\\}"
+        },
         "array-binding-pattern": {
             "comment": "Referenced in source.svelte#destructuring",
             "begin": "(?:(\\.\\.\\.)\\s*)?(\\[)",
             "end": "\\]"
         },
-		"array-binding-pattern-const": {
+        "array-binding-pattern-const": {
             "comment": "Referenced in source.svelte#destructuring-const",
-			"begin": "(?:(\\.\\.\\.)\\s*)?(\\[)",
-			"end": "\\]"
-		}
+            "begin": "(?:(\\.\\.\\.)\\s*)?(\\[)",
+            "end": "\\]"
+        }
     }
 }

--- a/packages/svelte-vscode/test/grammar/samples/const/input.svelte
+++ b/packages/svelte-vscode/test/grammar/samples/const/input.svelte
@@ -1,4 +1,6 @@
 {#each items as item}
     {@const _item = item}
     {item}
+    {@const { a } = abc}
+    {@const [ e ] = abc}
 {/each}

--- a/packages/svelte-vscode/test/grammar/samples/const/input.svelte.snap
+++ b/packages/svelte-vscode/test/grammar/samples/const/input.svelte.snap
@@ -16,13 +16,37 @@
 #           ^ source.svelte meta.special.const.svelte
 #            ^^^^^ source.svelte meta.special.const.svelte variable.other.constant.svelte
 #                 ^ source.svelte meta.special.const.svelte
-#                  ^^^^^^ source.svelte meta.special.const.svelte
+#                  ^^^^^^ source.svelte meta.special.const.svelte meta.embedded.expression.svelte source.ts
 #                        ^ source.svelte meta.special.const.svelte punctuation.definition.block.end.svelte
 >    {item}
 #^^^^ source.svelte text.svelte
 #    ^ source.svelte punctuation.section.embedded.begin.svelte
 #     ^^^^ source.svelte meta.embedded.expression.svelte source.ts
 #         ^ source.svelte punctuation.section.embedded.end.svelte
+>    {@const { a } = abc}
+#^^^^ source.svelte text.svelte
+#    ^ source.svelte meta.special.const.svelte punctuation.definition.block.begin.svelte
+#     ^ source.svelte meta.special.const.svelte punctuation.definition.keyword.svelte
+#      ^^^^^ source.svelte meta.special.const.svelte storage.type.svelte
+#           ^ source.svelte meta.special.const.svelte
+#            ^ source.svelte meta.special.const.svelte meta.embedded.expression.svelte source.ts
+#             ^^^ source.svelte meta.special.const.svelte meta.embedded.expression.svelte source.ts
+#                ^ source.svelte meta.special.const.svelte meta.embedded.expression.svelte source.ts
+#                 ^ source.svelte meta.special.const.svelte
+#                  ^^^^^ source.svelte meta.special.const.svelte meta.embedded.expression.svelte source.ts
+#                       ^ source.svelte meta.special.const.svelte punctuation.definition.block.end.svelte
+>    {@const [ e ] = abc}
+#^^^^ source.svelte text.svelte
+#    ^ source.svelte meta.special.const.svelte punctuation.definition.block.begin.svelte
+#     ^ source.svelte meta.special.const.svelte punctuation.definition.keyword.svelte
+#      ^^^^^ source.svelte meta.special.const.svelte storage.type.svelte
+#           ^ source.svelte meta.special.const.svelte
+#            ^ source.svelte meta.special.const.svelte meta.embedded.expression.svelte source.ts
+#             ^^^ source.svelte meta.special.const.svelte meta.embedded.expression.svelte source.ts
+#                ^ source.svelte meta.special.const.svelte meta.embedded.expression.svelte source.ts
+#                 ^ source.svelte meta.special.const.svelte
+#                  ^^^^^ source.svelte meta.special.const.svelte meta.embedded.expression.svelte source.ts
+#                       ^ source.svelte meta.special.const.svelte punctuation.definition.block.end.svelte
 >{/each}
 #^ source.svelte meta.special.each.svelte meta.special.end.svelte punctuation.definition.block.begin.svelte
 # ^ source.svelte meta.special.each.svelte meta.special.end.svelte punctuation.definition.keyword.svelte

--- a/packages/svelte-vscode/test/grammar/samples/each-block/input.svelte.snap
+++ b/packages/svelte-vscode/test/grammar/samples/each-block/input.svelte.snap
@@ -46,11 +46,11 @@
 #       ^^^^^^^^^^ source.svelte meta.special.each.svelte meta.special.start.svelte meta.embedded.expression.svelte source.ts
 #                 ^ source.svelte meta.special.each.svelte meta.special.start.svelte
 #                  ^^ source.svelte meta.special.each.svelte meta.special.start.svelte keyword.control.as.svelte
-#                    ^^ source.svelte meta.special.each.svelte meta.special.start.svelte
-#                      ^^^ source.svelte meta.special.each.svelte meta.special.start.svelte meta.embedded.expression.svelte source.ts
-#                         ^ source.svelte meta.special.each.svelte meta.special.start.svelte punctuation.separator.svelte
-#                          ^^^^^^ source.svelte meta.special.each.svelte meta.special.start.svelte meta.embedded.expression.svelte source.ts
-#                                ^^ source.svelte meta.special.each.svelte meta.special.start.svelte
+#                    ^ source.svelte meta.special.each.svelte meta.special.start.svelte
+#                     ^ source.svelte meta.special.each.svelte meta.special.start.svelte meta.embedded.expression.svelte source.ts
+#                      ^^^^^^^^^^ source.svelte meta.special.each.svelte meta.special.start.svelte meta.embedded.expression.svelte source.ts
+#                                ^ source.svelte meta.special.each.svelte meta.special.start.svelte meta.embedded.expression.svelte source.ts
+#                                 ^ source.svelte meta.special.each.svelte meta.special.start.svelte
 #                                  ^ source.svelte meta.special.each.svelte meta.special.start.svelte meta.brace.round.svelte
 #                                   ^^^ source.svelte meta.special.each.svelte meta.special.start.svelte meta.embedded.expression.svelte source.ts
 #                                      ^ source.svelte meta.special.each.svelte meta.special.start.svelte meta.brace.round.svelte

--- a/packages/svelte-vscode/test/grammar/samples/handler/input.svelte
+++ b/packages/svelte-vscode/test/grammar/samples/handler/input.svelte
@@ -1,3 +1,3 @@
-<div on:click="{(e) => {console.log(e)}}"></div>
+<div on:click="{(e) => console.log(e)}"></div>
 
-<Component on:click={(e) => {console.log(e)}}></Component>
+<Component on:click={(e) => console.log(e)}></Component>

--- a/packages/svelte-vscode/test/grammar/samples/handler/input.svelte.snap
+++ b/packages/svelte-vscode/test/grammar/samples/handler/input.svelte.snap
@@ -1,4 +1,4 @@
-><div on:click="{(e) => {console.log(e)}}"></div>
+><div on:click="{(e) => console.log(e)}"></div>
 #^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
 # ^^^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte entity.name.tag.svelte
 #    ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte
@@ -8,16 +8,15 @@
 #             ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte punctuation.separator.key-value.svelte
 #              ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte string.quoted.svelte punctuation.definition.string.begin.svelte
 #               ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte string.quoted.svelte punctuation.section.embedded.begin.svelte
-#                ^^^^^^^^^^^^^^^^^^^^^^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte string.quoted.svelte meta.embedded.expression.svelte source.ts
-#                                      ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte string.quoted.svelte punctuation.section.embedded.end.svelte
-#                                       ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte string.quoted.svelte
-#                                        ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte string.quoted.svelte punctuation.definition.string.end.svelte
-#                                         ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
-#                                          ^^ source.svelte meta.scope.tag.div.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
-#                                            ^^^ source.svelte meta.scope.tag.div.svelte meta.tag.end.svelte entity.name.tag.svelte
-#                                               ^ source.svelte meta.scope.tag.div.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
+#                ^^^^^^^^^^^^^^^^^^^^^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte string.quoted.svelte meta.embedded.expression.svelte source.ts
+#                                     ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte string.quoted.svelte punctuation.section.embedded.end.svelte
+#                                      ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte meta.directive.on.svelte string.quoted.svelte punctuation.definition.string.end.svelte
+#                                       ^ source.svelte meta.scope.tag.div.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
+#                                        ^^ source.svelte meta.scope.tag.div.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
+#                                          ^^^ source.svelte meta.scope.tag.div.svelte meta.tag.end.svelte entity.name.tag.svelte
+#                                             ^ source.svelte meta.scope.tag.div.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
 >
-><Component on:click={(e) => {console.log(e)}}></Component>
+><Component on:click={(e) => console.log(e)}></Component>
 #^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
 # ^^^^^^^^^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte support.class.component.svelte
 #          ^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte
@@ -26,11 +25,10 @@
 #              ^^^^^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte meta.directive.on.svelte entity.name.type.svelte
 #                   ^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte meta.directive.on.svelte punctuation.separator.key-value.svelte
 #                    ^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte meta.directive.on.svelte punctuation.section.embedded.begin.svelte
-#                     ^^^^^^^^^^^^^^^^^^^^^^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte meta.directive.on.svelte meta.embedded.expression.svelte source.ts
-#                                           ^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte meta.directive.on.svelte punctuation.section.embedded.end.svelte
-#                                            ^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte
-#                                             ^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
-#                                              ^^ source.svelte meta.scope.tag.Component.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
-#                                                ^^^^^^^^^ source.svelte meta.scope.tag.Component.svelte meta.tag.end.svelte support.class.component.svelte
-#                                                         ^ source.svelte meta.scope.tag.Component.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
+#                     ^^^^^^^^^^^^^^^^^^^^^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte meta.directive.on.svelte meta.embedded.expression.svelte source.ts
+#                                          ^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte meta.directive.on.svelte punctuation.section.embedded.end.svelte
+#                                           ^ source.svelte meta.scope.tag.Component.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
+#                                            ^^ source.svelte meta.scope.tag.Component.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
+#                                              ^^^^^^^^^ source.svelte meta.scope.tag.Component.svelte meta.tag.end.svelte support.class.component.svelte
+#                                                       ^ source.svelte meta.scope.tag.Component.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
 >

--- a/packages/svelte-vscode/test/grammar/test.js
+++ b/packages/svelte-vscode/test/grammar/test.js
@@ -40,7 +40,7 @@ async function snapShotTest() {
         'source.svelte',
         '-t',
         './test/grammar/samples/**/*.svelte',
-        ...allGrammars.reduce((previous, path) => [...previous, '-g', path], []),
+        ...allGrammars.reduce((previous, path) => [...previous, '-g', path], /** @type {string[]} */([])),
         ...extraArgs
     ];
 

--- a/packages/svelte-vscode/test/grammar/test.js
+++ b/packages/svelte-vscode/test/grammar/test.js
@@ -40,7 +40,10 @@ async function snapShotTest() {
         'source.svelte',
         '-t',
         './test/grammar/samples/**/*.svelte',
-        ...allGrammars.reduce((previous, path) => [...previous, '-g', path], /** @type {string[]} */([])),
+        ...allGrammars.reduce(
+            (previous, path) => [...previous, '-g', path],
+            /** @type {string[]} */ ([])
+        ),
         ...extraArgs
     ];
 


### PR DESCRIPTION
#2013. 

Using the same approach for each tag destructuring. Because the `}` in the restructuring will be part of the `source.ts` matching. It won't count as the end of the `@const` tag.  Different from each tag restructuring, this uses `source.ts#object-binding-pattern-const` and `source.ts#array-binding-pattern-const` to highlight the variable as `variable.other.constant.ts`.