### PR TITLE
chore: add packageManager to root package.json to support corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
         "prettier": "2.8.6",
         "cross-env": "^7.0.2",
         "ts-node": "^10.0.0"
-    }
+    },
+    "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
needed for svelte-ecosytem-ci  (and helps users that use corepack on their local machines)