### PR TITLE
(fix) svelte:document types

### DIFF
--- a/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
+++ b/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
@@ -67,7 +67,7 @@ describe('Svelte Plugin', () => {
         assert.deepStrictEqual(diagnostics, []);
     });
 
-    describe.only('#formatDocument', () => {
+    describe('#formatDocument', () => {
         function stubPrettierV2(config: any) {
             const formatStub = sinon.stub().returns('formatted');
 

--- a/packages/svelte2tsx/svelte-jsx-v4.d.ts
+++ b/packages/svelte2tsx/svelte-jsx-v4.d.ts
@@ -219,6 +219,7 @@ declare namespace svelteHTML {
     // Svelte specific
     'svelte:window': HTMLProps<'svelte:window', HTMLAttributes>;
     'svelte:body': HTMLProps<'svelte:body', HTMLAttributes>;
+    'svelte:document': HTMLProps<'svelte:document', HTMLAttributes>;
     'svelte:fragment': { slot?: string };
     'svelte:options': { [name: string]: any };
     'svelte:head': { [name: string]: any };

--- a/packages/svelte2tsx/svelte-jsx.d.ts
+++ b/packages/svelte2tsx/svelte-jsx.d.ts
@@ -238,6 +238,7 @@ declare namespace svelteHTML {
     // Svelte specific
     'svelte:window': HTMLProps<'svelte:window', HTMLAttributes>;
     'svelte:body': HTMLProps<'svelte:body', HTMLAttributes>;
+    'svelte:document': HTMLProps<'svelte:document', HTMLAttributes>;
     'svelte:fragment': { slot?: string };
     'svelte:options': { [name: string]: any };
     'svelte:head': { [name: string]: any };


### PR DESCRIPTION
#2111

Ideally, we should make it always map all the members of `SvelteHTMLElements`, but it seems like Interface doesn't allow complex index types. At least if we move it to the Svelte core, There'll be a higher chance of remembering we need to add it in both places.