### PR TITLE
test: increase test timeout for riscv64

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -5,7 +5,7 @@
     "main": "dist/src/index.js",
     "typings": "dist/src/index",
     "scripts": {
-        "test": "cross-env TS_NODE_TRANSPILE_ONLY=true mocha --require ts-node/register \"test/**/*.ts\" --exclude \"test/**/*.d.ts\"",
+        "test": "cross-env TS_NODE_TRANSPILE_ONLY=true mocha --require ts-node/register \"test/**/*.ts\" --exclude \"test/**/*.d.ts\" --timeout 200000",
         "build": "tsc",
         "prepublishOnly": "npm run build",
         "watch": "tsc -w"

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1041,7 +1041,7 @@ describe('CompletionProviderImpl', function () {
             const item = completions?.items?.[0];
             assert.strictEqual(item?.label, 'abc');
         }
-    }).timeout(4000);
+    }).timeout(400_000);
 
     it('provides default slot-let completion for components with type definition', async () => {
         const { completionProvider, document } = setup('component-events-completion-ts-def.svelte');

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -55,7 +55,7 @@ describe('DiagnosticsProvider', function () {
 
         const diagnostics3 = await plugin.getDiagnostics(document);
         assert.deepStrictEqual(diagnostics3.length, 1);
-    }).timeout(5000);
+    }).timeout(500_000);
 
     it('notices changes of module resolution because of new file', async () => {
         const { plugin, document, lsAndTsDocResolver } = setup('unresolvedimport.svelte');
@@ -90,7 +90,7 @@ describe('DiagnosticsProvider', function () {
             unlinkSync(newTsFilePath);
             unlinkSync(newFilePath);
         }
-    }).timeout(5000);
+    }).timeout(500_000);
 
     it('notices update of imported module', async () => {
         const { plugin, document, lsAndTsDocResolver } = setup(
@@ -116,7 +116,7 @@ describe('DiagnosticsProvider', function () {
         const diagnostics2 = await plugin.getDiagnostics(document);
         assert.deepStrictEqual(diagnostics2.length, 0);
         await lsAndTsDocResolver.deleteSnapshot(newFilePath);
-    }).timeout(5000);
+    }).timeout(500_000);
 
     it('notices file changes in all services that reference that file', async () => {
         // Hacky but ensures that this tests is not interfered with by other tests
@@ -169,5 +169,5 @@ describe('DiagnosticsProvider', function () {
         assert.deepStrictEqual(diagnostics3.length, 0);
         const diagnostics4 = await plugin.getDiagnostics(otherDocument);
         assert.deepStrictEqual(diagnostics4.length, 0);
-    }).timeout(5000);
+    }).timeout(500_000);
 });

--- a/packages/language-server/test/plugins/typescript/test-utils.ts
+++ b/packages/language-server/test/plugins/typescript/test-utils.ts
@@ -255,7 +255,7 @@ export async function createJsonSnapshotFormatter(dir: string) {
 export function serviceWarmup(suite: Mocha.Suite, testDir: string, rootUri = pathToUrl(testDir)) {
     const defaultTimeout = suite.timeout();
 
-    suite.timeout(5_000);
+    suite.timeout(500_000);
     before(async () => {
         const start = Date.now();
         console.log('Warming up language service...');

--- a/packages/language-server/test/plugins/typescript/typescript-performance.test.ts
+++ b/packages/language-server/test/plugins/typescript/typescript-performance.test.ts
@@ -78,5 +78,5 @@ describe('TypeScript Plugin Performance Tests', () => {
 
             return end - start;
         }
-    }).timeout(25_000);
+    }).timeout(250_000);
 });


### PR DESCRIPTION
Some tests fails on slow RISC-V architecture.
Fix by increasing the timeout.
