### PR TITLE
feat: add option to force-start svelte plugin

### DIFF
--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -24,7 +24,10 @@ Then add it to your `tsconfig.json` or `jsconfig.json`:
     "compilerOptions": {
         ...
         "plugins": [{
-            "name": "typescript-svelte-plugin"
+            "name": "typescript-svelte-plugin",
+            // the following options can be set additionally; they are optional; their default values are listed here
+            "enabled": true, // enables this plugin
+            "assumeIsSvelteProject": false // if true, skip detection and always assume it's a Svelte project
         }]
     }
 }

--- a/packages/typescript-plugin/src/config-manager.ts
+++ b/packages/typescript-plugin/src/config-manager.ts
@@ -4,12 +4,15 @@ const configurationEventName = 'configuration-changed';
 
 export interface Configuration {
     enable: boolean;
+    /** Skip the Svelte detection and assume this is a Svelte project */
+    assumeIsSvelteProject: boolean;
 }
 
 export class ConfigManager {
     private emitter = new EventEmitter();
     private config: Configuration = {
-        enable: true
+        enable: true,
+        assumeIsSvelteProject: false
     };
 
     onConfigurationChanged(listener: (config: Configuration) => void) {

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -14,7 +14,10 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
 
     function create(info: ts.server.PluginCreateInfo) {
         const logger = new Logger(info.project.projectService.logger);
-        if (!isSvelteProject(info.project.getCompilerOptions())) {
+        if (
+            !(info.config as Configuration)?.assumeIsSvelteProject &&
+            !isSvelteProject(info.project.getCompilerOptions())
+        ) {
             logger.log('Detected that this is not a Svelte project, abort patching TypeScript');
             return info.languageService;
         }


### PR DESCRIPTION
This adds the assumeIsSvelteProject project for the typescript plugin. Some editors like Intellij may use their own detection mechanisms for whether or not a plugin should run, and this allows them to do that and skip our detection mechanism.

@tomblachut does this solve your use case?