### PR TITLE
svelte-check: Add `vite.config.{js,ts}.timestamp-*` to watch ignore list

### DIFF
--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -114,7 +114,7 @@ class DiagnosticsWatcher {
         ignoreInitialAdd: boolean
     ) {
         watch(`${workspaceUri.fsPath}/**/*.{svelte,d.ts,ts,js,jsx,tsx,mjs,cjs,mts,cts}`, {
-            ignored: ['node_modules']
+            ignored: ['node_modules', 'vite.config.{js,ts}.timestamp-*']
                 .concat(filePathsToIgnore)
                 .map((ignore) => path.join(workspaceUri.fsPath, ignore)),
             ignoreInitial: ignoreInitialAdd


### PR DESCRIPTION
In one of my projects, the `svelte-check --watch` mode consistently crashes due to a race condition. Vite seems to create a lot of temporary files when they compile the `vite.config.ts`: https://github.com/vitejs/vite/issues/9470

The files all have names like:

```
vite.config.ts.timestamp-1686522030668-443d39ae8bf6c.mjs
vite.config.ts.timestamp-1686522030668-ecb1451ca3d3b.mjs
vite.config.ts.timestamp-1686522030661-21acd12c7aeed.mjs
vite.config.ts.timestamp-1686522030661-2cc7cb7c864ca.mjs
vite.config.ts.timestamp-1686522030663-9ac74f2f58a78.mjs
```

and they are added and removed from the file system with incredible speed. Because of this, svelte-check is getting the `add` event from chokidar, but before it can do anything, the file is already gone.

This is my error output:

```
node:fs:601
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, open '/Users/daniel/dev/node/example/vite.config.ts.timestamp-1686521049669-4898644e8deb4.mjs'
    at Object.openSync (node:fs:601:3)
    at Object.readFileSync (node:fs:469:35)
    at DiagnosticsWatcher.updateDocument (/Users/daniel/dev/node/example/node_modules/svelte-check/dist/src/index.js:103238:44)
    at FSWatcher.<anonymous> (/Users/daniel/dev/node/example/node_modules/svelte-check/dist/src/index.js:103230:39)
    at FSWatcher.emit (node:events:513:28)
    at FSWatcher.emitWithAll (/Users/daniel/dev/node/example/node_modules/chokidar/index.js:540:8)
    at FSWatcher._emit (/Users/daniel/dev/node/example/node_modules/chokidar/index.js:632:8)
    at FsEventsHandler.handleEvent (/Users/daniel/dev/node/example/node_modules/chokidar/lib/fsevents-handler.js:289:14)
    at FsEventsHandler.addOrChange (/Users/daniel/dev/node/example/node_modules/chokidar/lib/fsevents-handler.js:239:8)
    at FsEventsHandler.checkExists (/Users/daniel/dev/node/example/node_modules/chokidar/lib/fsevents-handler.js:247:12) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/Users/daniel/dev/node/example/vite.config.ts.timestamp-1686521049669-4898644e8deb4.mjs'
}
```

I'm not 100% sure under which circumstances this file is generated. I created a new repo as a reproduction, but it doesn't happen there, even though it's also using the `vite.config.ts`. I'm also surprised that nobody else has filed this as an issue before. My suggestion here definitely fixed it for me, but if you have another idea, I'm happy to try it out!