### PR TITLE
(fix) prevent ts plugin crash when config updated

### DIFF
--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -19,7 +19,7 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
             return info.languageService;
         }
 
-        if (isPatched(info.languageService)) {
+        if (isPatched(info.project)) {
             logger.log('Already patched. Checking tsconfig updates.');
 
             ProjectSvelteFilesManager.getInstance(
@@ -130,18 +130,14 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
             }
         });
 
-        return decorateLanguageServiceDispose(
-            decorateLanguageService(
-                info.languageService,
-                snapshotManager,
-                logger,
-                configManager,
-                info,
-                modules.typescript
-            ),
-            projectSvelteFilesManager ?? {
-                dispose() {}
-            }
+        return decorateLanguageService(
+            info.languageService,
+            snapshotManager,
+            logger,
+            configManager,
+            info,
+            modules.typescript,
+            () => projectSvelteFilesManager?.dispose()
         );
     }
 
@@ -189,20 +185,6 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
 
     function onConfigurationChanged(config: Configuration) {
         configManager.updateConfigFromPluginConfig(config);
-    }
-
-    function decorateLanguageServiceDispose(
-        languageService: ts.LanguageService,
-        disposable: { dispose(): void }
-    ) {
-        const dispose = languageService.dispose;
-
-        languageService.dispose = () => {
-            disposable.dispose();
-            dispose();
-        };
-
-        return languageService;
     }
 
     /**

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -104,6 +104,7 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
                   info.project,
                   info.serverHost,
                   snapshotManager,
+                  logger,
                   parsedCommandLine,
                   configManager
               )

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -15,10 +15,10 @@ import { decorateRename } from './rename';
 import { decorateUpdateImports } from './update-imports';
 import { decorateLanguageServiceHost } from './host';
 
-const sveltePluginPatchSymbol = Symbol('sveltePluginPatchSymbol');
+const patchedProject = new Set<string>();
 
-export function isPatched(ls: ts.LanguageService) {
-    return (ls as any)[sveltePluginPatchSymbol] === true;
+export function isPatched(project: ts.server.Project) {
+    return patchedProject.has(project.getProjectName());
 }
 
 export function decorateLanguageService(
@@ -27,13 +27,16 @@ export function decorateLanguageService(
     logger: Logger,
     configManager: ConfigManager,
     info: ts.server.PluginCreateInfo,
-    typescript: typeof ts
+    typescript: typeof ts,
+    onDispose: () => void
 ) {
+    patchedProject.add(info.project.getProjectName());
+
     // Decorate using a proxy so we can dynamically enable/disable method
     // patches depending on the enabled state of our config
     const proxy = new Proxy(ls, createProxyHandler(configManager));
     decorateLanguageServiceHost(info.languageServiceHost);
-    decorateLanguageServiceInner(proxy, snapshotManager, logger, info, typescript);
+    decorateLanguageServiceInner(proxy, snapshotManager, logger, info, typescript, onDispose);
 
     return proxy;
 }
@@ -43,7 +46,8 @@ function decorateLanguageServiceInner(
     snapshotManager: SvelteSnapshotManager,
     logger: Logger,
     info: ts.server.PluginCreateInfo,
-    typescript: typeof ts
+    typescript: typeof ts,
+    onDispose: () => void
 ): ts.LanguageService {
     patchLineColumnOffset(ls, snapshotManager);
     decorateRename(ls, snapshotManager, logger);
@@ -56,6 +60,7 @@ function decorateLanguageServiceInner(
     decorateCallHierarchy(ls, snapshotManager, typescript);
     decorateHover(ls, info, typescript, logger);
     decorateInlayHints(ls, info, typescript, logger);
+    decorateDispose(ls, info.project, onDispose);
     return ls;
 }
 
@@ -64,11 +69,6 @@ function createProxyHandler(configManager: ConfigManager): ProxyHandler<ts.Langu
 
     return {
         get(target, p) {
-            // always return patch symbol whether the plugin is enabled or not
-            if (p === sveltePluginPatchSymbol) {
-                return true;
-            }
-
             if (!configManager.getConfig().enable || p === 'dispose') {
                 return target[p as keyof ts.LanguageService];
             }
@@ -101,4 +101,20 @@ function patchLineColumnOffset(ls: ts.LanguageService, snapshotManager: SvelteSn
         }
         return toLineColumnOffset(fileName, position);
     };
+}
+
+function decorateDispose(
+    ls: ts.LanguageService,
+    project: ts.server.Project,
+    onDispose: () => void
+) {
+    const dispose = ls.dispose;
+
+    ls.dispose = () => {
+        patchedProject.delete(project.getProjectName());
+        onDispose();
+        dispose();
+    };
+
+    return ls;
 }

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -69,7 +69,7 @@ function createProxyHandler(configManager: ConfigManager): ProxyHandler<ts.Langu
 
     return {
         get(target, p) {
-            if (!configManager.getConfig().enable || p === 'dispose') {
+            if (!configManager.getConfig().enable) {
                 return target[p as keyof ts.LanguageService];
             }
 

--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -69,7 +69,8 @@ function createProxyHandler(configManager: ConfigManager): ProxyHandler<ts.Langu
 
     return {
         get(target, p) {
-            if (!configManager.getConfig().enable) {
+            // always check for decorated dispose
+            if (!configManager.getConfig().enable && p !== 'dispose') {
                 return target[p as keyof ts.LanguageService];
             }
 

--- a/packages/typescript-plugin/src/project-svelte-files.ts
+++ b/packages/typescript-plugin/src/project-svelte-files.ts
@@ -10,7 +10,7 @@ export interface TsFilesSpec {
 }
 
 export class ProjectSvelteFilesManager {
-    private files = new Set<string>();
+    private projectFileToOriginalCasing = new Map<string, string>();
     private directoryWatchers = new Set<ts.FileWatcher>();
 
     private static instances = new Map<string, ProjectSvelteFilesManager>();
@@ -53,7 +53,7 @@ export class ProjectSvelteFilesManager {
     }
 
     getFiles() {
-        return Array.from(this.files);
+        return Array.from(this.projectFileToOriginalCasing.values());
     }
 
     /**
@@ -96,23 +96,34 @@ export class ProjectSvelteFilesManager {
     }
 
     private updateProjectSvelteFiles() {
-        const fileNamesAfter = this.readProjectSvelteFilesFromFs();
-        const removedFiles = new Set(...this.files);
-        const newFiles = fileNamesAfter.filter((fileName) => {
-            const has = this.files.has(fileName);
-            if (has) {
-                removedFiles.delete(fileName);
+        const fileNamesAfter = this.readProjectSvelteFilesFromFs().map((file) => ({
+            originalCasing: file,
+            canonicalFileName: this.project.projectService.toCanonicalFileName(file)
+        }));
+
+        const removedFiles = new Set(this.projectFileToOriginalCasing.keys());
+        const newFiles: typeof fileNamesAfter = [];
+
+        for (const file of fileNamesAfter) {
+            const existingFile = this.projectFileToOriginalCasing.get(file.canonicalFileName);
+            if (!existingFile) {
+                newFiles.push(file);
+                continue;
             }
-            return !has;
-        });
+
+            removedFiles.delete(file.canonicalFileName);
+            if (existingFile !== file.originalCasing) {
+                this.projectFileToOriginalCasing.set(file.canonicalFileName, file.originalCasing);
+            }
+        }
 
         for (const newFile of newFiles) {
-            this.addFileToProject(newFile);
-            this.files.add(newFile);
+            this.addFileToProject(newFile.originalCasing);
+            this.projectFileToOriginalCasing.set(newFile.canonicalFileName, newFile.originalCasing);
         }
         for (const removedFile of removedFiles) {
             this.removeFileFromProject(removedFile, false);
-            this.files.delete(removedFile);
+            this.projectFileToOriginalCasing.delete(removedFile);
         }
     }
 
@@ -171,8 +182,8 @@ export class ProjectSvelteFilesManager {
         this.directoryWatchers.forEach((watcher) => watcher.close());
         this.directoryWatchers.clear();
 
-        this.files.forEach((file) => this.removeFileFromProject(file));
-        this.files.clear();
+        this.projectFileToOriginalCasing.forEach((file) => this.removeFileFromProject(file));
+        this.projectFileToOriginalCasing.clear();
     }
 
     dispose() {

--- a/packages/typescript-plugin/src/project-svelte-files.ts
+++ b/packages/typescript-plugin/src/project-svelte-files.ts
@@ -118,7 +118,7 @@ export class ProjectSvelteFilesManager {
         this.snapshotManager.create(newFile);
         const snapshot = this.project.projectService.getScriptInfo(newFile);
 
-        if (snapshot) {
+        if (snapshot && !this.project.isRoot(snapshot)) {
             this.project.addRoot(snapshot);
         }
     }


### PR DESCRIPTION
#2018 https://github.com/sveltejs/kit/issues/9932

This happens when tsconfig or extending tsconfig updates and another ts-plugin returns another language service object. For example, https://marketplace.visualstudio.com/items?itemName=VisualStudioExptTeam.vscodeintellicode. Because the patched symbol is no longer there, patching will run again. And when we call `project.addRoot`, a Debug assertion error will be thrown as the file is already a root file. TypeScript will then removes the external files because the plugin failed to initialise. 