### PR TITLE
feat: support prettier v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
         "typescript": "^5.1.3"
     },
     "devDependencies": {
-        "prettier": "2.8.6",
         "cross-env": "^7.0.2",
+        "prettier": "~2.8.8",
         "ts-node": "^10.0.0"
     },
     "packageManager": "pnpm@8.4.0"

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -53,7 +53,7 @@
         "estree-walker": "^2.0.1",
         "fast-glob": "^3.2.7",
         "lodash": "^4.17.21",
-        "prettier": "2.8.6",
+        "prettier": "~2.8.8",
         "prettier-plugin-svelte": "~2.10.1",
         "svelte": "^3.57.0",
         "svelte-preprocess": "~5.0.4",

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -183,7 +183,7 @@ export class SveltePlugin
         }
 
         async function hasSveltePluginLoaded(p: typeof prettier, plugins: string[] = []) {
-            if (plugins.includes('prettier-plugin-svelte')) return true;
+            if (plugins.some((plugin) => plugin.includes('prettier-plugin-svelte'))) return true;
             if (Number(p.version[0]) >= 3) return false; // Prettier version 3 has removed the "search plugins" feature
             // Prettier v3 getSupportInfo is async, v2 is not
             const info = await p.getSupportInfo();

--- a/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
+++ b/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
@@ -67,11 +67,12 @@ describe('Svelte Plugin', () => {
         assert.deepStrictEqual(diagnostics, []);
     });
 
-    describe('#formatDocument', () => {
+    describe.only('#formatDocument', () => {
         function stubPrettier(config: any) {
             const formatStub = sinon.stub().returns('formatted');
 
             sinon.stub(importPackage, 'importPrettier').returns(<any>{
+                version: '2.8.0',
                 resolveConfig: () => Promise.resolve(config),
                 getFileInfo: () => ({ ignored: false }),
                 format: formatStub,

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/index.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/index.test.ts
@@ -59,7 +59,7 @@ async function executeTest(
         : defaultExpectedFile;
     const snapshotFormatter = await createJsonSnapshotFormatter(dir);
 
-    updateSnapshotIfFailedOrEmpty({
+    await updateSnapshotIfFailedOrEmpty({
         assertion() {
             assert.deepStrictEqual(diagnostics, JSON.parse(readFileSync(expectedFile, 'utf-8')));
         },

--- a/packages/language-server/test/plugins/typescript/features/inlayHints/index.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/index.test.ts
@@ -71,7 +71,7 @@ async function executeTest(
 
     const snapshotFormatter = await createJsonSnapshotFormatter(dir);
 
-    updateSnapshotIfFailedOrEmpty({
+    await updateSnapshotIfFailedOrEmpty({
         assertion() {
             assert.deepStrictEqual(
                 JSON.parse(JSON.stringify(inlayHints)),

--- a/packages/language-server/test/plugins/typescript/test-utils.ts
+++ b/packages/language-server/test/plugins/typescript/test-utils.ts
@@ -207,7 +207,7 @@ export function createSnapshotTester<
     }
 }
 
-export function updateSnapshotIfFailedOrEmpty({
+export async function updateSnapshotIfFailedOrEmpty({
     assertion,
     expectedFile,
     rootDir,
@@ -216,25 +216,25 @@ export function updateSnapshotIfFailedOrEmpty({
     assertion: () => void;
     expectedFile: string;
     rootDir: string;
-    getFileContent: () => string;
+    getFileContent: () => string | Promise<string>;
 }) {
     if (existsSync(expectedFile)) {
         try {
             assertion();
         } catch (e) {
             if (process.argv.includes('--auto')) {
-                writeFile(`Updated ${expectedFile} for`);
+                await writeFile(`Updated ${expectedFile} for`);
             } else {
                 throw e;
             }
         }
     } else {
-        writeFile(`Created ${expectedFile} for`);
+        await writeFile(`Created ${expectedFile} for`);
     }
 
-    function writeFile(msg: string) {
+    async function writeFile(msg: string) {
         console.info(msg, dirname(expectedFile).substring(rootDir.length));
-        writeFileSync(expectedFile, getFileContent(), 'utf-8');
+        writeFileSync(expectedFile, await getFileContent(), 'utf-8');
     }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.3
       prettier:
-        specifier: 2.8.6
-        version: 2.8.6
+        specifier: ~2.8.8
+        version: 2.8.8
       ts-node:
         specifier: ^10.0.0
         version: 10.9.1(@types/node@16.18.32)(typescript@5.1.3)
@@ -43,11 +43,11 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       prettier:
-        specifier: 2.8.6
-        version: 2.8.6
+        specifier: ~2.8.8
+        version: 2.8.8
       prettier-plugin-svelte:
         specifier: ~2.10.1
-        version: 2.10.1(prettier@2.8.6)(svelte@3.57.0)
+        version: 2.10.1(prettier@2.8.8)(svelte@3.57.0)
       svelte:
         specifier: ^3.57.0
         version: 3.57.0
@@ -1566,18 +1566,18 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  /prettier-plugin-svelte@2.10.1(prettier@2.8.6)(svelte@3.57.0):
+  /prettier-plugin-svelte@2.10.1(prettier@2.8.8)(svelte@3.57.0):
     resolution: {integrity: sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
-      prettier: 2.8.6
+      prettier: 2.8.8
       svelte: 3.57.0
     dev: false
 
-  /prettier@2.8.6:
-    resolution: {integrity: sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==}
+  /prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 


### PR DESCRIPTION
Prettier v3 changed some APIs to be asynchronous. This is an easy fix, we just add `await` to some methods which is useless but harmless for v2 invocations.

The more involved problem is that the v3 Prettier API is incompatible with v2, and likewise you can't use prettier plugins that support v2 with Prettier v3 and vice versa. This means we need to add additional code to keep things working when someone has Prettier (or the plugin) installed but not the other (the plugin or Prettier). The current code does ignore the user's Prettier version if it's v3 but `prettier-plugin-svelte` is not found - it falls back to v2 of both Prettier and the plugin. It falls back to v2 for now because based on installs Prettier v2 is still far more popular so that's the safer choice.
There's one problem though: What if someone has other plugins in their node modules but _not_ the prettier plugin? In this case formatting could be done with Prettier v2 using plugins (from the user) that only support v3, and that fails. I don't see a good way around this, but I would also hope this does not happen often.

Thoughts @jasonlyu123 ?