### PR TITLE
feat: add a default types in the $$Generic

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/nodes/Generics.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/Generics.ts
@@ -51,13 +51,22 @@ export class Generics {
                     'Invalid $$Generic declaration: $$Generic definitions are not allowed when the generics attribute is present on the script tag'
                 );
             }
-            if (node.type.typeArguments?.length > 1) {
-                throw new Error('Invalid $$Generic declaration: Only one type argument allowed');
+            if (node.type.typeArguments?.length > 2) {
+                throw new Error('Invalid $$Generic declaration: Only two type argument allowed');
             }
-            if (node.type.typeArguments?.length === 1) {
+            if (node.type.typeArguments?.length >= 1) {
                 const typeReference = node.type.typeArguments[0].getText();
+                const defaultType = node.type.typeArguments[1]?.getText();
+
                 this.typeReferences.push(typeReference);
-                this.definitions.push(`${node.name.text} extends ${typeReference}`);
+                
+                let generic = `${node.name.text} extends ${typeReference}`;
+                
+                if (defaultType) {
+                    generic += ` = ${defaultType}`
+                }
+                
+                this.definitions.push(generic);
             } else {
                 this.definitions.push(node.name.text);
             }


### PR DESCRIPTION
Hi!✨
A common problem with $$Generic is that there was no way to set a default type

I tried to add more functionality and now it is possible to set the default type as the second argument to $$Generic

```ts
type T = $$Generic<number, 2>
interface $$Props {
    value?:T
    result?: T extends 2 ? 'AAAAAA' : 'OOOOO'
}
export let value:$$Props['value'] = 2
```

I think this will take types in svelte one step further and open up a lot of new possibilities
I can't live without default types))🥲