### PR TITLE
chore: try fix flaky test

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -783,7 +783,7 @@ describe('CompletionProviderImpl', function () {
     async function openFileToBeImported(
         docManager: DocumentManager,
         completionProvider: CompletionsProviderImpl,
-        name = 'imported-file.svelte'
+        name = '../imported-file.svelte'
     ) {
         const filePath = join(testFilesDir, name);
         const hoverinfoDoc = docManager.openClientDocument(<any>{

--- a/packages/language-server/test/plugins/typescript/service.test.ts
+++ b/packages/language-server/test/plugins/typescript/service.test.ts
@@ -185,4 +185,33 @@ describe('service', () => {
             );
         }
     });
+
+    it('can open client file that do not exist in fs', async () => {
+        const dirPath = getRandomVirtualDirPath(testDir);
+        const { virtualSystem, lsDocumentContext, rootUris } = setup();
+
+        virtualSystem.writeFile(
+            path.join(dirPath, 'tsconfig.json'),
+            JSON.stringify({
+                compilerOptions: <ts.CompilerOptions>{
+                    checkJs: true,
+                    strict: true
+                }
+            })
+        );
+
+        const ls = await getService(
+            path.join(dirPath, 'random.svelte'),
+            rootUris,
+            lsDocumentContext
+        );
+
+        const document = new Document(pathToUrl(path.join(dirPath, 'random.ts')), '');
+        document.openedByClient = true;
+        ls.updateSnapshot(document);
+
+        assert.doesNotThrow(() => {
+            ls.getService().getSemanticDiagnostics(document.getFilePath()!);
+        });
+    });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/ScndImport.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/ScndImport.svelte
@@ -1,0 +1,1 @@
+<script></script>


### PR DESCRIPTION
https://github.com/sveltejs/svelte-ecosystem-ci/actions/runs/6845976020/job/18611980022

There are two files that don't exist that were referenced in the test. We must rely on `openClientDocument` to open them. But It seems like there is a race condition somewhere that would close it after it's opened. I'm not really sure if this is the case since I can't reproduce it locally even if I run it at least 100 times. 

If the file does exist, it'll be loaded as a project file the first time the ts service is created. And the `openClientDocument` will only be used as a failed safe. Hopefully, it will fix the problem. I also added a new test to test the language feature of the client file that doesn't exist in the file system. It's tested in a virtual system, so it should be more isolated and less likely to fail randomly. 