### PR TITLE
Support Yarn PnP Imports

### DIFF
--- a/packages/svelte-vscode/README.md
+++ b/packages/svelte-vscode/README.md
@@ -64,6 +64,11 @@ This setting can only be changed in user settings for security reasons.
 You normally don't set this. Path to the language server executable. If you installed the `svelte-language-server` npm package, it's within there at `bin/server.js`. Path can be either relative to your workspace root or absolute. Set this only if you want to use a custom version of the language server. This will then also use the workspace version of TypeScript.
 This setting can only be changed in user settings for security reasons.
 
+#### `svelte.language-server.runtime-args`
+
+You normally don't set this. Additional arguments to pass to Node when spawning the language server.
+This is useful when you use something like Yarn PnP and need its loader arguments `["--loader", ".pnp.loader.mjs"]`.
+
 ##### `svelte.language-server.port`
 
 You normally don't set this. At which port to spawn the language server.
@@ -86,7 +91,7 @@ Settings to toggle specific features of the extension. The full list of all sett
 ### Usage with Yarn 2 PnP
 
 1. Run `yarn add -D svelte-language-server` to install svelte-language-server as a dev dependency
-2. Run `yarn dlx @yarnpkg/sdks vscode` to generate or update the VSCode/Yarn integration SDKs. This also sets the `svelte.language-server.ls-path` setting for the workspace, pointing it to the workspace-installed language server. Note that this requires workspace trust - else set the `svelte.language-server.ls-path` setting in your user configuration.
+2. Run `yarn dlx @yarnpkg/sdks vscode` to generate or update the VSCode/Yarn integration SDKs. This also sets the `svelte.language-server.ls-path` and `svelte.language-server.runtime-args` setting for the workspace, pointing it to the workspace-installed language server. Note that this requires workspace trust - else set the `svelte.language-server.ls-path` and `svelte.language-server.runtime-args` setting in your user configuration.
 3. Restart VSCode.
 4. Commit the changes to `.yarn/sdks`
 

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -50,7 +50,8 @@
             "supported": "limited",
             "restrictedConfigurations": [
                 "svelte.language-server.runtime",
-                "svelte.language-server.ls-path"
+                "svelte.language-server.ls-path",
+                "svelte.language-server.runtime-args"
             ],
             "description": "The extension requires workspace trust because it executes code specified by the workspace. Loading the user's node_modules and loading svelte config files is disabled when untrusted"
         }
@@ -87,6 +88,11 @@
                     "type": "string",
                     "title": "Language Server Path",
                     "description": "- You normally don't set this - Path to the language server executable. If you installed the \"svelte-language-server\" npm package, it's within there at \"bin/server.js\". Path can be either relative to your workspace root or absolute. Set this only if you want to use a custom version of the language server. This will then also use the workspace version of TypeScript. This setting can only be changed in user settings for security reasons."
+                },
+                "svelte.language-server.runtime-args": {
+                    "type": "array",
+                    "title": "Language Server Runtime Args",
+                    "description": "You normally don't set this. Additional arguments to pass to the node executable when spawning the language server. This is useful when you use something like Yarn PnP and need its loader arguments `[\"--loader\", \".pnp.loader.mjs\"]`."
                 },
                 "svelte.language-server.port": {
                     "type": "number",

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -133,12 +133,12 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
         run: {
             module: serverModule,
             transport: TransportKind.ipc,
-            options: { execArgv: runExecArgv, cwd: rootPath }
+            options: { execArgv: runExecArgv }
         },
         debug: {
             module: serverModule,
             transport: TransportKind.ipc,
-            options: { execArgv: debugArgs, cwd: rootPath }
+            options: { execArgv: debugArgs }
         }
     };
 


### PR DESCRIPTION
Resolves #1514 which describes the crux of the issue. Specifically imports in your `svelete.config.js` won't be able to resolve because they use ESM imports and Node doesn't have a loader set up.

This is my first contribution to the repo so let me know if anything doesn't fit the style etc.!

The PR itself is fairly simple but it shouldn't be merged until https://github.com/yarnpkg/berry/issues/5953 is ready as otherwise `yarn dlx @yarnpkg/sdks vscode` won't set up the VSCode setting. Arguably more importantly if the `--loader ./.pnp.loader.mjs` approach is inappropriate here I'm sure they'll let me know on that PR!