### PR TITLE
fix: enhance precompile blank for parser error workaround

### DIFF
--- a/packages/svelte2tsx/src/utils/htmlxparser.ts
+++ b/packages/svelte2tsx/src/utils/htmlxparser.ts
@@ -163,7 +163,7 @@ function blankPossiblyErrorOperatorOrPropertyAccess(htmlx: string) {
                 }
                 htmlx =
                     htmlx.substring(0, backwardIndex) + ' ' + htmlx.substring(backwardIndex + 1);
-            } else if (!/\s/.test(char)) {
+            } else if (!/\s/.test(char) && char !== ')' && char !== ']') {
                 break;
             }
             backwardIndex--;

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-bracket/expected.error.json
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-bracket/expected.error.json
@@ -1,0 +1,16 @@
+{
+    "name": "ParseError",
+    "code": "parse-error",
+    "start": {
+        "line": 1,
+        "column": 26,
+        "character": 26
+    },
+    "end": {
+        "line": 1,
+        "column": 26,
+        "character": 26
+    },
+    "pos": 26,
+    "frame": "1: {someRecord[anotherRecord.]}\n                             ^"
+}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-bracket/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-bracket/expectedv2.js
@@ -1,0 +1,1 @@
+someRecord[anotherRecord.];

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-bracket/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-bracket/input.svelte
@@ -1,0 +1,1 @@
+{someRecord[anotherRecord.]}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-parentheses/expected.error.json
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-parentheses/expected.error.json
@@ -1,0 +1,16 @@
+{
+    "name": "ParseError",
+    "code": "parse-error",
+    "start": {
+        "line": 1,
+        "column": 16,
+        "character": 16
+    },
+    "end": {
+        "line": 1,
+        "column": 16,
+        "character": 16
+    },
+    "pos": 16,
+    "frame": "1: {console.log(''.)}\n                   ^\n2: \n3: {#await Promise.resolve(''.)}"
+}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-parentheses/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-parentheses/expectedv2.js
@@ -1,0 +1,7 @@
+console.log(''.);
+
+   { 
+
+const $$_value = await (Promise.resolve(''.));{ const value = $$_value; 
+
+}}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-parentheses/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-parentheses/input.svelte
@@ -1,0 +1,7 @@
+{console.log(''.)}
+
+{#await Promise.resolve(''.)}
+
+{:then value}
+
+{/await}


### PR DESCRIPTION
For the specific case of #2168. The blanking pre-process currently will stop whenever it encounters a char that is not something we want to blank. But it's probably safe to skip `]` and `)` and continue checking operators to blank. Haven't thought of cases where it might be not safe