### PR TITLE
chore: bump TS and adjust tsconfigs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "lint": "prettier --check ."
     },
     "dependencies": {
-        "typescript": "^5.1.3"
+        "typescript": "^5.2.2"
     },
     "devDependencies": {
         "cross-env": "^7.0.2",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -34,7 +34,6 @@
         "node": ">= 12.0.0"
     },
     "devDependencies": {
-        "@tsconfig/node16": "^1.0.0",
         "@types/estree": "^0.0.42",
         "@types/lodash": "^4.14.116",
         "@types/mocha": "^9.1.0",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -57,7 +57,7 @@
         "svelte": "^3.57.0",
         "svelte-preprocess": "~5.0.4",
         "svelte2tsx": "workspace:~",
-        "typescript": "*",
+        "typescript": "^5.2.2",
         "vscode-css-languageservice": "~6.2.0",
         "vscode-html-languageservice": "~5.0.0",
         "vscode-languageserver": "8.0.2",

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -476,6 +476,7 @@ describe('CompletionProviderImpl', function () {
         assert.deepStrictEqual(data, {
             data: undefined,
             hasAction: undefined,
+            filterText: undefined,
             insertText: undefined,
             isPackageJsonImport: undefined,
             isImportStatementCompletion: undefined,
@@ -1441,7 +1442,7 @@ describe('CompletionProviderImpl', function () {
         assert.deepStrictEqual(item, {
             label: 'hi',
             kind: CompletionItemKind.Method,
-            sortText: '17',
+            sortText: '11',
             preselect: undefined,
             insertText: `hi(name: string): string {${newLine}${indent}$0${newLine}}`,
             insertTextFormat: 2,

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/actions-animations-transitions-typechecks/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/actions-animations-transitions-typechecks/expectedv2.json
@@ -14,7 +14,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Argument of type 'HTMLParagraphElement' is not assignable to parameter of type 'HTMLInputElement'.\n  Type 'HTMLParagraphElement' is missing the following properties from type 'HTMLInputElement': accept, alt, autocomplete, capture, and 52 more.",
+        "message": "Argument of type 'HTMLParagraphElement' is not assignable to parameter of type 'HTMLInputElement'.\n  Type 'HTMLParagraphElement' is missing the following properties from type 'HTMLInputElement': accept, alt, autocomplete, capture, and 54 more.",
         "code": 2345,
         "tags": []
     }

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expected_svelte_4.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expected_svelte_4.json
@@ -25,7 +25,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Type 'HTMLDivElement' is missing the following properties from type 'HTMLInputElement': accept, alt, autocomplete, capture, and 52 more.",
+        "message": "Type 'HTMLDivElement' is missing the following properties from type 'HTMLInputElement': accept, alt, autocomplete, capture, and 54 more.",
         "code": 2740,
         "tags": []
     },

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expectedv2.json
@@ -25,7 +25,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Type 'HTMLDivElement' is missing the following properties from type 'HTMLInputElement': accept, alt, autocomplete, capture, and 52 more.",
+        "message": "Type 'HTMLDivElement' is missing the following properties from type 'HTMLInputElement': accept, alt, autocomplete, capture, and 54 more.",
         "code": 2740,
         "tags": []
     },

--- a/packages/language-server/tsconfig.json
+++ b/packages/language-server/tsconfig.json
@@ -1,14 +1,17 @@
 {
-    "extends": "@tsconfig/node16/tsconfig.json",
     "compilerOptions": {
+        "lib": ["es2021"],
+        "target": "es2021",
         "moduleResolution": "node",
         "module": "CommonJS",
+
+        "outDir": "dist",
         "strict": true,
         "declaration": true,
-        "outDir": "dist",
         "esModuleInterop": true,
         "sourceMap": true,
         "composite": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true
     }
 }

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -46,7 +46,6 @@
         "@rollup/plugin-node-resolve": "^15.0.0",
         "@rollup/plugin-replace": "5.0.2",
         "@rollup/plugin-typescript": "^10.0.0",
-        "@tsconfig/node16": "^1.0.0",
         "@types/sade": "^1.7.2",
         "builtin-modules": "^3.3.0",
         "rollup": "3.7.5",

--- a/packages/svelte-check/tsconfig.json
+++ b/packages/svelte-check/tsconfig.json
@@ -1,9 +1,14 @@
 {
-    "extends": "@tsconfig/node16/tsconfig.json",
     "compilerOptions": {
+        "lib": ["es2021"],
+        "module": "CommonJS",
+        "target": "es2021",
         "moduleResolution": "node",
+
         "strict": true,
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true
     },
     "include": ["src/**/*"]
 }

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -708,7 +708,6 @@
         ]
     },
     "devDependencies": {
-        "@tsconfig/node16": "^1.0.0",
         "@types/lodash": "^4.14.116",
         "@types/node": "^16.0.0",
         "@types/vscode": "^1.67",

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -713,7 +713,7 @@
         "@types/vscode": "^1.67",
         "js-yaml": "^3.14.0",
         "tslib": "^2.4.0",
-        "typescript": "*",
+        "typescript": "^5.2.2",
         "vscode-tmgrammar-test": "^0.0.11"
     },
     "dependencies": {

--- a/packages/svelte-vscode/tsconfig.json
+++ b/packages/svelte-vscode/tsconfig.json
@@ -1,10 +1,16 @@
 {
-    "extends": "@tsconfig/node16/tsconfig.json",
     "compilerOptions": {
+        "lib": ["es2021"],
+        "module": "CommonJS",
+        "target": "es2021",
         "moduleResolution": "node",
-        "strict": true,
-        "declaration": true,
+
         "outDir": "dist",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "declaration": true,
         "sourceMap": true,
         "composite": true
     }

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -40,7 +40,7 @@
         "svelte": "~3.57.0",
         "tiny-glob": "^0.2.6",
         "tslib": "^2.4.0",
-        "typescript": "^5.1.3"
+        "typescript": "^5.2.2"
     },
     "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -19,7 +19,7 @@
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^16.0.0",
-        "typescript": "*"
+        "typescript": "^5.2.2"
     },
     "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.14",

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -18,7 +18,6 @@
     "author": "The Svelte Community",
     "license": "MIT",
     "devDependencies": {
-        "@tsconfig/node16": "^1.0.0",
         "@types/node": "^16.0.0",
         "typescript": "*"
     },

--- a/packages/typescript-plugin/tsconfig.json
+++ b/packages/typescript-plugin/tsconfig.json
@@ -1,14 +1,18 @@
 {
-    "extends": "@tsconfig/node16/tsconfig.json",
     "compilerOptions": {
+        "lib": ["es2021"],
+        "target": "es2021",
         "moduleResolution": "node",
         "module": "CommonJS",
+
+        "outDir": "dist",
         "esModuleInterop": true,
         "strict": true,
         "declaration": true,
-        "outDir": "dist",
         "sourceMap": true,
-        "composite": true
+        "composite": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true
     },
     "include": ["./src/**/*"],
     "exclude": ["./node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.3
+        specifier: ^5.2.2
+        version: 5.2.2
     devDependencies:
       cross-env:
         specifier: ^7.0.2
@@ -20,7 +20,7 @@ importers:
         version: 2.8.8
       ts-node:
         specifier: ^10.0.0
-        version: 10.9.1(@types/node@16.18.32)(typescript@5.1.3)
+        version: 10.9.1(@types/node@16.18.32)(typescript@5.2.2)
 
   packages/language-server:
     dependencies:
@@ -53,13 +53,13 @@ importers:
         version: 3.57.0
       svelte-preprocess:
         specifier: ~5.0.4
-        version: 5.0.4(svelte@3.57.0)(typescript@5.1.3)
+        version: 5.0.4(svelte@3.57.0)(typescript@5.2.2)
       svelte2tsx:
         specifier: workspace:~
         version: link:../svelte2tsx
       typescript:
-        specifier: '*'
-        version: 5.1.3
+        specifier: ^5.2.2
+        version: 5.2.2
       vscode-css-languageservice:
         specifier: ~6.2.0
         version: 6.2.5
@@ -108,7 +108,7 @@ importers:
         version: 11.1.2
       ts-node:
         specifier: ^10.0.0
-        version: 10.9.1(@types/node@16.18.32)(typescript@5.1.3)
+        version: 10.9.1(@types/node@16.18.32)(typescript@5.2.2)
 
   packages/svelte-check:
     dependencies:
@@ -135,10 +135,10 @@ importers:
         version: 3.59.2
       svelte-preprocess:
         specifier: ^5.0.4
-        version: 5.0.4(svelte@3.59.2)(typescript@5.1.3)
+        version: 5.0.4(svelte@3.59.2)(typescript@5.2.2)
       typescript:
         specifier: ^5.0.3
-        version: 5.1.3
+        version: 5.2.2
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^24.0.0
@@ -154,7 +154,7 @@ importers:
         version: 5.0.2(rollup@3.7.5)
       '@rollup/plugin-typescript':
         specifier: ^10.0.0
-        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.1.3)
+        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.2.2)
       '@types/sade':
         specifier: ^1.7.2
         version: 1.7.4
@@ -220,8 +220,8 @@ importers:
         specifier: ^2.4.0
         version: 2.5.2
       typescript:
-        specifier: '*'
-        version: 5.1.3
+        specifier: ^5.2.2
+        version: 5.2.2
       vscode-tmgrammar-test:
         specifier: ^0.0.11
         version: 0.0.11
@@ -252,7 +252,7 @@ importers:
         version: 15.0.2(rollup@3.7.5)
       '@rollup/plugin-typescript':
         specifier: ^10.0.0
-        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.1.3)
+        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.2.2)
       '@types/estree':
         specifier: ^0.0.42
         version: 0.0.42
@@ -302,8 +302,8 @@ importers:
         specifier: ^2.4.0
         version: 2.5.2
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.3
+        specifier: ^5.2.2
+        version: 5.2.2
 
   packages/typescript-plugin:
     dependencies:
@@ -318,8 +318,8 @@ importers:
         specifier: ^16.0.0
         version: 16.18.32
       typescript:
-        specifier: '*'
-        version: 5.1.3
+        specifier: ^5.2.2
+        version: 5.2.2
 
 packages:
 
@@ -455,7 +455,7 @@ packages:
       rollup: 3.7.5
     dev: true
 
-  /@rollup/plugin-typescript@10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.1.3):
+  /@rollup/plugin-typescript@10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.2.2):
     resolution: {integrity: sha512-wBykxRLlX7EzL8BmUqMqk5zpx2onnmRMSw/l9M1sVfkJvdwfxogZQVNUM9gVMJbjRLDR5H6U0OMOrlDGmIV45A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -472,7 +472,7 @@ packages:
       resolve: 1.22.2
       rollup: 3.7.5
       tslib: 2.5.2
-      typescript: 5.1.3
+      typescript: 5.2.2
     dev: true
 
   /@rollup/pluginutils@5.0.2(rollup@3.7.5):
@@ -802,7 +802,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -1031,8 +1031,8 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -1661,7 +1661,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-parallel@1.2.0:
@@ -1821,7 +1821,7 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svelte-preprocess@5.0.4(svelte@3.57.0)(typescript@5.1.3):
+  /svelte-preprocess@5.0.4(svelte@3.57.0)(typescript@5.2.2):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -1865,10 +1865,10 @@ packages:
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 3.57.0
-      typescript: 5.1.3
+      typescript: 5.2.2
     dev: false
 
-  /svelte-preprocess@5.0.4(svelte@3.59.2)(typescript@5.1.3):
+  /svelte-preprocess@5.0.4(svelte@3.59.2)(typescript@5.2.2):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -1912,7 +1912,7 @@ packages:
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 3.59.2
-      typescript: 5.1.3
+      typescript: 5.2.2
     dev: false
 
   /svelte@3.57.0:
@@ -1937,7 +1937,7 @@ packages:
     dependencies:
       is-number: 7.0.0
 
-  /ts-node@10.9.1(@types/node@16.18.32)(typescript@5.1.3):
+  /ts-node@10.9.1(@types/node@16.18.32)(typescript@5.2.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -1963,7 +1963,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.1.3
+      typescript: 5.2.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -1976,8 +1976,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /typescript@5.1.3:
-    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,9 +79,6 @@ importers:
         specifier: ~3.0.0
         version: 3.0.7
     devDependencies:
-      '@tsconfig/node16':
-        specifier: ^1.0.0
-        version: 1.0.4
       '@types/estree':
         specifier: ^0.0.42
         version: 0.0.42
@@ -158,9 +155,6 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^10.0.0
         version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.1.3)
-      '@tsconfig/node16':
-        specifier: ^1.0.0
-        version: 1.0.4
       '@types/sade':
         specifier: ^1.7.2
         version: 1.7.4
@@ -210,9 +204,6 @@ importers:
         specifier: 3.17.2
         version: 3.17.2
     devDependencies:
-      '@tsconfig/node16':
-        specifier: ^1.0.0
-        version: 1.0.4
       '@types/lodash':
         specifier: ^4.14.116
         version: 4.14.194
@@ -323,9 +314,6 @@ importers:
         specifier: workspace:~
         version: link:../svelte2tsx
     devDependencies:
-      '@tsconfig/node16':
-        specifier: ^1.0.0
-        version: 1.0.4
       '@types/node':
         specifier: ^16.0.0
         version: 16.18.32


### PR DESCRIPTION
TS 5.2 is more strict about module resolution, and seems to not take into account "extends". Therefore inline the base. (deployment of the extension failed for that reason)