### PR TITLE
(chore) warmup ts service before running test

### DIFF
--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -16,8 +16,13 @@ import { INITIAL_VERSION } from '../../../src/plugins/typescript/DocumentSnapsho
 import { __resetCache } from '../../../src/plugins/typescript/service';
 import { ignoredBuildDirectories } from '../../../src/plugins/typescript/SnapshotManager';
 import { pathToUrl } from '../../../src/utils';
+import { serviceWarmup } from './test-utils';
 
-describe('TypescriptPlugin', () => {
+const testDir = path.join(__dirname, 'testfiles');
+
+describe('TypescriptPlugin', function () {
+    serviceWarmup(this, testDir);
+
     function getUri(filename: string) {
         const filePath = path.join(__dirname, 'testfiles', filename);
         return pathToUrl(filePath);
@@ -33,7 +38,6 @@ describe('TypescriptPlugin', () => {
                 ? new Document(args.uri, harmonizeNewLines(args.text))
                 : document
         );
-        const testDir = path.join(__dirname, 'testfiles');
         const filePath = path.join(testDir, filename);
         const document = new Document(pathToUrl(filePath), ts.sys.readFile(filePath) || '');
         const lsConfigManager = new LSConfigManager();

--- a/packages/language-server/test/plugins/typescript/features/CallHierarchyProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CallHierarchyProvider.test.ts
@@ -13,11 +13,13 @@ import { CallHierarchyProviderImpl } from '../../../../src/plugins/typescript/fe
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { __resetCache } from '../../../../src/plugins/typescript/service';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
 
-describe('CallHierarchyProvider', () => {
+describe('CallHierarchyProvider', function () {
     const callHierarchyTestDirRelative = path.join('testfiles', 'call-hierarchy');
+    serviceWarmup(this, path.join(testDir, callHierarchyTestDirRelative), pathToUrl(testDir));
 
     function getFullPath(filename: string) {
         return path.join(testDir, 'testfiles', 'call-hierarchy', filename);

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -19,11 +19,18 @@ import { CompletionsProviderImpl } from '../../../../src/plugins/typescript/feat
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { __resetCache } from '../../../../src/plugins/typescript/service';
 import { pathToUrl } from '../../../../src/utils';
+import { recursiveServiceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
 const indent = ' '.repeat(4);
 
-describe('CodeActionsProvider', () => {
+describe('CodeActionsProvider', function () {
+    recursiveServiceWarmup(
+        this,
+        path.join(testDir, 'testfiles', 'code-actions'),
+        pathToUrl(testDir)
+    );
+
     function getFullPath(filename: string) {
         return path.join(testDir, 'testfiles', 'code-actions', filename);
     }

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -23,7 +23,7 @@ import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDo
 import { sortBy } from 'lodash';
 import { LSConfigManager } from '../../../../src/ls-config';
 import { __resetCache } from '../../../../src/plugins/typescript/service';
-import { getRandomVirtualDirPath, setupVirtualEnvironment } from '../test-utils';
+import { getRandomVirtualDirPath, serviceWarmup, setupVirtualEnvironment } from '../test-utils';
 
 const testDir = join(__dirname, '..');
 const testFilesDir = join(testDir, 'testfiles', 'completions');
@@ -39,7 +39,9 @@ function harmonizeNewLines(input?: string) {
 }
 
 // describe('CompletionProviderImpl (old transformation)', test(false));
-describe('CompletionProviderImpl', () => {
+describe('CompletionProviderImpl', function () {
+    serviceWarmup(this, testFilesDir, pathToUrl(testDir));
+
     function setup(filename: string) {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text)

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -8,10 +8,13 @@ import { DiagnosticsProviderImpl } from '../../../../src/plugins/typescript/feat
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { __resetCache } from '../../../../src/plugins/typescript/service';
 import { normalizePath, pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..', 'testfiles', 'diagnostics');
 
-describe('DiagnosticsProvider', () => {
+describe('DiagnosticsProvider', function () {
+    serviceWarmup(this, testDir);
+
     function setup(filename: string) {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text)

--- a/packages/language-server/test/plugins/typescript/features/FindComponentReferencesProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/FindComponentReferencesProvider.test.ts
@@ -6,10 +6,13 @@ import { LSConfigManager } from '../../../../src/ls-config';
 import { FindComponentReferencesProviderImpl } from '../../../../src/plugins/typescript/features/FindComponentReferencesProvider';
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
 
-describe('FindComponentReferencesProvider', () => {
+describe('FindComponentReferencesProvider', function () {
+    serviceWarmup(this, testDir);
+
     function getFullPath(filename: string) {
         return path.join(testDir, 'testfiles', filename);
     }
@@ -24,7 +27,11 @@ describe('FindComponentReferencesProvider', () => {
         );
         const lsConfigManager = new LSConfigManager();
 
-        const lsAndTsDocResolver = new LSAndTSDocResolver(docManager, [testDir], lsConfigManager);
+        const lsAndTsDocResolver = new LSAndTSDocResolver(
+            docManager,
+            [pathToUrl(testDir)],
+            lsConfigManager
+        );
         const provider = new FindComponentReferencesProviderImpl(lsAndTsDocResolver);
         const document = openDoc(filename);
         return { provider, document, openDoc, lsConfigManager };

--- a/packages/language-server/test/plugins/typescript/features/FindFileReferencesProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/FindFileReferencesProvider.test.ts
@@ -7,10 +7,13 @@ import { LSConfigManager } from '../../../../src/ls-config';
 import { FindFileReferencesProviderImpl } from '../../../../src/plugins/typescript/features/FindFileReferencesProvider';
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
 
-describe('FindFileReferencesProvider', () => {
+describe('FindFileReferencesProvider', function () {
+    serviceWarmup(this, testDir);
+
     function getFullPath(filename: string) {
         return path.join(testDir, 'testfiles', filename);
     }
@@ -24,7 +27,11 @@ describe('FindFileReferencesProvider', () => {
             (textDocument) => new Document(textDocument.uri, textDocument.text)
         );
         const lsConfigManager = new LSConfigManager();
-        const lsAndTsDocResolver = new LSAndTSDocResolver(docManager, [testDir], lsConfigManager);
+        const lsAndTsDocResolver = new LSAndTSDocResolver(
+            docManager,
+            [pathToUrl(testDir)],
+            lsConfigManager
+        );
         const provider = new FindFileReferencesProviderImpl(lsAndTsDocResolver);
         const document = openDoc(filename);
         return { provider, document, openDoc };
@@ -39,7 +46,7 @@ describe('FindFileReferencesProvider', () => {
         }
     }
 
-    it('finds file references', async () => {
+    it('finds file references', async function () {
         const { provider, document, openDoc } = setup('find-file-references-child.svelte');
         //Make known all the associated files
         openDoc('find-file-references-parent.svelte');

--- a/packages/language-server/test/plugins/typescript/features/FindReferencesProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/FindReferencesProvider.test.ts
@@ -8,10 +8,13 @@ import { FindReferencesProviderImpl } from '../../../../src/plugins/typescript/f
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { __resetCache } from '../../../../src/plugins/typescript/service';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
 
-describe('FindReferencesProvider', () => {
+describe('FindReferencesProvider', function () {
+    serviceWarmup(this, testDir);
+
     function getFullPath(filename: string) {
         return path.join(testDir, 'testfiles', filename);
     }

--- a/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/HoverProvider.test.ts
@@ -8,12 +8,16 @@ import { HoverProviderImpl } from '../../../../src/plugins/typescript/features/H
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { __resetCache } from '../../../../src/plugins/typescript/service';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
+const hoverTestDir = path.join(testDir, 'testfiles', 'hover');
 
-describe('HoverProvider', () => {
+describe('HoverProvider', function () {
+    serviceWarmup(this, hoverTestDir, pathToUrl(testDir));
+
     function getFullPath(filename: string) {
-        return path.join(testDir, 'testfiles', 'hover', filename);
+        return path.join(hoverTestDir, filename);
     }
 
     function setup(filename: string) {

--- a/packages/language-server/test/plugins/typescript/features/ImplemenationProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/ImplemenationProvider.test.ts
@@ -7,10 +7,14 @@ import { LSAndTSDocResolver } from '../../../../src/plugins';
 import { ImplementationProviderImpl } from '../../../../src/plugins/typescript/features/ImplementationProvider';
 import { pathToUrl } from '../../../../src/utils';
 import { Location } from 'vscode-languageserver-protocol';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
+const implementationTestDir = path.join(testDir, 'testfiles', 'implementation');
 
-describe('ImplementationProvider', () => {
+describe('ImplementationProvider', function () {
+    serviceWarmup(this, implementationTestDir, pathToUrl(testDir));
+
     function getFullPath(filename: string) {
         return path.join(testDir, 'testfiles', 'implementation', filename);
     }

--- a/packages/language-server/test/plugins/typescript/features/RenameProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/RenameProvider.test.ts
@@ -8,12 +8,16 @@ import { RenameProviderImpl } from '../../../../src/plugins/typescript/features/
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { __resetCache } from '../../../../src/plugins/typescript/service';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
+const renameTestDir = path.join(testDir, 'testfiles', 'rename');
 
-describe('RenameProvider', () => {
+describe('RenameProvider', function () {
+    serviceWarmup(this, renameTestDir, pathToUrl(testDir));
+
     function getFullPath(filename: string) {
-        return path.join(testDir, 'testfiles', 'rename', filename);
+        return path.join(renameTestDir, filename);
     }
 
     function getUri(filename: string) {

--- a/packages/language-server/test/plugins/typescript/features/SelectionRangeProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/SelectionRangeProvider.test.ts
@@ -7,10 +7,14 @@ import { SelectionRangeProviderImpl } from '../../../../src/plugins/typescript/f
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { pathToUrl } from '../../../../src/utils';
 import { LSConfigManager } from '../../../../src/ls-config';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
+const selectionRangeTestDir = path.join(testDir, 'testfiles', 'selection-range');
 
-describe('SelectionRangeProvider', () => {
+describe('SelectionRangeProvider', function () {
+    serviceWarmup(this, selectionRangeTestDir, pathToUrl(testDir));
+
     function setup() {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text)

--- a/packages/language-server/test/plugins/typescript/features/SemanticTokensProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/SemanticTokensProvider.test.ts
@@ -13,17 +13,20 @@ import { LSConfigManager } from '../../../../src/ls-config';
 import { SemanticTokensProviderImpl } from '../../../../src/plugins/typescript/features/SemanticTokensProvider';
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
+const semanticTokenTestDir = path.join(testDir, 'testfiles', 'semantic-tokens');
 
-describe('SemanticTokensProvider', () => {
+describe('SemanticTokensProvider', function () {
     const tsFile = 'tokens.svelte';
+    serviceWarmup(this, semanticTokenTestDir, pathToUrl(testDir));
 
     function setup(filename: string) {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text)
         );
-        const filePath = path.join(testDir, 'testfiles', 'semantic-tokens', filename);
+        const filePath = path.join(semanticTokenTestDir, filename);
         const lsAndTsDocResolver = new LSAndTSDocResolver(
             docManager,
             [pathToUrl(testDir)],
@@ -38,7 +41,7 @@ describe('SemanticTokensProvider', () => {
     }
 
     // TODO reenable with updated tokens for new transformation
-    it.skip('provides semantic token', async () => {
+    it('provides semantic token', async () => {
         const { provider, document } = setup(tsFile);
 
         const { data } = (await provider.getSemanticTokens(document)) ?? {
@@ -184,8 +187,15 @@ describe('SemanticTokensProvider', () => {
                 line: 11,
                 character: 25,
                 length: 'text'.length,
-                type: TokenType.parameter,
-                modifiers: [TokenModifier.declaration]
+                type: TokenType.variable,
+                modifiers: [TokenModifier.declaration, TokenModifier.local, TokenModifier.readonly]
+            },
+            {
+                line: 12,
+                character: 5,
+                length: 'Imported'.length,
+                type: TokenType.class,
+                modifiers: []
             },
             {
                 line: 12,
@@ -198,8 +208,8 @@ describe('SemanticTokensProvider', () => {
                 line: 12,
                 character: 43,
                 length: 'text'.length,
-                type: TokenType.parameter,
-                modifiers: []
+                type: TokenType.variable,
+                modifiers: [TokenModifier.local, TokenModifier.readonly]
             },
             {
                 line: 12,
@@ -212,15 +222,15 @@ describe('SemanticTokensProvider', () => {
                 line: 14,
                 character: 16,
                 length: 1,
-                type: TokenType.parameter,
-                modifiers: [TokenModifier.declaration]
+                type: TokenType.variable,
+                modifiers: [TokenModifier.declaration, TokenModifier.local]
             },
             {
                 line: 15,
                 character: 5,
                 length: 1,
-                type: TokenType.parameter,
-                modifiers: []
+                type: TokenType.variable,
+                modifiers: [TokenModifier.local]
             }
         ];
 

--- a/packages/language-server/test/plugins/typescript/features/SignatureHelpProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/SignatureHelpProvider.test.ts
@@ -12,15 +12,19 @@ import { SignatureHelpProviderImpl } from '../../../../src/plugins/typescript/fe
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { pathToUrl } from '../../../../src/utils';
 import { LSConfigManager } from '../../../../src/ls-config';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
+const signatureHelpTestDir = path.join(testDir, 'testfiles', 'signature-help');
 
-describe('SignatureHelpProvider', () => {
+describe('SignatureHelpProvider', function () {
+    serviceWarmup(this, signatureHelpTestDir, pathToUrl(testDir));
+
     function setup() {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text)
         );
-        const filePath = path.join(testDir, 'testfiles', 'signature-help', 'signature-help.svelte');
+        const filePath = path.join(signatureHelpTestDir, 'signature-help.svelte');
         const lsAndTsDocResolver = new LSAndTSDocResolver(
             docManager,
             [pathToUrl(testDir)],

--- a/packages/language-server/test/plugins/typescript/features/TypeDefinitionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/TypeDefinitionProvider.test.ts
@@ -7,12 +7,16 @@ import { LSConfigManager } from '../../../../src/ls-config';
 import { LSAndTSDocResolver } from '../../../../src/plugins';
 import { TypeDefinitionProviderImpl } from '../../../../src/plugins/typescript/features/TypeDefinitionProvider';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = path.join(__dirname, '..');
+const typeDefinitionTestDir = path.join(testDir, 'testfiles', 'typedefinition');
 
-describe('TypeDefinitionProvider', () => {
+describe('TypeDefinitionProvider', function () {
+    serviceWarmup(this, typeDefinitionTestDir, pathToUrl(testDir));
+
     function getFullPath(filename: string) {
-        return path.join(testDir, 'testfiles', 'typedefinition', filename);
+        return path.join(typeDefinitionTestDir, filename);
     }
 
     function getUri(filename: string) {

--- a/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
@@ -14,11 +14,14 @@ import { LSConfigManager } from '../../../../src/ls-config';
 import { UpdateImportsProviderImpl } from '../../../../src/plugins/typescript/features/UpdateImportsProvider';
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testDir = join(__dirname, '..');
-const testFilesDir = join(testDir, 'testfiles', 'update-imports');
+const updateImportTestDir = join(testDir, 'testfiles', 'update-imports');
 
-describe('UpdateImportsProviderImpl', () => {
+describe('UpdateImportsProviderImpl', function () {
+    serviceWarmup(this, updateImportTestDir, pathToUrl(testDir));
+
     async function setup(filename: string, useCaseSensitiveFileNames: boolean) {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text),
@@ -31,7 +34,7 @@ describe('UpdateImportsProviderImpl', () => {
             { tsSystem: { ...ts.sys, useCaseSensitiveFileNames } }
         );
         const updateImportsProvider = new UpdateImportsProviderImpl(lsAndTsDocResolver);
-        const filePath = join(testFilesDir, filename);
+        const filePath = join(updateImportTestDir, filename);
         const fileUri = pathToUrl(filePath);
         const document = docManager.openDocument(<any>{
             uri: fileUri,
@@ -50,8 +53,8 @@ describe('UpdateImportsProviderImpl', () => {
         );
 
         const workspaceEdit = await updateImportsProvider.updateImports({
-            oldUri: pathToUrl(join(testFilesDir, 'imported.svelte')),
-            newUri: pathToUrl(join(testFilesDir, 'documentation.svelte'))
+            oldUri: pathToUrl(join(updateImportTestDir, 'imported.svelte')),
+            newUri: pathToUrl(join(updateImportTestDir, 'documentation.svelte'))
         });
 
         assert.deepStrictEqual(workspaceEdit?.documentChanges, [
@@ -71,8 +74,8 @@ describe('UpdateImportsProviderImpl', () => {
         );
 
         const workspaceEdit = await updateImportsProvider.updateImports({
-            oldUri: pathToUrl(join(testFilesDir, 'imported.svelte')),
-            newUri: pathToUrl(join(testFilesDir, 'Imported.svelte'))
+            oldUri: pathToUrl(join(updateImportTestDir, 'imported.svelte')),
+            newUri: pathToUrl(join(updateImportTestDir, 'Imported.svelte'))
         });
 
         assert.deepStrictEqual(workspaceEdit?.documentChanges, [

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/index.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/index.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 import ts from 'typescript';
 import { Document, DocumentManager } from '../../../../../src/lib/documents';
@@ -73,11 +73,13 @@ async function executeTest(
 
 const executeTests = createSnapshotTester(executeTest);
 
-describe('DiagnosticsProvider', () => {
+describe('DiagnosticsProvider', function () {
     executeTests({
         dir: join(__dirname, 'fixtures'),
-        workspaceDir: join(__dirname, 'fixtures')
+        workspaceDir: join(__dirname, 'fixtures'),
+        context: this
     });
+
     // Hacky, but it works. Needed due to testing both new and old transformation
     after(() => {
         __resetCache();

--- a/packages/language-server/test/plugins/typescript/features/getDirectiveCommentCompletions.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/getDirectiveCommentCompletions.test.ts
@@ -5,19 +5,19 @@ import { Document } from '../../../../src/lib/documents';
 import { pathToUrl } from '../../../../src/utils';
 import { Position, CompletionContext, CompletionTriggerKind } from 'vscode-languageserver';
 import { getDirectiveCommentCompletions } from '../../../../src/plugins/typescript/features/getDirectiveCommentCompletions';
+import { serviceWarmup } from '../test-utils';
 
-describe('can get typescript directive comment completions', () => {
+const testDir = path.join(__dirname, '..');
+const completionTestDir = path.join(testDir, 'testfiles', 'completions');
+
+describe('can get typescript directive comment completions', function () {
+    serviceWarmup(this, completionTestDir, pathToUrl(testDir));
+
     function setup(
         position: Position,
         context: CompletionContext = { triggerKind: CompletionTriggerKind.Invoked }
     ) {
-        const testDir = path.join(__dirname, '..');
-        const filePath = path.join(
-            testDir,
-            'testfiles',
-            'completions',
-            'ts-directive-comment.svelte'
-        );
+        const filePath = path.join(completionTestDir, 'ts-directive-comment.svelte');
         const document = new Document(pathToUrl(filePath), ts.sys.readFile(filePath)!);
         const result = getDirectiveCommentCompletions(position, document, context);
 

--- a/packages/language-server/test/plugins/typescript/features/inlayHints/index.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/index.test.ts
@@ -122,9 +122,10 @@ async function executeTest(
 
 const executeTests = createSnapshotTester(executeTest);
 
-describe('InlayHintProvider', () => {
+describe('InlayHintProvider', function () {
     executeTests({
         dir: join(__dirname, 'fixtures'),
-        workspaceDir: join(__dirname, 'fixtures')
+        workspaceDir: join(__dirname, 'fixtures'),
+        context: this
     });
 });

--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -15,10 +15,13 @@ import { CodeActionsProviderImpl } from '../../../../src/plugins/typescript/feat
 import { CompletionsProviderImpl } from '../../../../src/plugins/typescript/features/CompletionProvider';
 import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDocResolver';
 import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
 
 const testFilesDir = join(__dirname, '..', 'testfiles', 'preferences');
 
-describe('ts user preferences', () => {
+describe('ts user preferences', function () {
+    serviceWarmup(this, testFilesDir);
+
     function setup(filename: string) {
         const docManager = new DocumentManager(
             (textDocument) => new Document(textDocument.uri, textDocument.text)

--- a/packages/language-server/test/plugins/typescript/test-utils.ts
+++ b/packages/language-server/test/plugins/typescript/test-utils.ts
@@ -164,7 +164,6 @@ export function createSnapshotTester<
     TestOptions extends {
         dir: string;
         workspaceDir: string;
-        timeout?: number;
         context: Mocha.Suite;
     }
 >(executeTest: (inputFile: string, testOptions: TestOptions) => Promise<void>) {
@@ -187,13 +186,9 @@ export function createSnapshotTester<
 
         if (existsSync(inputFile)) {
             const _it = dir.endsWith('.only') ? it.only : it;
-            const test = _it(dir.substring(__dirname.length), () =>
+            _it(dir.substring(__dirname.length), () =>
                 executeTest(inputFile, testOptions)
             );
-
-            if (testOptions.timeout) {
-                test.timeout(testOptions.timeout);
-            }
         } else {
             const _describe = dir.endsWith('.only') ? describe.only : describe;
             _describe(dir.substring(__dirname.length), function () {
@@ -259,11 +254,10 @@ export async function createJsonSnapshotFormatter(dir: string) {
         });
 }
 
-const warmupTimeout = process.env.WARMUP_TIMEOUT ? parseInt(process.env.WARMUP_TIMEOUT) : 5_000;
 export function serviceWarmup(suite: Mocha.Suite, testDir: string, rootUri = pathToUrl(testDir)) {
     const defaultTimeout = suite.timeout();
 
-    suite.timeout(warmupTimeout);
+    suite.timeout(5_000);
     before(async () => {
         const start = Date.now();
         console.log('Warming up language service...');


### PR DESCRIPTION
#2007

Our typescript-related tests usually time out because the typescript's internal building takes too long. This makes the test frequently fail in less performant machines and in `test.only` during development. This PR moves the internal building to the `before` hook with a 5000ms timeout. After moving the building out, most of the tests should be able to finish within 1s. So I also dropped the snapshot test timeout back to default. If we want to test potential performance degradation, we could also drop the timeout to 1500ms or even 1000ms in CI.