### PR TITLE
(fix) manual define svelteSys.readFile for compatibility

### DIFF
--- a/packages/typescript-plugin/src/svelte-sys.ts
+++ b/packages/typescript-plugin/src/svelte-sys.ts
@@ -17,6 +17,12 @@ export function createSvelteSys(ts: _ts, logger: Logger) {
             const extensionsWithSvelte = (extensions ?? []).concat('.svelte');
 
             return ts.sys.readDirectory(path, extensionsWithSvelte, exclude, include, depth);
+        },
+        readFile(path, encoding) {
+            // imba typescript plugin patch this with Object.defineProperty
+            // and copying the property descriptor from a class that extends the original ts.sys
+            // so we explicitly define it here
+            return ts.sys.readFile(path, encoding);
         }
     };
 


### PR DESCRIPTION
#2138

Imba typescript plugin patch this with Object.defineProperty and copy the property descriptor from a class that extends the original ts.sys. So, we explicitly define it here. Although it makes more sense to fix it on their side It's more productive for us to define it than arguing with them in an issue.