### PR TITLE
feat: enhance component references in find references

### DIFF
--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -159,12 +159,15 @@ export class TypeScriptPlugin
         );
         this.renameProvider = new RenameProviderImpl(this.lsAndTsDocResolver, configManager);
         this.hoverProvider = new HoverProviderImpl(this.lsAndTsDocResolver);
-        this.findReferencesProvider = new FindReferencesProviderImpl(this.lsAndTsDocResolver);
         this.findFileReferencesProvider = new FindFileReferencesProviderImpl(
             this.lsAndTsDocResolver
         );
         this.findComponentReferencesProvider = new FindComponentReferencesProviderImpl(
             this.lsAndTsDocResolver
+        );
+        this.findReferencesProvider = new FindReferencesProviderImpl(
+            this.lsAndTsDocResolver,
+            this.findComponentReferencesProvider
         );
         this.selectionRangeProvider = new SelectionRangeProviderImpl(this.lsAndTsDocResolver);
         this.signatureHelpProvider = new SignatureHelpProviderImpl(this.lsAndTsDocResolver);

--- a/packages/language-server/test/plugins/typescript/features/FindComponentReferencesProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/FindComponentReferencesProvider.test.ts
@@ -50,6 +50,7 @@ describe('FindComponentReferencesProvider', function () {
         const { provider, document, openDoc } = setup('find-component-references-child.svelte');
         //Make known all the associated files
         openDoc('find-component-references-parent.svelte');
+        openDoc('find-component-references-parent2.svelte');
 
         const results = await provider.findComponentReferences(document.uri.toString());
 
@@ -105,6 +106,19 @@ describe('FindComponentReferencesProvider', function () {
                     }
                 },
                 uri: getUri('find-component-references-parent.svelte')
+            },
+            {
+                range: {
+                    start: {
+                        line: 1,
+                        character: 9
+                    },
+                    end: {
+                        line: 1,
+                        character: 19
+                    }
+                },
+                uri: getUri('find-component-references-parent2.svelte')
             }
         ]);
     });

--- a/packages/language-server/test/plugins/typescript/features/FindReferencesProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/FindReferencesProvider.test.ts
@@ -9,6 +9,7 @@ import { LSAndTSDocResolver } from '../../../../src/plugins/typescript/LSAndTSDo
 import { __resetCache } from '../../../../src/plugins/typescript/service';
 import { pathToUrl } from '../../../../src/utils';
 import { serviceWarmup } from '../test-utils';
+import { FindComponentReferencesProviderImpl } from '../../../../src/plugins/typescript/features/FindComponentReferencesProvider';
 
 const testDir = path.join(__dirname, '..');
 
@@ -29,7 +30,10 @@ describe('FindReferencesProvider', function () {
         );
         const lsConfigManager = new LSConfigManager();
         const lsAndTsDocResolver = new LSAndTSDocResolver(docManager, [testDir], lsConfigManager);
-        const provider = new FindReferencesProviderImpl(lsAndTsDocResolver);
+        const provider = new FindReferencesProviderImpl(
+            lsAndTsDocResolver,
+            new FindComponentReferencesProviderImpl(lsAndTsDocResolver)
+        );
         const document = openDoc(filename);
         return { provider, document, openDoc };
 
@@ -76,7 +80,7 @@ describe('FindReferencesProvider', function () {
         await test(Position.create(1, 11), true);
     });
 
-    it('finds references, exluding definition', async () => {
+    it('finds references, excluding definition', async () => {
         await test(Position.create(1, 11), false);
     });
 
@@ -328,6 +332,99 @@ describe('FindReferencesProvider', function () {
                 uri: getUri('declaration-map/importing.svelte')
             }
         ]);
+    });
+
+    const componentReferences = [
+        {
+            range: {
+                start: {
+                    line: 8,
+                    character: 15
+                },
+                end: {
+                    line: 8,
+                    character: 22
+                }
+            },
+            uri: getUri('find-component-references-parent.svelte')
+        },
+        {
+            range: {
+                start: {
+                    line: 1,
+                    character: 9
+                },
+                end: {
+                    line: 1,
+                    character: 19
+                }
+            },
+            uri: getUri('find-component-references-parent.svelte')
+        },
+        {
+            range: {
+                start: {
+                    line: 18,
+                    character: 1
+                },
+                end: {
+                    line: 18,
+                    character: 11
+                }
+            },
+            uri: getUri('find-component-references-parent.svelte')
+        },
+        {
+            range: {
+                start: {
+                    line: 20,
+                    character: 1
+                },
+                end: {
+                    line: 20,
+                    character: 11
+                }
+            },
+            uri: getUri('find-component-references-parent.svelte')
+        },
+        {
+            range: {
+                start: {
+                    line: 1,
+                    character: 9
+                },
+                end: {
+                    line: 1,
+                    character: 19
+                }
+            },
+            uri: getUri('find-component-references-parent2.svelte')
+        }
+    ];
+
+    it('can find component references from script tag', async () => {
+        const { provider, document, openDoc } = setup('find-component-references-child.svelte');
+
+        openDoc('find-component-references-parent.svelte');
+        openDoc('find-component-references-parent2.svelte');
+
+        const results = await provider.findReferences(document, Position.create(0, 1), {
+            includeDeclaration: true
+        });
+
+        assert.deepStrictEqual(results, componentReferences);
+    });
+
+    it('can find all component references', async () => {
+        const { provider, document, openDoc } = setup('find-component-references-parent.svelte');
+
+        openDoc('find-component-references-parent2.svelte');
+
+        const results = await provider.findReferences(document, Position.create(18, 1), {
+            includeDeclaration: true
+        });
+
+        assert.deepStrictEqual(results, componentReferences);
     });
 
     // Hacky, but it works. Needed due to testing both new and old transformation

--- a/packages/language-server/test/plugins/typescript/testfiles/find-component-references-parent2.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/find-component-references-parent2.svelte
@@ -1,0 +1,3 @@
+<script script lang="ts">
+  import Component1 from "./find-component-references-child.svelte";
+</script>


### PR DESCRIPTION
#2130

This allows for finding current component references from the script tag. The advantage of this is that you can now use the "Find All References" command for component references. This will always open in the sidebar without setting the `references.preferredLocation` config. 

While we're on this topic, I also map the reference for a component to "find component references". Currently, these are only the references for the file that was requested. The reason is that the name of the generated component is suffixed, so any import will be an aliased default import. Thus, TypeScript only searches within the same file. 

I plan to add code lens support, but that will be in a separate PR later. 