### PR TITLE
feat: zero effort typings for `reroute`

### DIFF
--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -443,6 +443,7 @@ export class JSOrTSDocumentSnapshot extends IdentityMapper implements DocumentSn
     private paramsPath = 'src/params';
     private serverHooksPath = 'src/hooks.server';
     private clientHooksPath = 'src/hooks.client';
+    private universalHooksPath = 'src/hooks';
 
     private openedByClient = false;
 
@@ -578,7 +579,8 @@ export class JSOrTSDocumentSnapshot extends IdentityMapper implements DocumentSn
             {
                 clientHooksPath: this.clientHooksPath,
                 paramsPath: this.paramsPath,
-                serverHooksPath: this.serverHooksPath
+                serverHooksPath: this.serverHooksPath,
+                universalHooksPath: this.universalHooksPath
             },
             () => this.createSource(),
             surroundWithIgnoreComments
@@ -596,6 +598,7 @@ export class JSOrTSDocumentSnapshot extends IdentityMapper implements DocumentSn
                 this.paramsPath ||= files.params;
                 this.serverHooksPath ||= files.hooks?.server;
                 this.clientHooksPath ||= files.hooks?.client;
+                this.universalHooksPath ||= files.hooks?.universal;
             }
         }
 

--- a/packages/svelte2tsx/index.d.ts
+++ b/packages/svelte2tsx/index.d.ts
@@ -135,16 +135,11 @@ export const internalHelpers: {
         options: InternalHelpers.KitFilesSettings
     ) => boolean;
     isKitRouteFile: (basename: string) => boolean,
-    isClientHooksFile: (
+    isHooksFile: (
         fileName: string,
         basename: string,
-        clientHooksPath: string
-    ) =>boolean,
-    isServerHooksFile: (
-        fileName: string,
-        basename: string,
-        serverHooksPath: string
-    )=> boolean,
+        hooksPath: string
+    ) => boolean,
     isParamsFile: (fileName: string, basename: string, paramsPath: string) =>boolean,
     upsertKitFile: (
         _ts: typeof ts,
@@ -185,6 +180,7 @@ export namespace InternalHelpers {
     export interface KitFilesSettings {
         serverHooksPath: string;
         clientHooksPath: string;
+        universalHooksPath: string;
         paramsPath: string;
     }
 }

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -1,6 +1,6 @@
 {
     "name": "svelte2tsx",
-    "version": "0.6.8",
+    "version": "0.7.0",
     "description": "Convert Svelte components to TSX for type checking",
     "author": "David Pershouse",
     "license": "MIT",

--- a/packages/svelte2tsx/src/helpers/index.ts
+++ b/packages/svelte2tsx/src/helpers/index.ts
@@ -1,9 +1,8 @@
 import {
-    isClientHooksFile,
+    isHooksFile,
     isKitFile,
     isKitRouteFile,
     isParamsFile,
-    isServerHooksFile,
     toOriginalPos,
     toVirtualPos,
     upsertKitFile
@@ -19,8 +18,7 @@ import { findExports } from './typescript';
 export const internalHelpers = {
     isKitFile,
     isKitRouteFile,
-    isClientHooksFile,
-    isServerHooksFile,
+    isHooksFile,
     isParamsFile,
     upsertKitFile,
     toVirtualPos,

--- a/packages/svelte2tsx/test/helpers/index.ts
+++ b/packages/svelte2tsx/test/helpers/index.ts
@@ -11,7 +11,8 @@ describe('Internal Helpers - upsertKitFile', () => {
             {
                 clientHooksPath: 'hooks.client',
                 paramsPath: 'params',
-                serverHooksPath: 'hooks.server'
+                serverHooksPath: 'hooks.server',
+                universalHooksPath: 'hooks'
             },
             () => sourceFile
         );

--- a/packages/typescript-plugin/src/language-service/diagnostics.ts
+++ b/packages/typescript-plugin/src/language-service/diagnostics.ts
@@ -183,7 +183,8 @@ function getKitDiagnostics<
                         messageText: `Invalid export '${exportName}' (valid exports are ${validExports.join(
                             ', '
                         )}, or anything with a '_' prefix)`,
-                        category: ts.DiagnosticCategory.Error,
+                        // make it a warning in case people are stuck on old versions and new exports are added to SvelteKit
+                        category: ts.DiagnosticCategory.Warning,
                         code: 71001 // arbitrary
                     });
                 }

--- a/packages/typescript-plugin/src/language-service/hover.ts
+++ b/packages/typescript-plugin/src/language-service/hover.ts
@@ -26,10 +26,8 @@ export function decorateHover(
         const node = source && findNodeAtPosition(source, virtualPos);
         if (node && isTopLevelExport(ts, node, source) && ts.isIdentifier(node)) {
             const name = node.text;
-            if (name in kitExports) {
-                quickInfo.documentation = !quickInfo.documentation?.length
-                    ? kitExports[name].documentation
-                    : quickInfo.documentation;
+            if (name in kitExports && !quickInfo.documentation?.length) {
+                quickInfo.documentation = kitExports[name].documentation;
             }
         }
 

--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -479,6 +479,19 @@ export const kitExports: Record<
                 kind: 'text'
             }
         ]
+    },
+    reroute: {
+        allowedIn: [],
+        displayParts: [],
+        documentation: [
+            {
+                text:
+                    `This function allows you to change how URLs are translated into routes. ` +
+                    `The returned pathname (which defaults to url.pathname) is used to select the route and its parameters. ` +
+                    `More info: https://kit.svelte.dev/docs/hooks#universal-hooks-reroute`,
+                kind: 'text'
+            }
+        ]
     }
 };
 
@@ -505,6 +518,13 @@ export function isKitRouteExportAllowedIn(
     );
 }
 
+const kitFilesSettings: InternalHelpers.KitFilesSettings = {
+    paramsPath: 'src/params',
+    clientHooksPath: 'src/hooks.client',
+    serverHooksPath: 'src/hooks.server',
+    universalHooksPath: 'src/hooks'
+};
+
 function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, logger?: Logger) {
     const cachedProxiedLanguageService = cache.get(info);
     if (cachedProxiedLanguageService !== undefined) {
@@ -521,37 +541,42 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
 
     class ProxiedLanguageServiceHost implements ts.LanguageServiceHost {
         private files: Record<string, KitSnapshot> = {};
-        paramsPath = 'src/params';
-        serverHooksPath = 'src/hooks.server';
-        clientHooksPath = 'src/hooks.client';
-        universalHooksPath = 'src/hooks';
 
         constructor() {
-            const configPath = info.project.getCurrentDirectory() + '/svelte.config.js';
-            import(configPath)
-                .then((module) => {
-                    const config = module.default;
-                    if (config.kit && config.kit.files) {
-                        if (config.kit.files.params) {
-                            this.paramsPath = config.kit.files.params;
-                        }
-                        if (config.kit.files.hooks) {
-                            this.serverHooksPath ||= config.kit.files.hooks.server;
-                            this.clientHooksPath ||= config.kit.files.hooks.client;
-                            this.universalHooksPath ||= config.kit.files.hooks.universal;
-                        }
-                        // We could be more sophisticated with only removing the files that are actually
-                        // wrong but this is good enough given how rare it is that this setting is used
-                        Object.keys(this.files)
-                            .filter((name) => {
-                                return !name.includes('src/hooks') && !name.includes('src/params');
-                            })
-                            .forEach((name) => {
-                                delete this.files[name];
-                            });
-                    }
-                })
-                .catch(() => {});
+            // This never worked due to configPath being the wrong format and due to https://github.com/microsoft/TypeScript/issues/43329 .
+            // Noone has complained about this not working, so this is commented out for now, revisit if it ever comes up.
+            // const configPath = info.project.getCurrentDirectory() + '/svelte.config.js';
+            // (import(configPath)) as Promise<any>)
+            //     .then((module) => {
+            //         const config = module.default;
+            //         if (config.kit && config.kit.files) {
+            //             if (config.kit.files.params) {
+            //                 this.paramsPath = config.kit.files.params;
+            //             }
+            //             if (config.kit.files.hooks) {
+            //                 this.serverHooksPath ||= config.kit.files.hooks.server;
+            //                 this.clientHooksPath ||= config.kit.files.hooks.client;
+            //                 this.universalHooksPath ||= config.kit.files.hooks.universal;
+            //             }
+            //             logger?.log(
+            //                 `Using SvelteKit files config: ${JSON.stringify(
+            //                     config.kit.files.hooks
+            //                 )}`
+            //             );
+            //             // We could be more sophisticated with only removing the files that are actually
+            //             // wrong but this is good enough given how rare it is that this setting is used
+            //             Object.keys(this.files)
+            //                 .filter((name) => {
+            //                     return !name.includes('src/hooks') && !name.includes('src/params');
+            //                 })
+            //                 .forEach((name) => {
+            //                     delete this.files[name];
+            //                 });
+            //         }
+            //     })
+            //     .catch((e) => {
+            //         logger?.log('error loading SvelteKit file', e);
+            //     });
         }
 
         log() {}
@@ -627,12 +652,7 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
             const result = internalHelpers.upsertKitFile(
                 ts,
                 fileName,
-                {
-                    clientHooksPath: this.clientHooksPath,
-                    paramsPath: this.paramsPath,
-                    serverHooksPath: this.serverHooksPath,
-                    universalHooksPath: this.universalHooksPath
-                },
+                kitFilesSettings,
                 () => info.languageService.getProgram()?.getSourceFile(fileName)
             );
             if (!result) {
@@ -708,7 +728,7 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
     const languageServiceHost = new ProxiedLanguageServiceHost();
     const languageService = ts.createLanguageService(
         languageServiceHost,
-        createProxyRegistry(ts, originalLanguageServiceHost, languageServiceHost)
+        createProxyRegistry(ts, originalLanguageServiceHost, kitFilesSettings)
     );
     cache.set(info, { languageService, languageServiceHost });
     return {

--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -630,7 +630,7 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
                 {
                     clientHooksPath: this.clientHooksPath,
                     paramsPath: this.paramsPath,
-                    serverHooksPath: this.serverHooksPath
+                    serverHooksPath: this.serverHooksPath,
                     universalHooksPath: this.universalHooksPath
                 },
                 () => info.languageService.getProgram()?.getSourceFile(fileName)

--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -524,6 +524,7 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
         paramsPath = 'src/params';
         serverHooksPath = 'src/hooks.server';
         clientHooksPath = 'src/hooks.client';
+        universalHooksPath = 'src/hooks';
 
         constructor() {
             const configPath = info.project.getCurrentDirectory() + '/svelte.config.js';
@@ -537,6 +538,7 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
                         if (config.kit.files.hooks) {
                             this.serverHooksPath ||= config.kit.files.hooks.server;
                             this.clientHooksPath ||= config.kit.files.hooks.client;
+                            this.universalHooksPath ||= config.kit.files.hooks.universal;
                         }
                         // We could be more sophisticated with only removing the files that are actually
                         // wrong but this is good enough given how rare it is that this setting is used
@@ -629,6 +631,7 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
                     clientHooksPath: this.clientHooksPath,
                     paramsPath: this.paramsPath,
                     serverHooksPath: this.serverHooksPath
+                    universalHooksPath: this.universalHooksPath
                 },
                 () => info.languageService.getProgram()?.getSourceFile(fileName)
             );


### PR DESCRIPTION
Related to https://github.com/sveltejs/kit/pull/11537 Also turns the error on unknown exports into a warning - people could be stuck on old versions of language tools while new features are added, and SvelteKit will throw a dev time error anyway