### PR TITLE
chore: remove use of soon to be deprecated method

### DIFF
--- a/packages/language-server/src/plugins/typescript/svelte-ast-utils.ts
+++ b/packages/language-server/src/plugins/typescript/svelte-ast-utils.ts
@@ -1,5 +1,5 @@
 import { Node } from 'estree';
-import { walk } from 'svelte/compiler';
+import { walk } from 'estree-walker';
 import { TemplateNode } from 'svelte/types/compiler/interfaces';
 
 export interface SvelteNode {

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -30,7 +30,6 @@
         "@types/unist": "^2.0.3",
         "@types/vfile": "^3.0.2",
         "builtin-modules": "^3.3.0",
-        "estree-walker": "^2.0.1",
         "magic-string": "^0.27.0",
         "mocha": "^9.2.0",
         "periscopic": "^2.0.2",
@@ -66,6 +65,7 @@
     ],
     "dependencies": {
         "dedent-js": "^1.0.1",
+        "estree-walker": "^2.0.1",
         "pascal-case": "^3.1.1"
     }
 }

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
@@ -1,5 +1,5 @@
 import MagicString from 'magic-string';
-import { walk } from 'svelte/compiler';
+import { walk } from 'estree-walker';
 import { TemplateNode, Text } from 'svelte/types/compiler/interfaces';
 import { Attribute, BaseNode, BaseDirective, StyleDirective, ConstTag } from '../interfaces';
 import { parseHtmlx } from '../utils/htmlxparser';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       dedent-js:
         specifier: ^1.0.1
         version: 1.0.1
+      estree-walker:
+        specifier: ^2.0.1
+        version: 2.0.2
       pascal-case:
         specifier: ^3.1.1
         version: 3.1.2
@@ -271,9 +274,6 @@ importers:
       builtin-modules:
         specifier: ^3.3.0
         version: 3.3.0
-      estree-walker:
-        specifier: ^2.0.1
-        version: 2.0.2
       magic-string:
         specifier: ^0.27.0
         version: 0.27.0


### PR DESCRIPTION
This has been removed from Svelte 5