### PR TITLE
fix: supress inlay hint for each block's index variable

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/each/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/each/expectedv2.json
@@ -1,0 +1,11 @@
+[
+  {
+    "kind": 1,
+    "label": ": number[]",
+    "paddingLeft": true,
+    "position": {
+      "character": 11,
+      "line": 1
+    }
+  }
+]

--- a/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/each/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/each/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  let items = [1]
+</script>
+
+{#each items as item, i}
+  {item}
+{/each}

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/EachBlock.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/EachBlock.ts
@@ -9,7 +9,7 @@ import { transform, TransformationArray } from '../utils/node-utils';
  * - If code is
  *   `{#each items as items,i (key)}`
  *   then the transformation is
- *   `{ const $$_each = __sveltets_2_ensureArray(items); for (const items of $$_each) { let i = 0;key;`.
+ *   `{ const $$_each = __sveltets_2_ensureArray(items); for (const items of $$_each) { let i: number = 0;key;`.
  *   Transform it this way because `{#each items as items}` is valid Svelte code, but the transformation
  *   `for(const items of items){..}` is invalid ("variable used before declaration"). Don't do the transformation
  *   like this everytime because `$$_each` could turn up in the auto completion.
@@ -50,7 +50,8 @@ export function handleEach(str: MagicString, eachBlock: BaseNode): void {
     if (eachBlock.index) {
         const indexStart = str.original.indexOf(eachBlock.index, eachBlock.context.end);
         const indexEnd = indexStart + eachBlock.index.length;
-        transforms.push('let ', [indexStart, indexEnd], ' = 1;');
+        // supress `: number` inlay hint as its position is not calculated correctly
+        transforms.push('let ', [indexStart, indexEnd], ': number = 1;');
     }
     if (eachBlock.key) {
         transforms.push([eachBlock.key.start, eachBlock.key.end], ';');


### PR DESCRIPTION
#1988 

Inlay hints for each block's index variable appears at a wrong position, 1 character before the proper position.
```
{#each items as item, inde[: number]x}
```

This PR suppresses the inlay hint by explicitly writing type annotation for the index variable.

<br />

### Side note

I initially attempted to fix the positioning code, but gave up as fixing that part proved to be too complex. Below is my investigation into the cause.

The problem code is in the `transform` function in `packages/svelte2tsx/src/htmlxtojsx_v2/utils/node-utils.ts`. 
https://github.com/sveltejs/language-tools/blob/0f2396e1a567040f5a33a27d6ddd98712a81f0b9/packages/svelte2tsx/src/htmlxtojsx_v2/utils/node-utils.ts#L57-L76

If a range (given in format [number, number]) `tEnd === end - 1`, the following line isn't run: `str.overwrite(tEnd - 1, tEnd, overwrite, { contentOnly: true });`

So the string `= 1;` inserted afterward is mapped to the last character of `index` variable, instead of the character right after. In generated code, inlay hint is positioned at the character right after `index`, which is mapped to `x`.

`tEnd < end - 1` exists because `str.move(tStart, end, end)` is not valid. So to fix it, we'd have to overhaul the entire transform logic, which moves everything to the end.