### PR TITLE
chore: fix flaky test for slow machines

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1041,7 +1041,7 @@ describe('CompletionProviderImpl', function () {
             const item = completions?.items?.[0];
             assert.strictEqual(item?.label, 'abc');
         }
-    }).timeout(4000);
+    });
 
     it('provides default slot-let completion for components with type definition', async () => {
         const { completionProvider, document } = setup('component-events-completion-ts-def.svelte');

--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -55,7 +55,7 @@ describe('DiagnosticsProvider', function () {
 
         const diagnostics3 = await plugin.getDiagnostics(document);
         assert.deepStrictEqual(diagnostics3.length, 1);
-    }).timeout(5000);
+    });
 
     it('notices changes of module resolution because of new file', async () => {
         const { plugin, document, lsAndTsDocResolver } = setup('unresolvedimport.svelte');
@@ -90,7 +90,7 @@ describe('DiagnosticsProvider', function () {
             unlinkSync(newTsFilePath);
             unlinkSync(newFilePath);
         }
-    }).timeout(5000);
+    });
 
     it('notices update of imported module', async () => {
         const { plugin, document, lsAndTsDocResolver } = setup(
@@ -116,7 +116,7 @@ describe('DiagnosticsProvider', function () {
         const diagnostics2 = await plugin.getDiagnostics(document);
         assert.deepStrictEqual(diagnostics2.length, 0);
         await lsAndTsDocResolver.deleteSnapshot(newFilePath);
-    }).timeout(5000);
+    });
 
     it('notices file changes in all services that reference that file', async () => {
         // Hacky but ensures that this tests is not interfered with by other tests
@@ -169,5 +169,5 @@ describe('DiagnosticsProvider', function () {
         assert.deepStrictEqual(diagnostics3.length, 0);
         const diagnostics4 = await plugin.getDiagnostics(otherDocument);
         assert.deepStrictEqual(diagnostics4.length, 0);
-    }).timeout(5000);
+    }).timeout(this.timeout() * 2.5);
 });

--- a/packages/language-server/test/plugins/typescript/test-utils.ts
+++ b/packages/language-server/test/plugins/typescript/test-utils.ts
@@ -255,7 +255,9 @@ export async function createJsonSnapshotFormatter(dir: string) {
 export function serviceWarmup(suite: Mocha.Suite, testDir: string, rootUri = pathToUrl(testDir)) {
     const defaultTimeout = suite.timeout();
 
-    suite.timeout(5_000);
+    // allow to set a higher timeout for slow machines from cli flag
+    const warmupTimeout = Math.max(defaultTimeout, 5_000);
+    suite.timeout(warmupTimeout);
     before(async () => {
         const start = Date.now();
         console.log('Warming up language service...');

--- a/packages/language-server/test/plugins/typescript/typescript-performance.test.ts
+++ b/packages/language-server/test/plugins/typescript/typescript-performance.test.ts
@@ -33,14 +33,19 @@ describe('TypeScript Plugin Performance Tests', () => {
         return { plugin, document, append, prepend };
     }
 
-    it('should be fast enough', async function () {
+    it('should be fast enough', async function() {
         const { document, plugin, append, prepend } = setup('performance.svelte');
+
+        // allow to set a higher timeout for slow machines from cli flag
+        const performanceTimeout = Math.max(this.timeout(), 25_000);
+        this.timeout(performanceTimeout);
+
         const benchmarkElapse = Math.ceil(await benchmark());
         // it usually takes around 5-6 times of the benchmark result
         // plus 1 for the benchmark itself
         const newTimeout = benchmarkElapse * 7;
 
-        if (newTimeout < this.timeout()) {
+        if (newTimeout < performanceTimeout) {
             console.log(`Benchmark took ${benchmarkElapse}ms. Setting timeout to ${newTimeout}ms`);
             this.timeout(newTimeout);
         }
@@ -78,5 +83,5 @@ describe('TypeScript Plugin Performance Tests', () => {
 
             return end - start;
         }
-    }).timeout(25_000);
+    });
 });


### PR DESCRIPTION
Some tests with random number may fail on slow RISC-V architecture.
I try to eliminate all random timeout and fallback it to command line, so that users on slow machines can set timeout in a simple way:
```
pnpm test -- --timeout 1000000
```
