### PR TITLE
feat: basic support for civet

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -57,7 +57,7 @@ export class DiagnosticsProviderImpl implements DiagnosticsProvider {
         const { lang, tsDoc } = await this.getLSAndTSDoc(document);
 
         if (
-            ['coffee', 'coffeescript'].includes(document.getLanguageAttribute('script')) ||
+            ['coffee', 'coffeescript', 'civet'].includes(document.getLanguageAttribute('script')) ||
             cancellationToken?.isCancellationRequested
         ) {
             return [];

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -438,7 +438,8 @@
                     "source.stylus": "stylus",
                     "source.js": "javascript",
                     "source.ts": "typescript",
-                    "source.coffee": "coffeescript"
+                    "source.coffee": "coffeescript",
+                    "source.civet": "civet"
                 },
                 "unbalancedBracketScopes": [
                     "keyword.operator.relational",

--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
@@ -29,6 +29,11 @@ injections:
     patterns: [{begin: '(?<=>)(?!</)', end: '(?=</)', name: meta.embedded.block.svelte,
     contentName: source.coffee, patterns: [{ include: source.coffee }]}]
 
+  # Civet | 'civet' | 'source.civet'
+  'L:(meta.script.svelte | meta.style.svelte) meta.lang.civet - (meta source)':
+    patterns: [{begin: '(?<=>)(?!</)', end: '(?=</)', name: meta.embedded.block.svelte,
+    contentName: source.civet, patterns: [{ include: source.civet }]}]
+
   # Script Languages
   # Default (JavaScript)
   'L:meta.script.svelte - meta.lang - (meta source)':
@@ -89,7 +94,7 @@ injections:
 
   # - TS / JS / CS -
 
-  'L:(source.ts, source.js, source.coffee)':
+  'L:(source.ts, source.js, source.coffee, source.civet)':
     patterns:
     # Matches the store accessor symbol.
     # i.e. the `$` in `$myStore`.

--- a/packages/svelte-vscode/test/grammar/dummy/civet.tmLanguage-dummy.json
+++ b/packages/svelte-vscode/test/grammar/dummy/civet.tmLanguage-dummy.json
@@ -1,0 +1,4 @@
+{
+    "comment": "Dummy Civet TextMate grammar for use in testing",
+    "scopeName": "source.civet"
+}

--- a/packages/svelte-vscode/test/grammar/samples/script-civet/input.svelte
+++ b/packages/svelte-vscode/test/grammar/samples/script-civet/input.svelte
@@ -1,0 +1,3 @@
+<script lang="civet">
+    export abc = 123
+</script>

--- a/packages/svelte-vscode/test/grammar/samples/script-civet/input.svelte.snap
+++ b/packages/svelte-vscode/test/grammar/samples/script-civet/input.svelte.snap
@@ -1,0 +1,17 @@
+><script lang="civet">
+#^ source.svelte meta.script.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
+# ^^^^^^ source.svelte meta.script.svelte meta.tag.start.svelte entity.name.tag.svelte
+#       ^ source.svelte meta.script.svelte meta.lang.civet.svelte meta.tag.start.svelte
+#        ^^^^ source.svelte meta.script.svelte meta.lang.civet.svelte meta.tag.start.svelte meta.attribute.lang.svelte entity.other.attribute-name.svelte
+#            ^ source.svelte meta.script.svelte meta.lang.civet.svelte meta.tag.start.svelte meta.attribute.lang.svelte punctuation.separator.key-value.svelte
+#             ^ source.svelte meta.script.svelte meta.lang.civet.svelte meta.tag.start.svelte meta.attribute.lang.svelte string.quoted.svelte punctuation.definition.string.begin.svelte
+#              ^^^^^ source.svelte meta.script.svelte meta.lang.civet.svelte meta.tag.start.svelte meta.attribute.lang.svelte string.quoted.svelte
+#                   ^ source.svelte meta.script.svelte meta.lang.civet.svelte meta.tag.start.svelte meta.attribute.lang.svelte string.quoted.svelte punctuation.definition.string.end.svelte
+#                    ^ source.svelte meta.script.svelte meta.lang.civet.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
+>    export abc = 123
+#^^^^^^^^^^^^^^^^^^^^^ source.svelte meta.script.svelte meta.lang.civet.svelte
+></script>
+#^^ source.svelte meta.script.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
+#  ^^^^^^ source.svelte meta.script.svelte meta.tag.end.svelte entity.name.tag.svelte
+#        ^ source.svelte meta.script.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
+>


### PR DESCRIPTION
Adds basic grammar support for the [civet](https://civet.dev/) language in scripts.
Lacks diagnostics in the same way that coffeescript lacks diagnostics.

(Related to [this PR in svelte-preprocess](https://github.com/sveltejs/svelte-preprocess/pull/600))