### PR TITLE
fix: inlay hint position sometimes off by one

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/each/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/each/expectedv2.json
@@ -1,0 +1,14 @@
+[
+    {
+        "label": ": number[]",
+        "position": { "line": 1, "character": 11 },
+        "kind": 1,
+        "paddingLeft": true
+    },
+    {
+        "label": ": number",
+        "position": { "line": 4, "character": 23 },
+        "kind": 1,
+        "paddingLeft": true
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/each/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/each/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  let items = [1]
+</script>
+
+{#each items as item, i}
+  {item}
+{/each}


### PR DESCRIPTION
Continued from PR https://github.com/sveltejs/language-tools/pull/2070
Fixes issue https://github.com/sveltejs/language-tools/issues/1988

Inlay hint position is sometimes off by 1 as mentioned in https://github.com/sveltejs/language-tools/pull/2070

This code detects if inlay hint position is off by 1 by checking `source[position]`. It is off by one if `kind == InlayHintKind.Type`, and `source[position]` is not a valid character that comes after an identifier.

A valid character that can come after an identifier, is ascii characters that is not alphanumeric A-Z(x41-x5A), a-z(x61-x7A), 0-9(x30-x39), or special characters '$'(x24), '_'(x5F), '\\'(x5C).