### PR TITLE
breaking: make ready for Svelte 4

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from 'path';
 import ts from 'typescript';
 import { TextDocumentContentChangeEvent } from 'vscode-languageserver-protocol';
-import { getPackageInfo } from '../../importPackage';
+import { getPackageInfo, importSvelte } from '../../importPackage';
 import { Document } from '../../lib/documents';
 import { configLoader } from '../../lib/documents/configLoader';
 import { FileMap, FileSet } from '../../lib/documents/fileCollection';
@@ -201,11 +201,12 @@ async function createLanguageService(
         // Fall back to dirname
         svelteTsPath = __dirname;
     }
-    const svelteTsxFiles = [
-        './svelte-shims.d.ts',
-        './svelte-jsx.d.ts',
-        './svelte-native-jsx.d.ts'
-    ].map((f) => tsSystem.resolvePath(resolve(svelteTsPath, f)));
+    const VERSION = importSvelte(tsconfigPath || workspacePath).VERSION;
+    const svelteTsxFiles = (
+        VERSION.split('.')[0] === '3'
+            ? ['./svelte-shims.d.ts', './svelte-jsx.d.ts', './svelte-native-jsx.d.ts']
+            : ['./svelte-shims-v4.d.ts', './svelte-jsx-v4.d.ts', './svelte-native-jsx.d.ts']
+    ).map((f) => tsSystem.resolvePath(resolve(svelteTsPath, f)));
 
     let languageServiceReducedMode = false;
     let projectVersion = 0;

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/importing/a.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/importing/a.ts
@@ -1,3 +1,3 @@
-import { writable } from 'svelte/store';
+import type { Writable } from 'svelte/store';
 
-export const someStore = writable(1);
+export const someStore = null as any as Writable<number>;

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/importing/b.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/importing/b.ts
@@ -1,4 +1,4 @@
-import { readable, writable } from 'svelte/store';
+import type { Readable, Writable } from 'svelte/store';
 
-export const someStore = readable(1);
-export const someOtherStore = writable(1);
+export const someStore = null as any as Readable<number>;
+export const someOtherStore = null as any as Writable<number>;

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/importing/c.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/importing/c.ts
@@ -1,3 +1,5 @@
-import { SvelteComponentTyped } from 'svelte';
+import type { SvelteComponentTyped as tmp } from 'svelte';
+
+const SvelteComponentTyped: typeof tmp = null as any;
 
 export class FixAllImported3 extends SvelteComponentTyped {}

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/ComponentDef.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/ComponentDef.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom" />
-import { SvelteComponentTyped } from 'svelte';
+import type { SvelteComponentTyped as tmp } from 'svelte';
+
+const SvelteComponentTyped: typeof tmp = null as any;
 
 export class ComponentDef extends SvelteComponentTyped<
     {},

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/to-import.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/to-import.ts
@@ -1,5 +1,5 @@
-import { writable } from 'svelte/store';
+import type { Writable } from 'svelte/store';
 
 export class ScndImport {}
 
-export const store = writable('');
+export const store = null as any as Writable<number>;

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -33,7 +33,7 @@
         "typescript": "^5.0.3"
     },
     "peerDependencies": {
-        "svelte": "^3.55.0"
+        "svelte": "^3.55.0 || ^4.0.0"
     },
     "scripts": {
         "build": "rollup -c && node ./dist/src/index.js --workspace ./test --tsconfig ./tsconfig.json",

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -43,7 +43,7 @@
         "typescript": "^5.0.3"
     },
     "peerDependencies": {
-        "svelte": "^3.55",
+        "svelte": "^3.55 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
     },
     "scripts": {
@@ -59,9 +59,10 @@
         "README.md",
         "LICENSE",
         "svelte-jsx.d.ts",
+        "svelte-jsx-v4.d.ts",
         "svelte-native-jsx.d.ts",
         "svelte-shims.d.ts",
-        "svelte-html-do-not-use.d.ts"
+        "svelte-shims-v4.d.ts"
     ],
     "dependencies": {
         "dedent-js": "^1.0.1",

--- a/packages/svelte2tsx/src/svelte2tsx/index.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/index.ts
@@ -425,6 +425,7 @@ export function svelte2tsx(
         // Prepend the import which is used for TS files
         // The other shims need to be provided by the user ambient-style,
         // for example through filenames.push(require.resolve('svelte2tsx/svelte-shims.d.ts'))
+        // TODO replace with SvelteComponent for Svelte 5, keep old for backwards compatibility with Svelte 3
         str.prepend('import { SvelteComponentTyped } from "svelte"\n' + '\n');
         let code = str.toString();
         // Remove all tsx occurences and the template part from the output

--- a/packages/svelte2tsx/svelte-jsx-v4.d.ts
+++ b/packages/svelte2tsx/svelte-jsx-v4.d.ts
@@ -1,0 +1,229 @@
+/// <reference lib="dom" />
+
+declare namespace svelteHTML {
+
+  // Every namespace eligible for use needs to implement the following two functions
+  /**
+   * @internal do not use
+   */
+  function mapElementTag<K extends keyof ElementTagNameMap>(
+    tag: K
+  ): ElementTagNameMap[K];
+  function mapElementTag<K extends keyof SVGElementTagNameMap>(
+    tag: K
+  ): SVGElementTagNameMap[K];
+  function mapElementTag(
+    tag: any
+  ): any; // needs to be any because used in context of <svelte:element>
+
+  /**
+   * @internal do not use
+   */
+  function createElement<Elements extends IntrinsicElements, Key extends keyof Elements>(
+    // "undefined | null" because of <svelte:element>
+    element: Key | undefined | null, attrs: string extends Key ? import('svelte/elements').HTMLAttributes<any> : Elements[Key]
+  ): Key extends keyof ElementTagNameMap ? ElementTagNameMap[Key] : Key extends keyof SVGElementTagNameMap ? SVGElementTagNameMap[Key] : any;
+  function createElement<Elements extends IntrinsicElements, Key extends keyof Elements, T>(
+    // "undefined | null" because of <svelte:element>
+    element: Key | undefined | null, attrsEnhancers: T, attrs: (string extends Key ? import('svelte/elements').HTMLAttributes<any> : Elements[Key]) & T
+  ): Key extends keyof ElementTagNameMap ? ElementTagNameMap[Key] : Key extends keyof SVGElementTagNameMap ? SVGElementTagNameMap[Key] : any;
+
+  // For backwards-compatibility and ease-of-use, in case someone enhanced the typings from import('svelte/elements').HTMLAttributes/SVGAttributes
+  interface HTMLAttributes<T extends EventTarget = any> {}
+  interface SVGAttributes<T extends EventTarget = any> {}
+
+  /**
+   * @internal do not use
+   */
+  type HTMLProps<Property extends string, Override> =
+    Omit<import('svelte/elements').SvelteHTMLElements[Property], keyof Override> & Override;
+
+  interface IntrinsicElements {
+    a: HTMLProps<'a', HTMLAttributes>;
+    abbr: HTMLProps<'abbr', HTMLAttributes>;
+    address: HTMLProps<'address', HTMLAttributes>;
+    area: HTMLProps<'area', HTMLAttributes>;
+    article: HTMLProps<'article', HTMLAttributes>;
+    aside: HTMLProps<'aside', HTMLAttributes>;
+    audio: HTMLProps<'audio', HTMLAttributes>;
+    b: HTMLProps<'b', HTMLAttributes>;
+    base: HTMLProps<'base', HTMLAttributes>;
+    bdi: HTMLProps<'bdi', HTMLAttributes>;
+    bdo: HTMLProps<'bdo', HTMLAttributes>;
+    big: HTMLProps<'big', HTMLAttributes>;
+    blockquote: HTMLProps<'blockquote', HTMLAttributes>;
+    body: HTMLProps<'body', HTMLAttributes>;
+    br: HTMLProps<'br', HTMLAttributes>;
+    button: HTMLProps<'button', HTMLAttributes>;
+    canvas: HTMLProps<'canvas', HTMLAttributes>;
+    caption: HTMLProps<'caption', HTMLAttributes>;
+    cite: HTMLProps<'cite', HTMLAttributes>;
+    code: HTMLProps<'code', HTMLAttributes>;
+    col: HTMLProps<'col', HTMLAttributes>;
+    colgroup: HTMLProps<'colgroup', HTMLAttributes>;
+    data: HTMLProps<'data', HTMLAttributes>;
+    datalist: HTMLProps<'datalist', HTMLAttributes>;
+    dd: HTMLProps<'dd', HTMLAttributes>;
+    del: HTMLProps<'del', HTMLAttributes>;
+    details: HTMLProps<'details', HTMLAttributes>;
+    dfn: HTMLProps<'dfn', HTMLAttributes>;
+    dialog: HTMLProps<'dialog', HTMLAttributes>;
+    div: HTMLProps<'div', HTMLAttributes>;
+    dl: HTMLProps<'dl', HTMLAttributes>;
+    dt: HTMLProps<'dt', HTMLAttributes>;
+    em: HTMLProps<'em', HTMLAttributes>;
+    embed: HTMLProps<'embed', HTMLAttributes>;
+    fieldset: HTMLProps<'fieldset', HTMLAttributes>;
+    figcaption: HTMLProps<'figcaption', HTMLAttributes>;
+    figure: HTMLProps<'figure', HTMLAttributes>;
+    footer: HTMLProps<'footer', HTMLAttributes>;
+    form: HTMLProps<'form', HTMLAttributes>;
+    h1: HTMLProps<'h1', HTMLAttributes>;
+    h2: HTMLProps<'h2', HTMLAttributes>;
+    h3: HTMLProps<'h3', HTMLAttributes>;
+    h4: HTMLProps<'h4', HTMLAttributes>;
+    h5: HTMLProps<'h5', HTMLAttributes>;
+    h6: HTMLProps<'h6', HTMLAttributes>;
+    head: HTMLProps<'head', HTMLAttributes>;
+    header: HTMLProps<'header', HTMLAttributes>;
+    hgroup: HTMLProps<'hgroup', HTMLAttributes>;
+    hr: HTMLProps<'hr', HTMLAttributes>;
+    html: HTMLProps<'html', HTMLAttributes>;
+    i: HTMLProps<'i', HTMLAttributes>;
+    iframe: HTMLProps<'iframe', HTMLAttributes>;
+    img: HTMLProps<'img', HTMLAttributes>;
+    input: HTMLProps<'input', HTMLAttributes>;
+    ins: HTMLProps<'ins', HTMLAttributes>;
+    kbd: HTMLProps<'kbd', HTMLAttributes>;
+    keygen: HTMLProps<'keygen', HTMLAttributes>;
+    label: HTMLProps<'label', HTMLAttributes>;
+    legend: HTMLProps<'legend', HTMLAttributes>;
+    li: HTMLProps<'li', HTMLAttributes>;
+    link: HTMLProps<'link', HTMLAttributes>;
+    main: HTMLProps<'main', HTMLAttributes>;
+    map: HTMLProps<'map', HTMLAttributes>;
+    mark: HTMLProps<'mark', HTMLAttributes>;
+    menu: HTMLProps<'menu', HTMLAttributes>;
+    menuitem: HTMLProps<'menuitem', HTMLAttributes>;
+    meta: HTMLProps<'meta', HTMLAttributes>;
+    meter: HTMLProps<'meter', HTMLAttributes>;
+    nav: HTMLProps<'nav', HTMLAttributes>;
+    noscript: HTMLProps<'noscript', HTMLAttributes>;
+    object: HTMLProps<'object', HTMLAttributes>;
+    ol: HTMLProps<'ol', HTMLAttributes>;
+    optgroup: HTMLProps<'optgroup', HTMLAttributes>;
+    option: HTMLProps<'option', HTMLAttributes>;
+    output: HTMLProps<'output', HTMLAttributes>;
+    p: HTMLProps<'p', HTMLAttributes>;
+    param: HTMLProps<'param', HTMLAttributes>;
+    picture: HTMLProps<'picture', HTMLAttributes>;
+    pre: HTMLProps<'pre', HTMLAttributes>;
+    progress: HTMLProps<'progress', HTMLAttributes>;
+    q: HTMLProps<'q', HTMLAttributes>;
+    rp: HTMLProps<'rp', HTMLAttributes>;
+    rt: HTMLProps<'rt', HTMLAttributes>;
+    ruby: HTMLProps<'ruby', HTMLAttributes>;
+    s: HTMLProps<'s', HTMLAttributes>;
+    samp: HTMLProps<'samp', HTMLAttributes>;
+    slot: HTMLProps<'slot', HTMLAttributes>;
+    script: HTMLProps<'script', HTMLAttributes>;
+    section: HTMLProps<'section', HTMLAttributes>;
+    select: HTMLProps<'select', HTMLAttributes>;
+    small: HTMLProps<'small', HTMLAttributes>;
+    source: HTMLProps<'source', HTMLAttributes>;
+    span: HTMLProps<'span', HTMLAttributes>;
+    strong: HTMLProps<'strong', HTMLAttributes>;
+    style: HTMLProps<'style', HTMLAttributes>;
+    sub: HTMLProps<'sub', HTMLAttributes>;
+    summary: HTMLProps<'summary', HTMLAttributes>;
+    sup: HTMLProps<'sup', HTMLAttributes>;
+    table: HTMLProps<'table', HTMLAttributes>;
+    template: HTMLProps<'template', HTMLAttributes>;
+    tbody: HTMLProps<'tbody', HTMLAttributes>;
+    td: HTMLProps<'td', HTMLAttributes>;
+    textarea: HTMLProps<'textarea', HTMLAttributes>;
+    tfoot: HTMLProps<'tfoot', HTMLAttributes>;
+    th: HTMLProps<'th', HTMLAttributes>;
+    thead: HTMLProps<'thead', HTMLAttributes>;
+    time: HTMLProps<'time', HTMLAttributes>;
+    title: HTMLProps<'title', HTMLAttributes>;
+    tr: HTMLProps<'tr', HTMLAttributes>;
+    track: HTMLProps<'track', HTMLAttributes>;
+    u: HTMLProps<'u', HTMLAttributes>;
+    ul: HTMLProps<'ul', HTMLAttributes>;
+    var: HTMLProps<'var', HTMLAttributes>;
+    video: HTMLProps<'video', HTMLAttributes>;
+    wbr: HTMLProps<'wbr', HTMLAttributes>;
+    webview: HTMLProps<'webview', HTMLAttributes>;
+    // SVG
+    svg: HTMLProps<'svg', SVGAttributes>;
+
+    animate: HTMLProps<'animate', SVGAttributes>;
+    animateMotion: HTMLProps<'animateMotion', SVGAttributes>;
+    animateTransform: HTMLProps<'animateTransform', SVGAttributes>;
+    circle: HTMLProps<'circle', SVGAttributes>;
+    clipPath: HTMLProps<'clipPath', SVGAttributes>;
+    defs: HTMLProps<'defs', SVGAttributes>;
+    desc: HTMLProps<'desc', SVGAttributes>;
+    ellipse: HTMLProps<'ellipse', SVGAttributes>;
+    feBlend: HTMLProps<'feBlend', SVGAttributes>;
+    feColorMatrix: HTMLProps<'feColorMatrix', SVGAttributes>;
+    feComponentTransfer: HTMLProps<'feComponentTransfer', SVGAttributes>;
+    feComposite: HTMLProps<'feComposite', SVGAttributes>;
+    feConvolveMatrix: HTMLProps<'feConvolveMatrix', SVGAttributes>;
+    feDiffuseLighting: HTMLProps<'feDiffuseLighting', SVGAttributes>;
+    feDisplacementMap: HTMLProps<'feDisplacementMap', SVGAttributes>;
+    feDistantLight: HTMLProps<'feDistantLight', SVGAttributes>;
+    feDropShadow: HTMLProps<'feDropShadow', SVGAttributes>;
+    feFlood: HTMLProps<'feFlood', SVGAttributes>;
+    feFuncA: HTMLProps<'feFuncA', SVGAttributes>;
+    feFuncB: HTMLProps<'feFuncB', SVGAttributes>;
+    feFuncG: HTMLProps<'feFuncG', SVGAttributes>;
+    feFuncR: HTMLProps<'feFuncR', SVGAttributes>;
+    feGaussianBlur: HTMLProps<'feGaussianBlur', SVGAttributes>;
+    feImage: HTMLProps<'feImage', SVGAttributes>;
+    feMerge: HTMLProps<'feMerge', SVGAttributes>;
+    feMergeNode: HTMLProps<'feMergeNode', SVGAttributes>;
+    feMorphology: HTMLProps<'feMorphology', SVGAttributes>;
+    feOffset: HTMLProps<'feOffset', SVGAttributes>;
+    fePointLight: HTMLProps<'fePointLight', SVGAttributes>;
+    feSpecularLighting: HTMLProps<'feSpecularLighting', SVGAttributes>;
+    feSpotLight: HTMLProps<'feSpotLight', SVGAttributes>;
+    feTile: HTMLProps<'feTile', SVGAttributes>;
+    feTurbulence: HTMLProps<'feTurbulence', SVGAttributes>;
+    filter: HTMLProps<'filter', SVGAttributes>;
+    foreignObject: HTMLProps<'foreignObject', SVGAttributes>;
+    g: HTMLProps<'g', SVGAttributes>;
+    image: HTMLProps<'image', SVGAttributes>;
+    line: HTMLProps<'line', SVGAttributes>;
+    linearGradient: HTMLProps<'linearGradient', SVGAttributes>;
+    marker: HTMLProps<'marker', SVGAttributes>;
+    mask: HTMLProps<'mask', SVGAttributes>;
+    metadata: HTMLProps<'metadata', SVGAttributes>;
+    mpath: HTMLProps<'mpath', SVGAttributes>;
+    path: HTMLProps<'path', SVGAttributes>;
+    pattern: HTMLProps<'pattern', SVGAttributes>;
+    polygon: HTMLProps<'polygon', SVGAttributes>;
+    polyline: HTMLProps<'polyline', SVGAttributes>;
+    radialGradient: HTMLProps<'radialGradient', SVGAttributes>;
+    rect: HTMLProps<'rect', SVGAttributes>;
+    stop: HTMLProps<'stop', SVGAttributes>;
+    switch: HTMLProps<'switch', SVGAttributes>;
+    symbol: HTMLProps<'symbol', SVGAttributes>;
+    text: HTMLProps<'text', SVGAttributes>;
+    textPath: HTMLProps<'textPath', SVGAttributes>;
+    tspan: HTMLProps<'tspan', SVGAttributes>;
+    use: HTMLProps<'use', SVGAttributes>;
+    view: HTMLProps<'view', SVGAttributes>;
+
+    // Svelte specific
+    'svelte:window': HTMLProps<'svelte:window', HTMLAttributes>;
+    'svelte:body': HTMLProps<'svelte:body', HTMLAttributes>;
+    'svelte:fragment': { slot?: string };
+    'svelte:options': { [name: string]: any };
+    'svelte:head': { [name: string]: any };
+
+    [name: string]: { [name: string]: any };
+  }
+
+}

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -2,84 +2,7 @@
 // This way, we avoid the situation where multiple ambient versions of svelte2tsx
 // are loaded and their declarations conflict each other
 // See https://github.com/sveltejs/language-tools/issues/1059 for an example bug that stems from it
-// If you change anything in this file, think about whether or not it should also be added to svelte-shims-v4.d.ts
-
-// -- start svelte-ls-remove --
-declare module '*.svelte' {
-    type _SvelteComponent<Props=any,Events=any,Slots=any> = import("svelte").SvelteComponentTyped<Props,Events,Slots>;
-    export default _SvelteComponent
-}
-// -- end svelte-ls-remove --
-
-/**
- * @deprecated This will be removed soon. Use `SvelteComponentTyped` instead:
- * ```ts
- * import type { SvelteComponentTyped } from 'svelte';
- * ```
- */
-declare class Svelte2TsxComponent<
-    Props extends {} = {},
-    Events extends {} = {},
-    Slots extends {} = {}
-> {
-    // svelte2tsx-specific
-    /**
-     * @internal This is for type checking capabilities only
-     * and does not exist at runtime. Don't use this property.
-     */
-    $$prop_def: Props;
-    /**
-     * @internal This is for type checking capabilities only
-     * and does not exist at runtime. Don't use this property.
-     */
-    $$events_def: Events;
-    /**
-     * @internal This is for type checking capabilities only
-     * and does not exist at runtime. Don't use this property.
-     */
-    $$slot_def: Slots;
-    // https://svelte.dev/docs#Client-side_component_API
-    constructor(options: Svelte2TsxComponentConstructorParameters<Props>);
-    /**
-     * Causes the callback function to be called whenever the component dispatches an event.
-     * A function is returned that will remove the event listener when called.
-     */
-    $on<K extends keyof Events & string>(event: K, handler: ((e: Events[K]) => any) | null | undefined): () => void;
-    /**
-     * Removes a component from the DOM and triggers any `onDestroy` handlers.
-     */
-    $destroy(): void;
-    /**
-     * Programmatically sets props on an instance.
-     * `component.$set({ x: 1 })` is equivalent to `x = 1` inside the component's `<script>` block.
-     * Calling this method schedules an update for the next microtask — the DOM is __not__ updated synchronously.
-     */
-    $set(props?: Partial<Props>): void;
-    // From SvelteComponent(Dev) definition
-    $$: any;
-    $capture_state(): void;
-    $inject_state(): void;
-}
-
-/** @deprecated PRIVATE API, DO NOT USE, REMOVED SOON */
-interface Svelte2TsxComponentConstructorParameters<Props extends {}> {
-    /**
-     * An HTMLElement to render to. This option is required.
-     */
-    target: Element | Document | ShadowRoot;
-    /**
-     * A child of `target` to render the component immediately before.
-     */
-    anchor?: Element;
-    /**
-     * An object of properties to supply to the component.
-     */
-    props?: Props;
-    context?: Map<any, any>;
-    hydrate?: boolean;
-    intro?: boolean;
-    $$inline?: boolean;
-}
+// If you change anything in this file, think about whether or not it should be backported to svelte-shims.d.ts
 
 type AConstructorTypeOf<T, U extends any[] = any[]> = new (...args: U) => T;
 /** @internal PRIVATE API, DO NOT USE */
@@ -301,4 +224,4 @@ declare type ATypedSvelteComponent = {
 declare type ConstructorOfATypedSvelteComponent = new (args: {target: any, props?: any}) => ATypedSvelteComponent
 declare function __sveltets_2_ensureComponent<T extends ConstructorOfATypedSvelteComponent | null | undefined>(type: T): NonNullable<T>;
 
-declare function __sveltets_2_ensureArray<T extends ArrayLike<unknown>>(array: T): T extends ArrayLike<infer U> ? U[] : any[];
+declare function __sveltets_2_ensureArray<T extends ArrayLike<unknown> | Iterable<unknown>>(array: T): T extends ArrayLike<infer U> ? U[] : T extends Iterable<infer U> ? Iterable<U> : any[];

--- a/packages/svelte2tsx/test/emitDts/index.ts
+++ b/packages/svelte2tsx/test/emitDts/index.ts
@@ -16,7 +16,7 @@ async function testEmitDts(sample: string) {
             : {};
         await emitDts({
             declarationDir: 'package',
-            svelteShimsPath: require.resolve(join(process.cwd(), 'svelte-shims.d.ts')),
+            svelteShimsPath: require.resolve(join(process.cwd(), 'svelte-shims-v4.d.ts')),
             ...config,
             libRoot: config.libRoot ? join(cwd, config.libRoot) : join(cwd, 'src')
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         specifier: ^1.7.4
         version: 1.8.1
       svelte:
-        specifier: ^3.55.0
+        specifier: ^3.55.0 || ^4.0.0
         version: 3.57.0
       svelte-preprocess:
         specifier: ^5.0.3


### PR DESCRIPTION
- adjust peer deps where necessary
- breaking change: for Svelte 4, the deprecated svelte.JSX typings are removed by introducing a new -v4 version of shims/jsx where these are left out
- temporary: fix tests to not depend on svelte imports because they are esm only, and tests use cjs. in the long run replace the test runner with vitest

Tests will fail with Svelte 4 because some things are deprecated and that throws warnings etc, but that can happen once 4 is released. I checked it locally and none of these are blockers.
