### PR TITLE
(fix) insert tab when usesTabs and tabWidth is 2

### DIFF
--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -603,7 +603,8 @@ export class LSConfigManager {
             convertTabsToSpaces: !prettierConfig.useTabs,
             semicolons: useSemicolons
                 ? ts.SemicolonPreference.Insert
-                : ts.SemicolonPreference.Remove
+                : ts.SemicolonPreference.Remove,
+            tabSize: indentSize
         };
     }
 

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -934,6 +934,24 @@ describe('CompletionProviderImpl', () => {
         ]);
     });
 
+    it('indent according to prettier config', async () => {
+        const { completionProvider, document } = setup('useTabs/importcompletions1.svelte');
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            Position.create(1, 3)
+        );
+
+        const item = completions?.items.find((item) => item.label === 'blubb');
+
+        const { additionalTextEdits } = await completionProvider.resolveCompletion(document, item!);
+
+        assert.strictEqual(
+            harmonizeNewLines(additionalTextEdits![0]?.newText),
+            `${newLine}\timport { blubb } from "../../definitions";${newLine}`
+        );
+    });
+
     it('can be canceled before promise resolved', async () => {
         const { completionProvider, document } = setup('importcompletions1.svelte');
         const cancellationTokenSource = new CancellationTokenSource();

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/useTabs/.prettierrc
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/useTabs/.prettierrc
@@ -1,0 +1,4 @@
+{
+	"useTabs": true,
+	"tabWidth": 2
+}

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/useTabs/importcompletions1.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/useTabs/importcompletions1.svelte
@@ -1,0 +1,3 @@
+<script>
+blu
+</script>


### PR DESCRIPTION
The problem is we set `tabWidth` to 4 by default. And when merging prettier config, We only update `indentSize` but not `tabWidth`. So TypeScript would see an indent of 2 is smaller than the tab width and insert 2 spaces instead of one tab. 