### PR TITLE
perf: cancel diagnostics

### DIFF
--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -76,7 +76,10 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
         this.deferredRequests = {};
     }
 
-    async getDiagnostics(textDocument: TextDocumentIdentifier): Promise<Diagnostic[]> {
+    async getDiagnostics(
+        textDocument: TextDocumentIdentifier,
+        cancellationToken?: CancellationToken
+    ): Promise<Diagnostic[]> {
         const document = this.getDocument(textDocument.uri);
 
         if (
@@ -96,7 +99,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
         return flatten(
             await this.execute<Diagnostic[]>(
                 'getDiagnostics',
-                [document],
+                [document, cancellationToken],
                 ExecuteMode.Collect,
                 'high'
             )

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -49,7 +49,10 @@ export class SveltePlugin
 
     constructor(private configManager: LSConfigManager) {}
 
-    async getDiagnostics(document: Document): Promise<Diagnostic[]> {
+    async getDiagnostics(
+        document: Document,
+        cancellationToken?: CancellationToken
+    ): Promise<Diagnostic[]> {
         if (!this.featureEnabled('diagnostics') || !this.configManager.getIsTrusted()) {
             return [];
         }
@@ -57,7 +60,8 @@ export class SveltePlugin
         return getDiagnostics(
             document,
             await this.getSvelteDoc(document),
-            this.configManager.getConfig().svelte.compilerWarnings
+            this.configManager.getConfig().svelte.compilerWarnings,
+            cancellationToken
         );
     }
 

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -80,11 +80,23 @@ export class DiagnosticsProviderImpl implements DiagnosticsProvider {
             ];
         }
 
-        let diagnostics: ts.Diagnostic[] = [
-            ...lang.getSyntacticDiagnostics(tsDoc.filePath),
-            ...lang.getSuggestionDiagnostics(tsDoc.filePath),
-            ...lang.getSemanticDiagnostics(tsDoc.filePath)
-        ];
+        let diagnostics: ts.Diagnostic[] = lang.getSyntacticDiagnostics(tsDoc.filePath);
+        const checkers = [lang.getSuggestionDiagnostics, lang.getSemanticDiagnostics];
+
+        for (const checker of checkers) {
+            if (!cancellationToken) {
+                diagnostics.push(...checker.call(lang, tsDoc.filePath));
+                continue;
+            }
+
+            // wait a bit so the event loop can check for cancellation
+            // or let completion go first
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            if (cancellationToken.isCancellationRequested) {
+                return [];
+            }
+            diagnostics.push(...checker.call(lang, tsDoc.filePath));
+        }
 
         const additionalStoreDiagnostics: ts.Diagnostic[] = [];
         const notGenerated = isNotGenerated(tsDoc.getFullText());

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -84,16 +84,13 @@ export class DiagnosticsProviderImpl implements DiagnosticsProvider {
         const checkers = [lang.getSuggestionDiagnostics, lang.getSemanticDiagnostics];
 
         for (const checker of checkers) {
-            if (!cancellationToken) {
-                diagnostics.push(...checker.call(lang, tsDoc.filePath));
-                continue;
-            }
-
-            // wait a bit so the event loop can check for cancellation
-            // or let completion go first
-            await new Promise((resolve) => setTimeout(resolve, 10));
-            if (cancellationToken.isCancellationRequested) {
-                return [];
+            if (cancellationToken) {
+                // wait a bit so the event loop can check for cancellation
+                // or let completion go first
+                await new Promise((resolve) => setTimeout(resolve, 10));
+                if (cancellationToken.isCancellationRequested) {
+                    return [];
+                }
             }
             diagnostics.push(...checker.call(lang, tsDoc.filePath));
         }

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -353,6 +353,7 @@ export function startServer(options?: LSOptions) {
 
     connection.onDidCloseTextDocument((evt) => docManager.closeDocument(evt.textDocument.uri));
     connection.onDidChangeTextDocument((evt) => {
+        diagnosticsManager.cancelStarted(evt.textDocument.uri);
         docManager.updateDocument(evt.textDocument, evt.contentChanges);
         pluginHost.didUpdateDocument();
     });
@@ -468,7 +469,7 @@ export function startServer(options?: LSOptions) {
         refreshCrossFilesSemanticFeatures();
     }
 
-    connection.onDidSaveTextDocument(diagnosticsManager.scheduleUpdateAll);
+    connection.onDidSaveTextDocument(diagnosticsManager.scheduleUpdateAll.bind(diagnosticsManager));
     connection.onNotification('$/onDidChangeTsOrJsFile', async (e: any) => {
         const path = urlToPath(e.uri);
         if (path) {

--- a/packages/language-server/test/plugins/PluginHost.test.ts
+++ b/packages/language-server/test/plugins/PluginHost.test.ts
@@ -52,7 +52,7 @@ describe('PluginHost', () => {
         await pluginHost.getDiagnostics(textDocument);
 
         sinon.assert.calledOnce(plugin.getDiagnostics);
-        sinon.assert.calledWithExactly(plugin.getDiagnostics, document);
+        sinon.assert.calledWithExactly(plugin.getDiagnostics, document, undefined);
     });
 
     it('executes doHover on plugins', async () => {


### PR DESCRIPTION
Another part of #2179 is that TypeScript took a long time to type-check the file. When the file is ts or check-js, it'll be `getSemanticDiagnostics`, and for non-checked js, it's `getSuggestionDiagnostics`. There is probably not much we can do about it. But we can instead cancel the check when the file is updated. The cancellation can only be checked if there is an async operation. I added a small delay in the typescript check so that the update notification queue might run in that time frame. And we could return early for the svelte and typescript diagnostic. CSS and HTML are pure sync code and generally not that heavy, so it's probably not worth the overhead. 