### PR TITLE
fix: workaround for move to file refactor restriction

### DIFF
--- a/packages/typescript-plugin/src/language-service/index.ts
+++ b/packages/typescript-plugin/src/language-service/index.ts
@@ -16,6 +16,7 @@ import { decorateUpdateImports } from './update-imports';
 import { decorateLanguageServiceHost } from './host';
 import { decorateNavigateToItems } from './navigate-to-items';
 import { decorateFileReferences } from './file-references';
+import { decorateMoveToRefactoringFileSuggestions } from './move-to-file';
 
 const patchedProject = new Set<string>();
 
@@ -64,6 +65,7 @@ function decorateLanguageServiceInner(
     decorateInlayHints(ls, info, typescript, logger);
     decorateNavigateToItems(ls, snapshotManager);
     decorateFileReferences(ls, snapshotManager);
+    decorateMoveToRefactoringFileSuggestions(ls);
     decorateDispose(ls, info.project, onDispose);
     return ls;
 }

--- a/packages/typescript-plugin/src/language-service/move-to-file.ts
+++ b/packages/typescript-plugin/src/language-service/move-to-file.ts
@@ -1,8 +1,6 @@
 import type ts from 'typescript/lib/tsserverlibrary';
 
-export function decorateMoveToRefactoringFileSuggestions(
-    ls: ts.LanguageService
-): void {
+export function decorateMoveToRefactoringFileSuggestions(ls: ts.LanguageService): void {
     const getMoveToRefactoringFileSuggestions = ls.getMoveToRefactoringFileSuggestions;
 
     ls.getMoveToRefactoringFileSuggestions = (

--- a/packages/typescript-plugin/src/language-service/move-to-file.ts
+++ b/packages/typescript-plugin/src/language-service/move-to-file.ts
@@ -1,0 +1,45 @@
+import type ts from 'typescript/lib/tsserverlibrary';
+
+export function decorateMoveToRefactoringFileSuggestions(
+    ls: ts.LanguageService
+): void {
+    const getMoveToRefactoringFileSuggestions = ls.getMoveToRefactoringFileSuggestions;
+
+    ls.getMoveToRefactoringFileSuggestions = (
+        fileName,
+        positionOrRange,
+        preferences,
+        triggerReason,
+        kind
+    ) => {
+        const program = ls.getProgram();
+
+        if (!program) {
+            return getMoveToRefactoringFileSuggestions(
+                fileName,
+                positionOrRange,
+                preferences,
+                triggerReason,
+                kind
+            );
+        }
+
+        const getSourceFiles = program.getSourceFiles;
+        try {
+            // typescript currently only allows js/ts files to be moved to.
+            // Once there isn't a restriction anymore, we can remove this.
+            program.getSourceFiles = () =>
+                getSourceFiles().filter((file) => !file.fileName.endsWith('.svelte'));
+
+            return getMoveToRefactoringFileSuggestions(
+                fileName,
+                positionOrRange,
+                preferences,
+                triggerReason,
+                kind
+            );
+        } finally {
+            program.getSourceFiles = getSourceFiles;
+        }
+    };
+}


### PR DESCRIPTION
 #2222
 
When using the move to existing file refactor, TypeScript currently throws a `Debug.assert` error when any file in the program is not a supported file extension. Working around it by monkey patching the `program.getSourceFiles` method during the `getMoveToRefactoringFileSuggestions` function call. Let's hope we can convince the TypeScript team to remove this restriction, and we'll no longer need this workaround. 