### PR TITLE
Align templates with "zero effort typing"

### DIFF
--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-load.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-load.ts
@@ -1,28 +1,9 @@
 import { GenerateConfig } from '../types';
 
 export default async function (config: GenerateConfig) {
-    const ts = `
-import type { LayoutLoad } from './$types';
-
-export const load: LayoutLoad = async () => {
-    return {};
-};
-    `.trim();
-
-    const tsSatisfies = `
-import type { LayoutLoad } from './$types';
-
-export const load = (async () => {
-    return {};
-}) satisfies LayoutLoad;
-    `.trim();
-
-    const js = `
-/** @type {import('./$types').LayoutLoad} */
+    return `
 export async function load() {
     return {};
 }
     `.trim();
-
-    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-server.ts
@@ -1,28 +1,9 @@
 import { GenerateConfig } from '../types';
 
 export default async function (config: GenerateConfig) {
-    const ts = `
-import type { LayoutServerLoad } from './$types';
-
-export const load: LayoutServerLoad = async () => {
-    return {};
-};
-    `.trim();
-
-    const tsSatisfies = `
-import type { LayoutServerLoad } from './$types';
-
-export const load = (async () => {
-    return {};
-}) satisfies LayoutServerLoad;
-    `.trim();
-
-    const js = `
-/** @type {import('./$types').LayoutServerLoad} */
+    return `
 export async function load() {
     return {};
 }
     `.trim();
-
-    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-load.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-load.ts
@@ -1,24 +1,7 @@
 import { GenerateConfig } from '../types';
 
 export default async function (config: GenerateConfig) {
-    const ts = `
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async () => {
-    return {};
-};
-    `.trim();
-
-    const tsSatisfies = `
-import type { PageLoad } from './$types';
-
-export const load = (async () => {
-    return {};
-}) satisfies PageLoad;
-    `.trim();
-
-    const js = `
-/** @type {import('./$types').PageLoad} */
+    return `
 export async function load() {
     return {};
 };

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-server.ts
@@ -1,24 +1,7 @@
 import { GenerateConfig } from '../types';
 
 export default async function (config: GenerateConfig) {
-    const ts = `
-import type { PageServerLoad } from './$types';
-
-export const load: PageServerLoad = async () => {
-    return {};
-};
-    `.trim();
-
-    const tsSatisfies = `
-import type { PageServerLoad } from './$types';
-
-export const load = (async () => {
-    return {};
-}) satisfies PageServerLoad;
-    `.trim();
-
-    const js = `
-/** @type {import('./$types').PageServerLoad} */
+    return `
 export async function load() {
     return {};
 };

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/server.ts
@@ -1,16 +1,7 @@
 import { GenerateConfig } from '../types';
 
 export default async function generate(config: GenerateConfig) {
-    const ts = `
-import type { RequestHandler } from './$types';
-
-export const GET: RequestHandler = async () => {
-    return new Response();
-};
-    `.trim();
-
-    const js = `
-/** @type {import('./$types').RequestHandler} */
+    return `
 export async function GET() {
     return new Response();
 };


### PR DESCRIPTION
With the introduction of "zero effort typing" the generated templates from the Svelt Extension no longer need the types, this change reflects that by removing these types from them.