### PR TITLE
perf: auto import cache

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -58,7 +58,7 @@
         "svelte-preprocess": "~5.1.0",
         "svelte2tsx": "workspace:~",
         "typescript": "^5.3.2",
-        "typescript-auto-import-cache": "^0.3.0",
+        "typescript-auto-import-cache": "^0.3.1",
         "vscode-css-languageservice": "~6.2.10",
         "vscode-html-languageservice": "~5.1.1",
         "vscode-languageserver": "8.0.2",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -58,7 +58,7 @@
         "svelte-preprocess": "~5.1.0",
         "svelte2tsx": "workspace:~",
         "typescript": "^5.3.2",
-        "typescript-auto-import-cache": "^0.3.1",
+        "typescript-auto-import-cache": "^0.3.2",
         "vscode-css-languageservice": "~6.2.10",
         "vscode-html-languageservice": "~5.1.1",
         "vscode-languageserver": "8.0.2",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -58,6 +58,7 @@
         "svelte-preprocess": "~5.1.0",
         "svelte2tsx": "workspace:~",
         "typescript": "^5.3.2",
+        "typescript-auto-import-cache": "^0.3.0",
         "vscode-css-languageservice": "~6.2.10",
         "vscode-html-languageservice": "~5.1.1",
         "vscode-languageserver": "8.0.2",

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -439,6 +439,10 @@ export class LSConfigManager {
             includeCompletionsWithObjectLiteralMethodSnippets:
                 config.suggest?.objectLiteralMethodSnippets?.enabled ?? true,
             preferTypeOnlyAutoImports: config.preferences?.preferTypeOnlyAutoImports,
+
+            // Although we don't support incompletion cache. 
+            // But this will make ts resolve the module specifier more aggressively
+            // Which also make the completion label detail show up in more cases
             allowIncompleteCompletions: true,
 
             includeInlayEnumMemberValueHints: inlayHints?.enumMemberValues?.enabled,

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -439,6 +439,7 @@ export class LSConfigManager {
             includeCompletionsWithObjectLiteralMethodSnippets:
                 config.suggest?.objectLiteralMethodSnippets?.enabled ?? true,
             preferTypeOnlyAutoImports: config.preferences?.preferTypeOnlyAutoImports,
+            allowIncompleteCompletions: true,
 
             includeInlayEnumMemberValueHints: inlayHints?.enumMemberValues?.enabled,
             includeInlayFunctionLikeReturnTypeHints: inlayHints?.functionLikeReturnTypes?.enabled,

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -440,9 +440,9 @@ export class LSConfigManager {
                 config.suggest?.objectLiteralMethodSnippets?.enabled ?? true,
             preferTypeOnlyAutoImports: config.preferences?.preferTypeOnlyAutoImports,
 
-            // Although we don't support incompletion cache. 
+            // Although we don't support incompletion cache.
             // But this will make ts resolve the module specifier more aggressively
-            // Which also make the completion label detail show up in more cases
+            // Which also makes the completion label detail show up in more cases
             allowIncompleteCompletions: true,
 
             includeInlayEnumMemberValueHints: inlayHints?.enumMemberValues?.enabled,

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -74,13 +74,10 @@ export class LSAndTSDocResolver {
             (options?.tsSystem ?? ts.sys).useCaseSensitiveFileNames
         );
 
-        this.tsSystem = this.options?.tsSystem ?? ts.sys;
+        this.tsSystem = this.wrapWithPackageJsonMonitoring(this.options?.tsSystem ?? ts.sys);
         this.globalSnapshotsManager = new GlobalSnapshotsManager(this.tsSystem);
         this.userPreferencesAccessor = { preferences: this.getTsUserPreferences() };
-        const projectService = createProjectService(
-            this.wrapWithPackageJsonMonitoring(this.tsSystem),
-            this.userPreferencesAccessor
-        );
+        const projectService = createProjectService(this.tsSystem, this.userPreferencesAccessor);
 
         configManager.onChange(() => {
             const newPreferences = this.getTsUserPreferences();

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -71,6 +71,10 @@ export class LSAndTSDocResolver {
         this.getCanonicalFileName = createGetCanonicalFileName(
             (options?.tsSystem ?? ts.sys).useCaseSensitiveFileNames
         );
+
+        configManager.onChange(() => {
+            this.configChanged = true;
+        });
     }
 
     /**
@@ -96,6 +100,8 @@ export class LSAndTSDocResolver {
     private extendedConfigCache = new Map<string, ts.ExtendedConfigCacheEntry>();
     private getCanonicalFileName: GetCanonicalFileName;
 
+    private configChanged = true;
+
     private get lsDocumentContext(): LanguageServiceDocumentContext {
         return {
             ambientTypesSource: this.options?.isSvelteCheck ? 'svelte-check' : 'svelte2tsx',
@@ -120,6 +126,11 @@ export class LSAndTSDocResolver {
         userPreferences: ts.UserPreferences;
     }> {
         const { tsDoc, lsContainer, userPreferences } = await this.getLSAndTSDocWorker(document);
+
+        if (this.configChanged) {
+            this.configChanged = false;
+            lsContainer.setUserPreferences(userPreferences);
+        }
 
         return { tsDoc, lang: lsContainer.getService(), userPreferences };
     }

--- a/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
+++ b/packages/language-server/src/plugins/typescript/LSAndTSDocResolver.ts
@@ -109,7 +109,7 @@ export class LSAndTSDocResolver {
             watchTsConfig: !!this.options?.watch,
             tsSystem: this.tsSystem,
             projectService: projectService
-        }
+        };
     }
 
     /**

--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -18,9 +18,7 @@ export class GlobalSnapshotsManager {
     private documents: FileMap<DocumentSnapshot>;
     private getCanonicalFileName: GetCanonicalFileName;
 
-    constructor(
-        private readonly tsSystem: ts.System
-    ) {
+    constructor(private readonly tsSystem: ts.System) {
         this.documents = new FileMap(tsSystem.useCaseSensitiveFileNames);
         this.getCanonicalFileName = createGetCanonicalFileName(tsSystem.useCaseSensitiveFileNames);
     }

--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -5,7 +5,6 @@ import { TextDocumentContentChangeEvent } from 'vscode-languageserver';
 import { createGetCanonicalFileName, GetCanonicalFileName, normalizePath } from '../../utils';
 import { EventEmitter } from 'events';
 import { FileMap } from '../../lib/documents/fileCollection';
-import { dirname } from 'path';
 
 type SnapshotChangeHandler = (fileName: string, newDocument: DocumentSnapshot | undefined) => void;
 
@@ -18,20 +17,12 @@ export class GlobalSnapshotsManager {
     private emitter = new EventEmitter();
     private documents: FileMap<DocumentSnapshot>;
     private getCanonicalFileName: GetCanonicalFileName;
-    private packageJsonCache: PackageJsonCache;
 
     constructor(
-        private readonly tsSystem: ts.System,
-        watchPackageJson = false
+        private readonly tsSystem: ts.System
     ) {
         this.documents = new FileMap(tsSystem.useCaseSensitiveFileNames);
         this.getCanonicalFileName = createGetCanonicalFileName(tsSystem.useCaseSensitiveFileNames);
-        this.packageJsonCache = new PackageJsonCache(
-            tsSystem,
-            watchPackageJson,
-            this.getCanonicalFileName,
-            this.updateSnapshotsInDirectory.bind(this)
-        );
     }
 
     get(fileName: string) {
@@ -93,16 +84,6 @@ export class GlobalSnapshotsManager {
 
     removeChangeListener(listener: SnapshotChangeHandler) {
         this.emitter.off('change', listener);
-    }
-
-    getPackageJson(path: string) {
-        return this.packageJsonCache.getPackageJson(path);
-    }
-
-    private updateSnapshotsInDirectory(dir: string) {
-        this.getByPrefix(dir).forEach((snapshot) => {
-            this.updateTsOrJsFile(snapshot.filePath);
-        });
     }
 }
 
@@ -267,76 +248,3 @@ export class SnapshotManager {
 }
 
 export const ignoredBuildDirectories = ['__sapper__', '.svelte-kit'];
-
-class PackageJsonCache {
-    constructor(
-        private readonly tsSystem: ts.System,
-        private readonly watchPackageJson: boolean,
-        private readonly getCanonicalFileName: GetCanonicalFileName,
-        private readonly updateSnapshotsInDirectory: (directory: string) => void
-    ) {
-        this.watchers = new FileMap(tsSystem.useCaseSensitiveFileNames);
-    }
-
-    private readonly watchers: FileMap<ts.FileWatcher>;
-
-    private packageJsonCache = new FileMap<
-        { text: string; modifiedTime: number | undefined } | undefined
-    >();
-
-    getPackageJson(path: string) {
-        if (!this.packageJsonCache.has(path)) {
-            this.packageJsonCache.set(path, this.initWatcherAndRead(path));
-        }
-
-        return this.packageJsonCache.get(path);
-    }
-
-    private initWatcherAndRead(path: string) {
-        if (this.watchPackageJson) {
-            this.tsSystem.watchFile?.(path, this.onPackageJsonWatchChange.bind(this), 3_000);
-        }
-        const exist = this.tsSystem.fileExists(path);
-
-        if (!exist) {
-            return undefined;
-        }
-
-        return this.readPackageJson(path);
-    }
-
-    private readPackageJson(path: string) {
-        return {
-            text: this.tsSystem.readFile(path) ?? '',
-            modifiedTime: this.tsSystem.getModifiedTime?.(path)?.valueOf()
-        };
-    }
-
-    private onPackageJsonWatchChange(path: string, onWatchChange: ts.FileWatcherEventKind) {
-        const dir = dirname(path);
-
-        if (onWatchChange === ts.FileWatcherEventKind.Deleted) {
-            this.packageJsonCache.delete(path);
-            this.watchers.get(path)?.close();
-            this.watchers.delete(path);
-        } else {
-            this.packageJsonCache.set(path, this.readPackageJson(path));
-        }
-
-        if (!path.includes('node_modules')) {
-            return;
-        }
-
-        setTimeout(() => {
-            this.updateSnapshotsInDirectory(dir);
-            const realPath =
-                this.tsSystem.realpath &&
-                this.getCanonicalFileName(normalizePath(this.tsSystem.realpath?.(dir)));
-
-            // pnpm
-            if (realPath && realPath !== dir) {
-                this.updateSnapshotsInDirectory(realPath);
-            }
-        }, 500);
-    }
-}

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -236,7 +236,9 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             offset,
             {
                 ...userPreferences,
-                triggerCharacter: validTriggerCharacter
+                triggerCharacter: validTriggerCharacter,
+                // Just in case, if there is a parser error. Force ts to not use the cache
+                triggerKind: tsDoc.parserError ? undefined : completionContext?.triggerKind
             },
             formatSettings
         );

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -236,7 +236,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             offset,
             {
                 ...userPreferences,
-                triggerCharacter: validTriggerCharacter,
+                triggerCharacter: validTriggerCharacter
             },
             formatSettings
         );

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -237,8 +237,6 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionEn
             {
                 ...userPreferences,
                 triggerCharacter: validTriggerCharacter,
-                // Just in case, if there is a parser error. Force ts to not use the cache
-                triggerKind: tsDoc.parserError ? undefined : completionContext?.triggerKind
             },
             formatSettings
         );

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -209,7 +209,7 @@ export function createSvelteModuleLoader(
         resolveTypeReferenceDirectiveReferences,
         mightHaveInvalidatedResolutions,
         clearPendingInvalidations,
-        getModuleResolutionCache: () => tsModuleCache,
+        getModuleResolutionCache: () => tsModuleCache
     };
 
     function resolveModuleNames(

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -208,7 +208,8 @@ export function createSvelteModuleLoader(
         resolveModuleNames,
         resolveTypeReferenceDirectiveReferences,
         mightHaveInvalidatedResolutions,
-        clearPendingInvalidations
+        clearPendingInvalidations,
+        getModuleResolutionCache: () => tsModuleCache,
     };
 
     function resolveModuleNames(

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -719,8 +719,13 @@ async function createLanguageService(
 
         dirty = false;
 
+        if (!oldProgram) {
+            changedFilesForExportCache.clear();
+            return;
+        }
+
         for (const fileName of changedFilesForExportCache) {
-            const oldFile = oldProgram?.getSourceFile(fileName);
+            const oldFile = oldProgram.getSourceFile(fileName);
             const newFile = program?.getSourceFile(fileName);
 
             // file for another tsconfig

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -804,7 +804,7 @@ async function createLanguageService(
             const inProgram = project
                 .getCurrentProgram()
                 ?.getSourceFiles()
-                .some((sf: ts.SourceFile) => sf.fileName.includes(dir));
+                .some((file) => file.fileName.includes(dir));
 
             if (inProgram) {
                 host.getModuleSpecifierCache?.().clear();

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -772,10 +772,11 @@ async function createLanguageService(
             return;
         }
 
-        const createLanguageService = (host: ts.LanguageServiceHost) =>
+        // Used by typescript-auto-import-cache to create a lean language service for package.json auto-import.
+        const createLanguageServiceForAutoImportProvider = (host: ts.LanguageServiceHost) =>
             ts.createLanguageService(host, documentRegistry);
 
-        return createProject(host, createLanguageService, {
+        return createProject(host, createLanguageServiceForAutoImportProvider, {
             compilerOptions: compilerOptions,
             projectService: projectService,
             currentDirectory: workspacePath

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -281,7 +281,7 @@ async function createLanguageService(
         resolveTypeReferenceDirectiveReferences:
             svelteModuleLoader.resolveTypeReferenceDirectiveReferences,
         hasInvalidatedResolutions: svelteModuleLoader.mightHaveInvalidatedResolutions,
-        getModuleResolutionCache: svelteModuleLoader.getModuleResolutionCache,
+        getModuleResolutionCache: svelteModuleLoader.getModuleResolutionCache
     };
 
     const documentRegistry = getOrCreateDocumentRegistry(

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -219,12 +219,7 @@ async function createLanguageService(
     // by the time they need to be accessed synchronously by DocumentSnapshots.
     await configLoader.loadConfigs(workspacePath);
 
-    const svelteModuleLoader = createSvelteModuleLoader(
-        getSnapshot,
-        compilerOptions,
-        tsSystem,
-        ts
-    );
+    const svelteModuleLoader = createSvelteModuleLoader(getSnapshot, compilerOptions, tsSystem, ts);
 
     let svelteTsPath: string;
     try {
@@ -444,8 +439,7 @@ async function createLanguageService(
         const projectFileCountAfter = projectFileAfter.length;
 
         const hasAddedOrRemoved =
-            !!project &&
-            projectFileCountAfter !== projectFileCountBefore ||
+            (!!project && projectFileCountAfter !== projectFileCountBefore) ||
             checkProjectFileUpdate(projectFileBefore, projectFileAfter);
 
         if (hasAddedOrRemoved) {
@@ -796,7 +790,7 @@ async function createLanguageService(
 
         if (project.packageJsonsForAutoImport?.has(packageJsonPath)) {
             project.moduleSpecifierCache.clear();
-            
+
             if (project.autoImportProviderHost) {
                 project.autoImportProviderHost.markAsDirty();
             }
@@ -804,7 +798,9 @@ async function createLanguageService(
 
         if (packageJsonPath.includes('node_modules')) {
             const dir = dirname(packageJsonPath);
-            const inProgram = project.getCurrentProgram()?.getSourceFiles()
+            const inProgram = project
+                .getCurrentProgram()
+                ?.getSourceFiles()
                 .some((sf: ts.SourceFile) => sf.fileName.includes(dir));
 
             if (inProgram) {

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -61,6 +61,8 @@ declare module 'typescript' {
          * that might change the module resolution results
          */
         hasInvalidatedResolutions?: (sourceFile: string) => boolean;
+
+        getModuleResolutionCache?(): ts.ModuleResolutionCache;
     }
 
     interface ResolvedModuleWithFailedLookupLocations {
@@ -278,7 +280,8 @@ async function createLanguageService(
         getNewLine: () => tsSystem.newLine,
         resolveTypeReferenceDirectiveReferences:
             svelteModuleLoader.resolveTypeReferenceDirectiveReferences,
-        hasInvalidatedResolutions: svelteModuleLoader.mightHaveInvalidatedResolutions
+        hasInvalidatedResolutions: svelteModuleLoader.mightHaveInvalidatedResolutions,
+        getModuleResolutionCache: svelteModuleLoader.getModuleResolutionCache,
     };
 
     const documentRegistry = getOrCreateDocumentRegistry(

--- a/packages/language-server/src/plugins/typescript/serviceCache.ts
+++ b/packages/language-server/src/plugins/typescript/serviceCache.ts
@@ -1,0 +1,97 @@
+// abstracting the typescript-auto-import-cache package to support our use case
+
+import {
+    ProjectService,
+    createProjectService as createProjectService50
+} from 'typescript-auto-import-cache/out/5_0/projectService';
+import { createProject as createProject50 } from 'typescript-auto-import-cache/out/5_0/project';
+import { createProject as createProject53 } from 'typescript-auto-import-cache/out/5_3/project';
+import ts from 'typescript';
+import { ExportInfoMap } from 'typescript-auto-import-cache/out/5_0/exportInfoMap';
+import { ModuleSpecifierCache } from 'typescript-auto-import-cache/out/5_0/moduleSpecifierCache';
+import { SymlinkCache } from 'typescript-auto-import-cache/out/5_0/symlinkCache';
+import { ProjectPackageJsonInfo } from 'typescript-auto-import-cache/out/5_0/packageJsonCache';
+
+export { ProjectService };
+
+declare module 'typescript' {
+    interface LanguageServiceHost {
+        /** @internal */ getCachedExportInfoMap?(): ExportInfoMap;
+        /** @internal */ getModuleSpecifierCache?(): ModuleSpecifierCache;
+        /** @internal */ getGlobalTypingsCacheLocation?(): string | undefined;
+        /** @internal */ getSymlinkCache?(files: readonly ts.SourceFile[]): SymlinkCache;
+        /** @internal */ getPackageJsonsVisibleToFile?(
+            fileName: string,
+            rootDir?: string
+        ): readonly ProjectPackageJsonInfo[];
+        /** @internal */ getPackageJsonAutoImportProvider?(): ts.Program | undefined;
+        /** @internal */ useSourceOfProjectReferenceRedirect?(): boolean;
+    }
+}
+
+export function createProjectService(
+    system: ts.System,
+    hostConfiguration: {
+        preferences: ts.UserPreferences;
+    }
+) {
+    const version = ts.version.split('.');
+    const major = parseInt(version[0]);
+
+    if (major < 5) {
+        return undefined;
+    }
+
+    const projectService = createProjectService50(
+        ts,
+        system,
+        system.getCurrentDirectory(),
+        hostConfiguration,
+        ts.LanguageServiceMode.Semantic
+    );
+
+    return projectService;
+}
+
+export function createProject(
+    host: ts.LanguageServiceHost,
+    createLanguageService: (host: ts.LanguageServiceHost) => ts.LanguageService,
+    options: {
+        projectService: ProjectService;
+        compilerOptions: ts.CompilerOptions;
+        currentDirectory: string;
+    }
+) {
+    const version = ts.version.split('.');
+    const major = parseInt(version[0]);
+    const minor = parseInt(version[1]);
+
+    if (major < 5) {
+        return undefined;
+    }
+
+    const factory = minor < 3 ? createProject50 : createProject53;
+    const project = factory(ts, host, createLanguageService, options);
+
+    const proxyMethods: (keyof typeof project)[] = [
+        'getCachedExportInfoMap',
+        'getModuleSpecifierCache',
+        'getGlobalTypingsCacheLocation',
+        'getSymlinkCache',
+        'getPackageJsonsVisibleToFile',
+        'getPackageJsonAutoImportProvider',
+        'includePackageJsonAutoImports',
+        'useSourceOfProjectReferenceRedirect'
+    ];
+    proxyMethods.forEach((key) => ((host as any)[key] = project[key].bind(project)));
+    
+    if (host.log) {
+        project.log = host.log.bind(host);
+    }
+
+    return project;
+
+    function ensureTrailDirSeparator(path: string) {
+        return path.endsWith('/') ? path : path + '/';
+    }
+}

--- a/packages/language-server/src/plugins/typescript/serviceCache.ts
+++ b/packages/language-server/src/plugins/typescript/serviceCache.ts
@@ -84,7 +84,7 @@ export function createProject(
         'useSourceOfProjectReferenceRedirect'
     ];
     proxyMethods.forEach((key) => ((host as any)[key] = project[key].bind(project)));
-    
+
     if (host.log) {
         project.log = host.log.bind(host);
     }

--- a/packages/language-server/src/plugins/typescript/serviceCache.ts
+++ b/packages/language-server/src/plugins/typescript/serviceCache.ts
@@ -90,8 +90,4 @@ export function createProject(
     }
 
     return project;
-
-    function ensureTrailDirSeparator(path: string) {
-        return path.endsWith('/') ? path : path + '/';
-    }
 }

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1545,7 +1545,7 @@ describe('CompletionProviderImpl', function () {
         const item = completions?.items.find((item) => item.label === '$store');
 
         assert.ok(item);
-        assert.equal(item?.data?.source?.endsWith('completions/to-import'), true);
+        assert.equal(item?.data?.source?.endsWith('/to-import'), true);
 
         const { data, ...itemWithoutData } = item;
 
@@ -1558,7 +1558,9 @@ describe('CompletionProviderImpl', function () {
             insertTextFormat: undefined,
             commitCharacters: ['.', ',', ';', '('],
             textEdit: undefined,
-            labelDetails: undefined
+            labelDetails: {
+                description: './to-import'
+            }
         });
 
         const { detail } = await completionProvider.resolveCompletion(document, item);

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1378,6 +1378,88 @@ describe('CompletionProviderImpl', function () {
         assert.strictEqual(detail, 'Add import from "random-package2"\n\nfunction foo(): string');
     });
 
+    it('can auto import package not in the program', async () => {
+        const virtualTestDir = getRandomVirtualDirPath(testFilesDir);
+        const { document, lsAndTsDocResolver, lsConfigManager, virtualSystem } =
+            setupVirtualEnvironment({
+                filename: 'index.svelte',
+                fileContent: '<script>b</script>',
+                testDir: virtualTestDir
+            });
+
+        const mockPackageDir = join(virtualTestDir, 'node_modules', 'random-package');
+
+        virtualSystem.writeFile(
+            join(virtualTestDir, 'package.json'),
+            JSON.stringify({
+                dependencies: {
+                    'random-package': '*'
+                }
+            })
+        );
+
+        virtualSystem.writeFile(
+            join(mockPackageDir, 'package.json'),
+            JSON.stringify({
+                name: 'random-package',
+                version: '1.0.0'
+            })
+        );
+
+        virtualSystem.writeFile(
+            join(mockPackageDir, 'index.d.ts'),
+            'export function bar(): string'
+        );
+
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, lsConfigManager);
+
+        const completions = await completionProvider.getCompletions(document, {
+            line: 0,
+            character: 9
+        });
+        const item = completions?.items.find((item) => item.label === 'bar');
+
+        const { detail } = await completionProvider.resolveCompletion(document, item!);
+
+        assert.strictEqual(detail, 'Add import from "random-package"\n\nfunction bar(): string');
+    });
+
+    it('can auto import new file', async () => {
+        const virtualTestDir = getRandomVirtualDirPath(testFilesDir);
+        const { document, lsAndTsDocResolver, lsConfigManager, docManager } =
+            setupVirtualEnvironment({
+                filename: 'index.svelte',
+                fileContent: '<script>b</script>',
+                testDir: virtualTestDir
+            });
+
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, lsConfigManager);
+
+        const completions = await completionProvider.getCompletions(document, {
+            line: 0,
+            character: 9
+        });
+
+        const item = completions?.items.find((item) => item.label === 'Bar');
+
+        assert.equal(item, undefined);
+
+        docManager.openClientDocument({
+            text: '',
+            uri: pathToUrl(join(virtualTestDir, 'Bar.svelte'))
+        });
+
+        const completions2 = await completionProvider.getCompletions(document, {
+            line: 0,
+            character: 9
+        });
+
+        const item2 = completions2?.items.find((item) => item.label === 'Bar');
+        const { detail } = await completionProvider.resolveCompletion(document, item2!);
+
+        assert.strictEqual(detail, 'Add import from "./Bar.svelte"\n\nclass Bar');
+    });
+
     it('provides completions for object literal member', async () => {
         const { completionProvider, document } = setup('object-member.svelte');
 

--- a/packages/language-server/test/plugins/typescript/service.test.ts
+++ b/packages/language-server/test/plugins/typescript/service.test.ts
@@ -27,7 +27,8 @@ describe('service', () => {
             tsSystem: virtualSystem,
             watchTsConfig: false,
             notifyExceedSizeLimit: undefined,
-            onProjectReloaded: undefined
+            onProjectReloaded: undefined,
+            projectService: undefined
         };
 
         const rootUris = [pathToUrl(testDir)];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^5.3.2
         version: 5.3.2
       typescript-auto-import-cache:
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.3.2
+        version: 0.3.2
       vscode-css-languageservice:
         specifier: ~6.2.10
         version: 6.2.10
@@ -1927,8 +1927,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /typescript-auto-import-cache@0.3.1:
-    resolution: {integrity: sha512-ujC5E2gT3Sf3Dzfg5QYgb8NkZNxFQI12W6rk5U/TbkDFXyvIb9YENic+hsNoVDmKEmlRTUjRRD8RCjLMIx1rxg==}
+  /typescript-auto-import-cache@0.3.2:
+    resolution: {integrity: sha512-+laqe5SFL1vN62FPOOJSUDTZxtgsoOXjneYOXIpx5rQ4UMiN89NAtJLpqLqyebv9fgQ/IMeeTX+mQyRnwvJzvg==}
     dependencies:
       semver: 7.5.1
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^5.3.2
         version: 5.3.2
       typescript-auto-import-cache:
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.1
       vscode-css-languageservice:
         specifier: ~6.2.10
         version: 6.2.10
@@ -1927,8 +1927,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /typescript-auto-import-cache@0.3.0:
-    resolution: {integrity: sha512-Rq6/q4O9iyqUdjvOoyas7x/Qf9nWUMeqpP3YeTaLA+uECgfy5wOhfOS+SW/+fZ/uI/ZcKaf+2/ZhFzXh8xfofQ==}
+  /typescript-auto-import-cache@0.3.1:
+    resolution: {integrity: sha512-ujC5E2gT3Sf3Dzfg5QYgb8NkZNxFQI12W6rk5U/TbkDFXyvIb9YENic+hsNoVDmKEmlRTUjRRD8RCjLMIx1rxg==}
     dependencies:
       semver: 7.5.1
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
+      typescript-auto-import-cache:
+        specifier: ^0.3.0
+        version: 0.3.0
       vscode-css-languageservice:
         specifier: ~6.2.10
         version: 6.2.10
@@ -1923,6 +1926,12 @@ packages:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
     dev: true
+
+  /typescript-auto-import-cache@0.3.0:
+    resolution: {integrity: sha512-Rq6/q4O9iyqUdjvOoyas7x/Qf9nWUMeqpP3YeTaLA+uECgfy5wOhfOS+SW/+fZ/uI/ZcKaf+2/ZhFzXh8xfofQ==}
+    dependencies:
+      semver: 7.5.1
+    dev: false
 
   /typescript@5.3.2:
     resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}


### PR DESCRIPTION
#2232 #2193

Implementing TypeScript's internal APIs for cache with the help of Volar's typescript-auto-import-cache. It also adopted the packag.json auto-import added in TS 4.0 for TSServer. The package.json auto-import has some limitations, though. It only works for dependencies and not dev dependencies. And it seems like the first dependencies also don't work until a server restarts. This also happens in ts/js files.

For implementation, the original text-based package.json cache was removed and now relies on typescript-auto-import-cache and ts.ModuleResolutionCache for the cache, and we only watch the files for invalidation.

The reason I didn't use the default API of typescript-auto-import-cache is that there is some memory leak with the implementation. One is that an old program object is stored, and the other is that there is no API to clear the project object stored in a map during the tsconfig update. The former is a bit hard to fix without changing the public API. But we definitely will need to try to resolve this when we eventually migrate to Volar. The `projectService` object also caused problems with the virtual file system test because it is a singleton with the `ts.sys` passed in earlier. It should not be a problem if we handle this by ourselves. 

Although migrating to Volar, which also uses `typescript-auto-import-cache`, also improves the auto import performance, it seems like we'll still need to put a lot of work into migrating existing post-processing and extra features for Volar. So, it probably still makes sense to add this now. 
