### PR TITLE
fix: prevent crashes when ts-plugin config updates

### DIFF
--- a/packages/typescript-plugin/src/config-manager.ts
+++ b/packages/typescript-plugin/src/config-manager.ts
@@ -16,6 +16,11 @@ export class ConfigManager {
         this.emitter.on(configurationEventName, listener);
     }
 
+    isConfigChanged(config: Configuration) {
+        // right now we only care about enable
+        return config.enable !== this.config.enable;
+    }
+
     updateConfigFromPluginConfig(config: Configuration) {
         this.config = {
             ...this.config,

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -134,7 +134,9 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
 
         configManager.onConfigurationChanged(() => {
             // enabling/disabling the plugin means TS has to recompute stuff
-            info.languageService.cleanupSemanticCache();
+            // don't clear semantic cache here
+            // typescript now expected the program updates to be completely in their control
+            // doing so will result in a crash
             info.project.markAsDirty();
 
             // updateGraph checks for new root files
@@ -207,7 +209,9 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
     }
 
     function onConfigurationChanged(config: Configuration) {
-        configManager.updateConfigFromPluginConfig(config);
+        if (configManager.isConfigChanged(config)) {
+            configManager.updateConfigFromPluginConfig(config);
+        }
     }
 
     /**


### PR DESCRIPTION
#2086

Reproduction: 

Enable the TypeScript nightly extension. Go to a non-routes ts/js file. Hover anything after TypeScript is initialized. 

The crash happens because we clear the semantic cache when the config updates. And now TypeScript actively `Debug.assert` if the `program` object is the same as the last time they update it. But in most cases, the config update is because of the API we use to update the config after the plugin is started. The semantic cache clearing seems unnecessary, at least in most cases, so it should be fine if we remove it and should stop the crash. 