### PR TITLE
fix: handle more cases of plugin config

### DIFF
--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -105,7 +105,12 @@ export class SveltePlugin
             const pluginLoaded = await hasSveltePluginLoaded(prettier1, resolvedPlugins1);
             if (Number(prettier1.version[0]) < 3 || pluginLoaded) {
                 // plugin loaded, or referenced in user config as a plugin, or same version as our fallback version -> ok
-                return { prettier: prettier1, config: config1, isFallback: false, resolvedPlugins: resolvedPlugins1 };
+                return {
+                    prettier: prettier1,
+                    config: config1,
+                    isFallback: false,
+                    resolvedPlugins: resolvedPlugins1
+                };
             }
 
             // User either only has Plugin or incompatible Prettier major version installed or none
@@ -113,7 +118,12 @@ export class SveltePlugin
             const prettier2 = importPrettier(__dirname);
             const config2 = await getConfig(prettier2);
             const resolvedPlugins2 = resolvePlugins(config2.plugins);
-            return { prettier: prettier2, config: config2, isFallback: true, resolvedPlugins: resolvedPlugins2 };
+            return {
+                prettier: prettier2,
+                config: config2,
+                isFallback: true,
+                resolvedPlugins: resolvedPlugins2
+            };
         };
 
         const { prettier, config, isFallback, resolvedPlugins } = await importFittingPrettier();
@@ -216,7 +226,7 @@ export class SveltePlugin
             return plugin.includes('prettier-plugin-svelte');
         }
 
-        return !!plugin.languages?.find((l) => l.name === 'svelte');
+        return !!plugin?.languages?.find((l) => l.name === 'svelte');
     }
 
     async getCompletions(

--- a/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
+++ b/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
@@ -332,7 +332,7 @@ describe('Svelte Plugin', () => {
 
             await testFormat(
                 {
-                    plugins: ['./do-not-exist/node_modules/prettier-plugin-svelte']
+                    plugins: ['@do-not-exist/prettier-plugin-svelte']
                 },
                 {},
                 undefined,

--- a/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
+++ b/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
@@ -330,10 +330,14 @@ describe('Svelte Plugin', () => {
                 return formatStub;
             }
 
-            debugger;
-            await testFormat({
-                plugins: ["./do-not-exist/node_modules/prettier-plugin-svelte"]
-            }, {}, undefined, stubPrettier);
+            await testFormat(
+                {
+                    plugins: ['./do-not-exist/node_modules/prettier-plugin-svelte']
+                },
+                {},
+                undefined,
+                stubPrettier
+            );
         });
     });
 


### PR DESCRIPTION
#2106

Fix cases where `plugins: [require('prettier-plugin-svelte')]`  and where `plugins ['prettier-plugin-svelte']` but never installed. 

There're still some cases where it would fail, like `plugins: [require.resolve('prettier-plugin-svelte')]` or `plugins: [path.join(prcess.cwd(), 'node_modules/prettier-plugin-svelte']`, but the plugin isn't installed, likely when people copy a prettier config but never pay attention to what the config actually does. Wondering if we should just show a message alert like #1763 suggested. Likely only detect errors with "Cannot find module". Or should we try to detect these two cases and fallback to using bundled version?