### PR TITLE
fix: ensure SvelteKit file is patched when first open

### DIFF
--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -481,6 +481,8 @@ export const kitExports: Record<
     }
 };
 
+const FORCE_UPDATE_VERSION = 'FORCE_UPDATE_VERSION';
+
 export function isKitRouteExportAllowedIn(
     basename: string,
     kitExport: (typeof kitExports)[keyof typeof kitExports]
@@ -607,10 +609,11 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
         }
 
         getKitScriptSnapshotIfUpToDate(fileName: string) {
+            const scriptVersion = this.getScriptVersion(fileName);
             if (
                 !this.files[fileName] ||
-                this.getScriptVersion(fileName) !==
-                    originalLanguageServiceHost.getScriptVersion(fileName)
+                (scriptVersion !== originalLanguageServiceHost.getScriptVersion(fileName) &&
+                    scriptVersion !== FORCE_UPDATE_VERSION)
             ) {
                 return undefined;
             }
@@ -635,8 +638,16 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
             const { text, addedCode } = result;
             const snap = ts.ScriptSnapshot.fromString(text);
             snap.getChangeRange = (_) => undefined;
+
+            // If this is a new file, typescript might have cached the unpatched version 
+            // It won't update even if we return the patched version in getScriptSnapshot, so we force an update
+            // This should only happen to files that are opened by the client after the first compilation of the proxy language service
+            // and won't happen if there are any updates to the file afterwards
             this.files[fileName] = {
-                version: originalLanguageServiceHost.getScriptVersion(fileName),
+                version:
+                    this.files[fileName] === undefined
+                        ? FORCE_UPDATE_VERSION
+                        : originalLanguageServiceHost.getScriptVersion(fileName),
                 file: snap,
                 addedCode
             };

--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -639,7 +639,7 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
             const snap = ts.ScriptSnapshot.fromString(text);
             snap.getChangeRange = (_) => undefined;
 
-            // If this is a new file, typescript might have cached the unpatched version 
+            // If this is a new file, typescript might have cached the unpatched version
             // It won't update even if we return the patched version in getScriptSnapshot, so we force an update
             // This should only happen to files that are opened by the client after the first compilation of the proxy language service
             // and won't happen if there are any updates to the file afterwards


### PR DESCRIPTION
#2053

If a file is patched the first time, typescript might have cached the unpatched version. It won't update even if we return the patched version in `getScriptSnapshot`. This should only happen to files the client opens after the first compilation of the proxy language service. In the first compilation, there won't be any files in the cache. And once there are any updates TypeScript will reparse the file with the patched snapshot. 