### PR TITLE
fix: generic const modifier

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/nodes/Generics.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/Generics.ts
@@ -24,7 +24,12 @@ export class Generics {
     }
 
     private getGenericTypeParameters(rawGenericsAttr: string) {
-        const sourceFile = ts.createSourceFile('index.ts', `<${rawGenericsAttr}>() => {}`, ts.ScriptTarget.Latest, true);
+        const sourceFile = ts.createSourceFile(
+            'index.ts',
+            `<${rawGenericsAttr}>() => {}`,
+            ts.ScriptTarget.Latest,
+            true
+        );
         const firstStatement = sourceFile.statements[0];
 
         if (!firstStatement || !ts.isExpressionStatement(firstStatement)) {

--- a/packages/svelte2tsx/test/helpers.ts
+++ b/packages/svelte2tsx/test/helpers.ts
@@ -11,7 +11,7 @@ function can_auto_update() {
     if (!process.argv.includes('--auto') && !all_tests_skipped) {
         if (update_count++ === 0) {
             process.on('exit', () => {
-                const command = color.yellow('yarn run test --auto');
+                const command = color.yellow('pnpm run test -- --auto');
                 console.log(`  Run ${command} to update ${update_count} files\n`);
             });
         }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/generic-attribute-const-modifier/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/generic-attribute-const-modifier/expectedv2.ts
@@ -1,0 +1,23 @@
+///<reference types="svelte" />
+;function render<const T extends readonly string[]>() {
+
+ let items: T/*Ωignore_startΩ*/;items = __sveltets_2_any(items);/*Ωignore_endΩ*/;
+;
+async () => {};
+return { props: {items: items}, slots: {}, events: {} }}
+class __sveltets_Render<const T extends readonly string[]> {
+    props() {
+        return render<T>().props;
+    }
+    events() {
+        return __sveltets_2_with_any_event(render<T>()).events;
+    }
+    slots() {
+        return render<T>().slots;
+    }
+}
+
+
+import { SvelteComponentTyped as __SvelteComponentTyped__ } from "svelte" 
+export default class Input__SvelteComponent_<const T extends readonly string[]> extends __SvelteComponentTyped__<ReturnType<__sveltets_Render<T>['props']>, ReturnType<__sveltets_Render<T>['events']>, ReturnType<__sveltets_Render<T>['slots']>> {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/generic-attribute-const-modifier/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/generic-attribute-const-modifier/input.svelte
@@ -1,0 +1,3 @@
+<script lang="ts" generics="const T extends readonly string[]">
+export let items: T;
+</script>


### PR DESCRIPTION
#2107

Switching to let TypeScript parse the generic attribute by wrapping it with an arrow function.