### PR TITLE
fix: output $$Props code differently

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$$props-usage/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$$props-usage/expectedv2.json
@@ -17,7 +17,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Type '{ exported1: string; exported2: string; invalidProp: true; }' is not assignable to type '{ exported1: string; exported2?: string | undefined; exported3: string; }'.\n  Object literal may only specify known properties, and '\"invalidProp\"' does not exist in type '{ exported1: string; exported2?: string | undefined; exported3: string; }'.",
+        "message": "Type '{ exported1: string; exported2: string; invalidProp: true; }' is not assignable to type '$$Props'.\n  Object literal may only specify known properties, and '\"invalidProp\"' does not exist in type '$$Props'.",
         "code": 2322,
         "tags": []
     },
@@ -25,7 +25,7 @@
         "range": { "start": { "line": 12, "character": 1 }, "end": { "line": 12, "character": 6 } },
         "severity": 1,
         "source": "ts",
-        "message": "Type '{}' is missing the following properties from type '{ exported1: string; exported2?: string | undefined; exported3: string; }': exported1, exported3",
+        "message": "Type '{}' is missing the following properties from type '$$Props': exported1, exported3",
         "code": 2739,
         "tags": []
     }

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -395,9 +395,9 @@ export class ExportedNames {
             //   to use less props than defined (it just ignores them)
             // - __sveltets_2_ensureRightProps needs to be declared in a way that doesn't affect the type result of props
             return (
-                '__sveltets_2_ensureRightProps<{' +
+                '{ ...__sveltets_2_ensureRightProps<{' +
                 this.createReturnElementsType(lets).join(',') +
-                '}>(__sveltets_2_any("") as $$Props) as ' +
+                '}>(__sveltets_2_any("") as $$Props)} as ' +
                 // We add other exports of classes and functions here because
                 // they need to appear in the props object in order to properly
                 // type bind:xx but they are not needed to be part of $$Props

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -395,17 +395,16 @@ export class ExportedNames {
             //   to use less props than defined (it just ignores them)
             // - __sveltets_2_ensureRightProps needs to be declared in a way that doesn't affect the type result of props
             return (
-                '{...__sveltets_2_ensureRightProps<{' +
+                '__sveltets_2_ensureRightProps<{' +
                 this.createReturnElementsType(lets).join(',') +
-                '}>(__sveltets_2_any("") as $$Props), ' +
-                '...{} as unknown as $$Props, ...{' +
+                '}>(__sveltets_2_any("") as $$Props) as ' +
                 // We add other exports of classes and functions here because
                 // they need to appear in the props object in order to properly
                 // type bind:xx but they are not needed to be part of $$Props
-                this.createReturnElements(others, false).join(', ') +
-                '} as {' +
-                this.createReturnElementsType(others).join(',') +
-                '}}'
+                (others.length
+                    ? '{' + this.createReturnElementsType(others).join(',') + '} & '
+                    : '') +
+                '$$Props'
             );
         }
 

--- a/packages/svelte2tsx/test/emitDts/samples/typescript/expected/Test3$$Props.svelte.d.ts
+++ b/packages/svelte2tsx/test/emitDts/samples/typescript/expected/Test3$$Props.svelte.d.ts
@@ -2,6 +2,7 @@ import { SvelteComponentTyped } from "svelte";
 declare const __propDef: {
     props: {
         b?: () => void;
+    } & {
         /**
          * comment is preserved
          */

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface-only-props/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface-only-props/expectedv2.ts
@@ -11,7 +11,7 @@
     }
 ;
 async () => {};
-return { props: __sveltets_2_ensureRightProps<{}>(__sveltets_2_any("") as $$Props) as $$Props, slots: {}, events: {} }}
+return { props: { ...__sveltets_2_ensureRightProps<{}>(__sveltets_2_any("") as $$Props)} as $$Props, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface-only-props/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface-only-props/expectedv2.ts
@@ -1,0 +1,17 @@
+///<reference types="svelte" />
+;function render() {
+
+    type $$Props = {
+        exported1: string;
+        exported2?: string;
+        name1?: string;
+        name2: string;
+        renamed1?: string;
+        renamed2: string;
+    }
+;
+async () => {};
+return { props: __sveltets_2_ensureRightProps<{}>(__sveltets_2_any("") as $$Props) as $$Props, slots: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface-only-props/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface-only-props/input.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    type $$Props = {
+        exported1: string;
+        exported2?: string;
+        name1?: string;
+        name2: string;
+        renamed1?: string;
+        renamed2: string;
+    }
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface/expectedv2.ts
@@ -31,7 +31,7 @@
     
 ;
 async () => {};
-return { props: __sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props) as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, slots: {}, events: {} }}
+return { props: { ...__sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props)} as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface/expectedv2.ts
@@ -31,7 +31,7 @@
     
 ;
 async () => {};
-return { props: {...__sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props), ...{} as unknown as $$Props, ...{Foo: Foo, bar: bar, baz: baz, RenamedFoo: RenameFoo, renamedbar: renamebar, renamedbaz: renamebaz} as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string}}, slots: {}, events: {} }}
+return { props: __sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props) as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-type/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-type/expectedv2.ts
@@ -31,7 +31,7 @@
     
 ;
 async () => {};
-return { props: __sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props) as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, slots: {}, events: {} }}
+return { props: { ...__sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props)} as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-type/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-type/expectedv2.ts
@@ -31,7 +31,7 @@
     
 ;
 async () => {};
-return { props: {...__sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props), ...{} as unknown as $$Props, ...{Foo: Foo, bar: bar, baz: baz, RenamedFoo: RenameFoo, renamedbar: renamebar, renamedbaz: renamebaz} as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string}}, slots: {}, events: {} }}
+return { props: __sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props) as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-with-$$props/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-with-$$props/expectedv2.ts
@@ -13,7 +13,7 @@
 async () => {
 
 $$props;};
-return { props: __sveltets_2_ensureRightProps<{}>(__sveltets_2_any("") as $$Props) as {c?: typeof c} & $$Props, slots: {}, events: {} }}
+return { props: { ...__sveltets_2_ensureRightProps<{}>(__sveltets_2_any("") as $$Props)} as {c?: typeof c} & $$Props, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
     get c() { return __sveltets_2_nonNullable(this.$$prop_def.c) }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-with-$$props/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-with-$$props/expectedv2.ts
@@ -13,7 +13,7 @@
 async () => {
 
 $$props;};
-return { props: {...__sveltets_2_ensureRightProps<{}>(__sveltets_2_any("") as $$Props), ...{} as unknown as $$Props, ...{c: c} as {c?: typeof c}}, slots: {}, events: {} }}
+return { props: __sveltets_2_ensureRightProps<{}>(__sveltets_2_any("") as $$Props) as {c?: typeof c} & $$Props, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
     get c() { return __sveltets_2_nonNullable(this.$$prop_def.c) }


### PR DESCRIPTION
Using a type union instead of spread, because the latter does remove index signatures from the resulting type #1825