### PR TITLE
feat: leverage workspace trust to support all settings in workspace

### DIFF
--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -86,10 +86,9 @@ Settings to toggle specific features of the extension. The full list of all sett
 ### Usage with Yarn 2 PnP
 
 1. Run `yarn add -D svelte-language-server` to install svelte-language-server as a dev dependency
-2. Run `yarn dlx @yarnpkg/sdks vscode` to generate or update the VSCode/Yarn integration SDKs.
-3. Set the `svelte.language-server.ls-path` setting in your user configuration, pointing it to the workspace-installed language server.
-4. Restart VSCode.
-5. Commit the changes to `.yarn/sdks`
+2. Run `yarn dlx @yarnpkg/sdks vscode` to generate or update the VSCode/Yarn integration SDKs. This also sets the `svelte.language-server.ls-path` setting for the workspace, pointing it to the workspace-installed language server. Note that this requires workspace trust - else set the `svelte.language-server.ls-path` setting in your user configuration.
+3. Restart VSCode.
+4. Commit the changes to `.yarn/sdks`
 
 ### Credits
 

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -48,6 +48,10 @@
     "capabilities": {
         "untrustedWorkspaces": {
             "supported": "limited",
+            "restrictedConfigurations": [
+                "svelte.language-server.runtime",
+                "svelte.language-server.ls-path"
+            ],
             "description": "The extension requires workspace trust because it executes code specified by the workspace. Loading the user's node_modules and loading svelte config files is disabled when untrusted"
         }
     },
@@ -75,13 +79,11 @@
                     "description": "Ask on startup to enable the TypeScript plugin."
                 },
                 "svelte.language-server.runtime": {
-                    "scope": "application",
                     "type": "string",
                     "title": "Language Server Runtime",
                     "description": "- You normally don't need this - Path to the node executable to use to spawn the language server. This is useful when you depend on native modules such as node-sass as without this they will run in the context of vscode, meaning node version mismatch is likely. Minimum required node version is 12.17. This setting can only be changed in user settings for security reasons."
                 },
                 "svelte.language-server.ls-path": {
-                    "scope": "application",
                     "type": "string",
                     "title": "Language Server Path",
                     "description": "- You normally don't set this - Path to the language server executable. If you installed the \"svelte-language-server\" npm package, it's within there at \"bin/server.js\". Path can be either relative to your workspace root or absolute. Set this only if you want to use a custom version of the language server. This will then also use the workspace version of TypeScript. This setting can only be changed in user settings for security reasons."

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -166,7 +166,7 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
                 html: workspace.getConfiguration('html')
             },
             dontFilterIncompleteCompletions: true, // VSCode filters client side and is smarter at it than us
-            isTrusted: (workspace as any).isTrusted
+            isTrusted: workspace.isTrusted
         }
     };
 


### PR DESCRIPTION
#1051
#678
This was the missing feature in #1086, but now that we have a new minimum required VS Code version which includes workspace trust, we can lift the restriction and allow the security-sensitive settings when the workspace is trusted.

@olafurkarl FYI