### PR TITLE
(Fix) VSCode. Cann't collapse #region with multi-line comment and JSDoc comments

### DIFF
--- a/packages/svelte-vscode/language-configuration.json
+++ b/packages/svelte-vscode/language-configuration.json
@@ -31,8 +31,8 @@
     ],
     "folding": {
         "markers": {
-            "start": "^\\s*//\\s*#?region\\b|^<(template|style|script)[^>]*>|^\\s*<!--\\s*#region\\b",
-            "end": "^\\s*//\\s*#?endregion\\b|^</(template|style|script)>|^\\s*<!--\\s*#endregion\\b"
+            "start": "^\\s*(//|/\\*\\*?)\\s*#?region\\b|^<(template|style|script)[^>]*>|^\\s*<!--\\s*#region\\b",
+            "end": "^\\s*(//|/\\*\\*?)\\s*#?endregion\\b|^</(template|style|script)>|^\\s*<!--\\s*#endregion\\b"
         }
     }
 }


### PR DESCRIPTION
I have created #2140 issue and I found where is the problem was and fixed it