### PR TITLE
(fix) diagnostics throttle shouldn't cancel other files

### DIFF
--- a/packages/language-server/src/lib/DiagnosticsManager.ts
+++ b/packages/language-server/src/lib/DiagnosticsManager.ts
@@ -18,6 +18,7 @@ export class DiagnosticsManager {
         this.docManager.getAllOpenedByClient().forEach((doc) => {
             this.update(doc[1]);
         });
+        this.pendingUpdates.clear();
     }
 
     scheduleUpdateAll = debounceThrottle(() => this.updateAll(), 1000);

--- a/packages/language-server/src/lib/DiagnosticsManager.ts
+++ b/packages/language-server/src/lib/DiagnosticsManager.ts
@@ -1,5 +1,6 @@
 import { _Connection, TextDocumentIdentifier, Diagnostic } from 'vscode-languageserver';
 import { DocumentManager, Document } from './documents';
+import { debounceThrottle } from '../utils';
 
 export type SendDiagnostics = _Connection['sendDiagnostics'];
 export type GetDiagnostics = (doc: TextDocumentIdentifier) => Thenable<Diagnostic[]>;
@@ -11,13 +12,17 @@ export class DiagnosticsManager {
         private getDiagnostics: GetDiagnostics
     ) {}
 
-    updateAll() {
+    private pendingUpdates = new Set<Document>();
+
+    private updateAll() {
         this.docManager.getAllOpenedByClient().forEach((doc) => {
             this.update(doc[1]);
         });
     }
 
-    async update(document: Document) {
+    scheduleUpdateAll = debounceThrottle(() => this.updateAll(), 1000);
+
+    private async update(document: Document) {
         const diagnostics = await this.getDiagnostics({ uri: document.getURL() });
         this.sendDiagnostics({
             uri: document.getURL(),
@@ -26,9 +31,26 @@ export class DiagnosticsManager {
     }
 
     removeDiagnostics(document: Document) {
+        this.pendingUpdates.delete(document);
         this.sendDiagnostics({
             uri: document.getURL(),
             diagnostics: []
         });
     }
+
+    scheduleUpdate(document: Document) {
+        if (!this.docManager.isOpenedInClient(document.getURL())) {
+            return;
+        }
+
+        this.pendingUpdates.add(document);
+        this.scheduleBatchUpdate();
+    }
+
+    private scheduleBatchUpdate = debounceThrottle(() => {
+        this.pendingUpdates.forEach((doc) => {
+            this.update(doc);
+        });
+        this.pendingUpdates.clear();
+    }, 750);
 }

--- a/packages/language-server/src/lib/documents/DocumentManager.ts
+++ b/packages/language-server/src/lib/documents/DocumentManager.ts
@@ -68,6 +68,10 @@ export class DocumentManager {
         );
     }
 
+    isOpenedInClient(uri: string) {
+        return this.openedInClient.has(normalizeUri(uri));
+    }
+
     releaseDocument(uri: string): void {
         uri = normalizeUri(uri);
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -508,10 +508,7 @@ export function startServer(options?: LSOptions) {
         async (evt, token) => await pluginHost.getOutgoingCalls(evt.item, token)
     );
 
-    docManager.on(
-        'documentChange',
-        diagnosticsManager.scheduleUpdate.bind(diagnosticsManager)
-    );
+    docManager.on('documentChange', diagnosticsManager.scheduleUpdate.bind(diagnosticsManager));
     docManager.on('documentClose', (document: Document) =>
         diagnosticsManager.removeDiagnostics(document)
     );

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -162,28 +162,28 @@ export function debounceSameArg<T>(
  * the next invocation. This avoids needless calls when a synchronous call (like diagnostics)
  * took too long and the whole timeout of the next call was eaten up already.
  *
- * @param fn The function with it's argument
+ * @param fn The function
  * @param miliseconds Number of miliseconds to debounce/throttle
  */
-export function debounceThrottle<T extends (...args: any) => void>(fn: T, miliseconds: number): T {
+export function debounceThrottle(fn: () => void, miliseconds: number): () => void {
     let timeout: any;
     let lastInvocation = Date.now() - miliseconds;
 
-    function maybeCall(...args: any) {
+    function maybeCall() {
         clearTimeout(timeout);
 
         timeout = setTimeout(() => {
             if (Date.now() - lastInvocation < miliseconds) {
-                maybeCall(...args);
+                maybeCall();
                 return;
             }
 
-            fn(...args);
+            fn();
             lastInvocation = Date.now();
         }, miliseconds);
     }
 
-    return maybeCall as any;
+    return maybeCall;
 }
 
 /**


### PR DESCRIPTION
#2050 

Side note: we can switch to the diagnostics pull model later. If so, these changes might only be used in clients not supporting the pull model. 