### PR TITLE
Sync compiled code preview with open svelte file

### DIFF
--- a/packages/svelte-vscode/src/CompiledCodeContentProvider.ts
+++ b/packages/svelte-vscode/src/CompiledCodeContentProvider.ts
@@ -71,7 +71,7 @@ export default class CompiledCodeContentProvider implements TextDocumentContentP
     // we can trigger this using the didChangeEmitter
     async provideTextDocumentContent(): Promise<string | undefined> {
         // If there is no selected svelte file, try to get it from the activeTextEditor
-        // This should only happen when the svelte.showCompiledCodeToSide command is first called
+        // This should only happen when the svelte.showCompiledCodeToSide command is called the first time
         if (!this.selectedSvelteFile && window.activeTextEditor) {
             this.selectedSvelteFile = window.activeTextEditor.document.uri.toString();
         }

--- a/packages/svelte-vscode/src/CompiledCodeContentProvider.ts
+++ b/packages/svelte-vscode/src/CompiledCodeContentProvider.ts
@@ -87,10 +87,12 @@ export default class CompiledCodeContentProvider implements TextDocumentContentP
             this.selectedSvelteFile
         );
 
+        const path = this.selectedSvelteFile.replace('file://', '');
+
         if (response?.js?.code) {
-            return response.js.code;
+            return `/* Compiled: ${path} */\n${response.js.code}`;
         } else {
-            window.setStatusBarMessage(`Svelte: fail to compile ${this.selectedSvelteFile}`, 3000);
+            window.setStatusBarMessage(`Svelte: fail to compile ${path}`, 3000);
         }
     }
 

--- a/packages/svelte-vscode/src/CompiledCodeContentProvider.ts
+++ b/packages/svelte-vscode/src/CompiledCodeContentProvider.ts
@@ -1,4 +1,5 @@
 import { LanguageClient } from 'vscode-languageclient/node';
+import { debounce } from 'lodash';
 import {
     Uri,
     TextDocumentContentProvider,
@@ -7,91 +8,89 @@ import {
     window,
     Disposable
 } from 'vscode';
-import { atob, btoa } from './utils';
-import { debounce } from 'lodash';
 
-type CompiledCodeResp = {
+type CompiledCodeResponse = {
     js: { code: string; map: any };
     css: { code: string; map: any };
 };
 
-const SVELTE_URI_SCHEME = 'svelte-compiled';
-
-function toSvelteSchemeUri<B extends boolean = false>(
-    srcUri: string | Uri,
-    asString?: B
-): B extends true ? string : Uri {
-    srcUri = typeof srcUri == 'string' ? Uri.parse(srcUri) : srcUri;
-    const src = btoa(srcUri.toString());
-    const destUri = srcUri.with({
-        scheme: SVELTE_URI_SCHEME,
-        fragment: src,
-        path: srcUri.path + '.js'
-    });
-    return (asString ? destUri.toString() : destUri) as any;
-}
-
-function fromSvelteSchemeUri<B extends boolean = false>(
-    destUri: string | Uri,
-    asString?: B
-): B extends true ? string : Uri {
-    destUri = typeof destUri == 'string' ? Uri.parse(destUri) : destUri;
-    const src = atob(destUri.fragment);
-    return (asString ? src : Uri.parse(src)) as any;
-}
-
+// ContentProvider for "svelte-compiled://" files
 export default class CompiledCodeContentProvider implements TextDocumentContentProvider {
-    static scheme = SVELTE_URI_SCHEME;
-    static toSvelteSchemeUri = toSvelteSchemeUri;
-    static fromSvelteSchemeUri = fromSvelteSchemeUri;
+    static previewWindowUri = Uri.parse('svelte-compiled:///preview.js');
+    static scheme = 'svelte-compiled';
 
-    private disposed = false;
     private didChangeEmitter = new EventEmitter<Uri>();
+    private selectedSvelteFile: string | undefined;
     private subscriptions: Disposable[] = [];
-    private watchedSourceUri = new Set<string>();
+    private disposed = false;
 
     get onDidChange() {
         return this.didChangeEmitter.event;
     }
 
+    // This function triggers a refresh of the preview window's content
+    // by emitting an event to the didChangeEmitter. VSCode listens to
+    // this.onDidChange and will call provideTextDocumentContent
+    private refresh() {
+        this.didChangeEmitter.fire(CompiledCodeContentProvider.previewWindowUri);
+    }
+
     constructor(private getLanguageClient: () => LanguageClient) {
         this.subscriptions.push(
+            // This event triggers a refresh of the preview window's content
+            // whenever the selected svelte file's content changes
+            // (debounced to prevent too many recompilations)
             workspace.onDidChangeTextDocument(
-                debounce(async (changeEvent) => {
-                    if (changeEvent.document.languageId !== 'svelte') {
-                        return;
-                    }
-
-                    const srcUri = changeEvent.document.uri.toString();
-                    if (this.watchedSourceUri.has(srcUri)) {
-                        this.didChangeEmitter.fire(toSvelteSchemeUri(srcUri));
+                debounce(async (event) => {
+                    if (event.document.languageId == 'svelte' && this.selectedSvelteFile) {
+                        this.refresh();
                     }
                 }, 500)
             )
         );
 
-        window.onDidChangeVisibleTextEditors((editors) => {
-            const previewEditors = editors.filter(
-                (editor) => editor?.document?.uri?.scheme === SVELTE_URI_SCHEME
-            );
-            this.watchedSourceUri = new Set(
-                previewEditors.map((editor) => fromSvelteSchemeUri(editor.document.uri, true))
-            );
-        });
+        this.subscriptions.push(
+            // This event sets the selectedSvelteFile when there is a different svelte file selected
+            // and triggers a refresh of the preview window's content
+            window.onDidChangeActiveTextEditor((editor) => {
+                if (editor?.document?.languageId !== 'svelte') {
+                    return;
+                }
+
+                const newFile = editor.document.uri.toString();
+
+                if (newFile !== this.selectedSvelteFile) {
+                    this.selectedSvelteFile = newFile;
+                    this.refresh();
+                }
+            })
+        );
     }
 
-    async provideTextDocumentContent(uri: Uri): Promise<string | undefined> {
-        const srcUriStr = fromSvelteSchemeUri(uri, true);
-        this.watchedSourceUri.add(srcUriStr);
+    // This is called when VSCode needs to get the content of the preview window
+    // we can trigger this using the didChangeEmitter
+    async provideTextDocumentContent(): Promise<string | undefined> {
+        // If there is no selected svelte file, try to get it from the activeTextEditor
+        // This should only happen when the svelte.showCompiledCodeToSide command is first called
+        if (!this.selectedSvelteFile && window.activeTextEditor) {
+            this.selectedSvelteFile = window.activeTextEditor.document.uri.toString();
+        }
 
-        const resp = await this.getLanguageClient().sendRequest<CompiledCodeResp>(
+        // Should not be possible but handle it anyway
+        if (!this.selectedSvelteFile) {
+            window.setStatusBarMessage('Svelte: no svelte file selected');
+            return;
+        }
+
+        const response = await this.getLanguageClient().sendRequest<CompiledCodeResponse>(
             '$/getCompiledCode',
-            srcUriStr
+            this.selectedSvelteFile
         );
-        if (resp?.js?.code) {
-            return resp.js.code;
+
+        if (response?.js?.code) {
+            return response.js.code;
         } else {
-            window.setStatusBarMessage(`Svelte: fail to compile ${uri.path}`, 3000);
+            window.setStatusBarMessage(`Svelte: fail to compile ${this.selectedSvelteFile}`, 3000);
         }
     }
 
@@ -100,7 +99,6 @@ export default class CompiledCodeContentProvider implements TextDocumentContentP
             return;
         }
 
-        this.didChangeEmitter.dispose();
         this.subscriptions.forEach((d) => d.dispose());
         this.subscriptions.length = 0;
         this.disposed = true;

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -418,6 +418,7 @@ function addCompilePreviewCommand(getLS: () => LanguageClient, context: Extensio
     const compiledCodeContentProvider = new CompiledCodeContentProvider(getLS);
 
     context.subscriptions.push(
+        // Register the content provider for "svelte-compiled://" files
         workspace.registerTextDocumentContentProvider(
             CompiledCodeContentProvider.scheme,
             compiledCodeContentProvider
@@ -431,15 +432,17 @@ function addCompilePreviewCommand(getLS: () => LanguageClient, context: Extensio
                 return;
             }
 
-            const uri = editor.document.uri;
-            const svelteUri = CompiledCodeContentProvider.toSvelteSchemeUri(uri);
             window.withProgress(
-                { location: ProgressLocation.Window, title: 'Compiling..' },
+                { location: ProgressLocation.Window, title: 'Compiling...' },
                 async () => {
-                    return await window.showTextDocument(svelteUri, {
-                        preview: true,
-                        viewColumn: ViewColumn.Beside
-                    });
+                    // Open a new preview window for the compiled code
+                    return await window.showTextDocument(
+                        CompiledCodeContentProvider.previewWindowUri,
+                        {
+                            preview: true,
+                            viewColumn: ViewColumn.Beside
+                        }
+                    );
                 }
             );
         })


### PR DESCRIPTION
Closes #831

I had to change how the preview window worked, previously it created a window for the current svelte file with the uri `svelte-compiled://FILE_PATH` (where FILE_PATH is the file path). Now whenever the command is run it creates an editor with the uri `svelte-compiled://preview.js`. I added comments to the code so it's easier to understand, since the file hasn't been touched in three years.

The only downside to the uri change is that the file path isn't in the editor label anymore. Unfortunately unless it's a webview you can't change the editor label so I added code (4bff895e6fb796b60bb15bfea0e9d87ac557fa4f) to make a comment in the compiled output to indicate what file is actually being compiled. I've based it's behaviour on the Markdown Preview window as much as possible, within the limitations of an editor.