### PR TITLE
fix: remove duplicate attribute value suggestion

### DIFF
--- a/packages/language-server/src/plugins/html/dataProvider.ts
+++ b/packages/language-server/src/plugins/html/dataProvider.ts
@@ -1,8 +1,9 @@
 import { IAttributeData, ITagData, newHTMLDataProvider } from 'vscode-html-languageservice';
 import { htmlData } from 'vscode-html-languageservice/lib/umd/languageFacts/data/webCustomData';
+import { unique } from '../../utils';
 
 const svelteEvents = [
-    ...htmlData.globalAttributes!.map(mapToSvelteEvent),
+    ...(htmlData.globalAttributes?.filter(isEvent).map(mapToSvelteEvent) ?? []),
     {
         name: 'on:introstart',
         description: 'Available when element has transition'
@@ -409,8 +410,18 @@ export const svelteHtmlDataProvider = newHTMLDataProvider('svelte-builtin', {
         ...sveltekitAttributes
     ],
     tags: [...html5Tags, ...svelteTags],
-    valueSets: htmlData.valueSets
+
+    // TODO remove this after it's fixed in the html language service
+    valueSets:
+        htmlData.valueSets?.map((set) => ({
+            name: set.name,
+            values: unique(set.values)
+        })) ?? []
 });
+
+function isEvent(attr: IAttributeData) {
+    return attr.name.startsWith('on');
+}
 
 function mapToSvelteEvent(attr: IAttributeData) {
     return {


### PR DESCRIPTION
#2074 

`region` repeated four times because it's duplicated in [vscode-html-languageservice](https://github.com/microsoft/vscode-html-languageservice/blob/main/src/languageFacts/data/webCustomData.ts) and [its upstream vscode-custom-data](https://github.com/microsoft/vscode-custom-data). Filter it out on our side for now and see if we can remove it from upstream later. 