### PR TITLE
feat: support rename/find reference for `$props()`

### DIFF
--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-best-effort-types/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-best-effort-types/expectedv2.ts
@@ -1,10 +1,10 @@
 ///<reference types="svelte" />
 ;function render() {
 
-    let/** @type {{ a: unknown, b?: boolean, c?: number, d?: string, e?: unknown, f?: unknown, g?: typeof foo }} */ { a, b = true, c = 1, d = '', e = null, f = {}, g = foo } = $props(); 
+    let/** @typedef {{ a: unknown, b?: boolean, c?: number, d?: string, e?: unknown, f?: unknown, g?: typeof foo }} $$_sveltets_Props *//** @type {$$_sveltets_Props} */ { a, b = true, c = 1, d = '', e = null, f = {}, g = foo } = $props(); 
 ;
 async () => {};
-return { props: /** @type {{ a: unknown, b?: boolean, c?: number, d?: string, e?: unknown, f?: unknown, g?: typeof foo }} */({}), slots: {}, events: {} }}
+return { props: /** @type {$$_sveltets_Props} */({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-looking-like-stores/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-looking-like-stores/expectedv2.ts
@@ -1,14 +1,14 @@
 ///<reference types="svelte" />
 ;function render() {
 
-    let/** @type {{ props: unknown }} */ { props } = $props();
+    let/** @typedef {{ props: unknown }} $$_sveltets_Props *//** @type {$$_sveltets_Props} */ { props } = $props();
     let state = $state(0);
     let derived = $derived(state * 2);
 ;
 async () => {
 
 state; derived;};
-return { props: /** @type {{ props: unknown }} */({}), slots: {}, events: {} }}
+return { props: /** @type {$$_sveltets_Props} */({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event(render()))) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune-no-changes/+page.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune-no-changes/+page.svelte
@@ -1,4 +1,6 @@
 <script>
+    /** @type {{form: boolean, data: true }} */
     let { form, data } = $props();
+    /** @type {any} */
     export const snapshot = {};
 </script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune-no-changes/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune-no-changes/expectedv2.ts
@@ -1,0 +1,14 @@
+///<reference types="svelte" />
+;function render() {
+
+    /** @typedef {{form: boolean, data: true }}  $$_sveltets_Props *//** @type {$$_sveltets_Props} */
+    let { form, data } = $props();
+    /** @type {any} */
+     const snapshot = {};
+;
+async () => {};
+return { props: /** @type {$$_sveltets_Props} */({}), slots: {}, events: {} }}
+
+export default class Page__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(['snapshot'], __sveltets_2_with_any_event(render()))) {
+    get snapshot() { return __sveltets_2_nonNullable(this.$$prop_def.snapshot) }
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune/expectedv2.ts
@@ -3,12 +3,9 @@
 
     let/** @type {{ data: import('./$types.js').PageData, form: import('./$types.js').ActionData }} */ { form, data } = $props();
      const snapshot/*Ωignore_startΩ*/: import('./$types.js').Snapshot/*Ωignore_endΩ*/ = {};
-
-    /** @type {{form: boolean, data: true }} */
-    let { form, data } = $props();
 ;
 async () => {};
-return { props: /** @type {{form: boolean, data: true }} */({}), slots: {}, events: {} }}
+return { props: /** @type {{ data: import('./$types.js').PageData, form: import('./$types.js').ActionData }} */({}), slots: {}, events: {} }}
 
 export default class Page__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(['snapshot'], __sveltets_2_with_any_event(render()))) {
     get snapshot() { return __sveltets_2_nonNullable(this.$$prop_def.snapshot) }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-best-effort-types/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-best-effort-types/expectedv2.ts
@@ -1,10 +1,10 @@
 ///<reference types="svelte" />
 ;function render() {
-
-    let { a, b = true, c = 1, d = '', e = null, f = {}, g = foo, h = null as Bar, i = null as any as Baz } = $props/*Ωignore_startΩ*/<{ a: unknown, b?: boolean, c?: number, d?: string, e?: unknown, f?: unknown, g?: typeof foo, h?: Bar, i?: Baz }>/*Ωignore_endΩ*/(); 
+/*Ωignore_startΩ*/;type $$_sveltets_Props = { a: unknown, b?: boolean, c?: number, d?: string, e?: unknown, f?: unknown, g?: typeof foo, h?: Bar, i?: Baz };/*Ωignore_endΩ*/
+    let { a, b = true, c = 1, d = '', e = null, f = {}, g = foo, h = null as Bar, i = null as any as Baz } = $props<$$_sveltets_Props>(); 
 ;
 async () => {};
-return { props: {} as any as { a: unknown, b?: boolean, c?: number, d?: string, e?: unknown, f?: unknown, g?: typeof foo, h?: Bar, i?: Baz }, slots: {}, events: {} }}
+return { props: {} as any as $$_sveltets_Props, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-generics/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-generics/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render() {
-
-    let { a, b } = $props<{ a: number, b: string }>();
+;type $$_sveltets_Props = { a: number, b: string };
+    let { a, b } = $props<$$_sveltets_Props>();
     let x = $state(0);
     let y = $derived(x * 2);
 
@@ -9,7 +9,7 @@
 async () => {
 
  { __sveltets_createSlot("default", {  x,y,});}};
-return { props: {} as any as { a: number, b: string }, slots: {'default': {x:x, y:y}}, events: {} }}
+return { props: {} as any as $$_sveltets_Props, slots: {'default': {x:x, y:y}}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function render<T>() {
-
-    let { a, b } = $props<{ a: T, b: string }>();
+;type $$_sveltets_Props = { a: T, b: string };
+    let { a, b } = $props<$$_sveltets_Props>();
     let x = $state<T>(0);
     let y = $derived(x * 2);
 
@@ -9,7 +9,7 @@
 async () => {
 
  { __sveltets_createSlot("default", {  x,y,});}};
-return { props: {} as any as { a: T, b: string }, slots: {'default': {x:x, y:y}}, events: {} }}
+return { props: {} as any as $$_sveltets_Props, slots: {'default': {x:x, y:y}}, events: {} }}
 class __sveltets_Render<T> {
     props() {
         return render<T>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune-unchanged/+page.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune-unchanged/+page.svelte
@@ -1,0 +1,4 @@
+<script>
+    export const snapshot: any = {};
+    let { form, data } = $props<{form: boolean, data: true }>();
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune-unchanged/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune-unchanged/expectedv2.ts
@@ -1,0 +1,12 @@
+///<reference types="svelte" />
+;function render() {
+
+     const snapshot: any = {};;type $$_sveltets_Props = {form: boolean, data: true };
+    let { form, data } = $props<$$_sveltets_Props>();
+;
+async () => {};
+return { props: {} as any as $$_sveltets_Props & { snapshot?: any }, slots: {}, events: {} }}
+
+export default class Page__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
+    get snapshot() { return __sveltets_2_nonNullable(this.$$prop_def.snapshot) }
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune/+page.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune/+page.svelte
@@ -1,6 +1,4 @@
 <script>
-    let { form, data } = $props();
     export const snapshot = {};
-
-    let { form, data } = $props<{form: boolean, data: true }>();
+    let { form, data } = $props();
 </script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune/expectedv2.ts
@@ -1,13 +1,11 @@
 ///<reference types="svelte" />
 ;function render() {
 
-    let { form, data } = $props/*Ωignore_startΩ*/<{ data: import('./$types.js').PageData, form: import('./$types.js').ActionData }>/*Ωignore_endΩ*/();
      const snapshot/*Ωignore_startΩ*/: import('./$types.js').Snapshot/*Ωignore_endΩ*/ = {};
-
-    let { form, data } = $props<{form: boolean, data: true }>();
+    let { form, data } = $props/*Ωignore_startΩ*/<{ data: import('./$types.js').PageData, form: import('./$types.js').ActionData }>/*Ωignore_endΩ*/();
 ;
 async () => {};
-return { props: {} as any as {form: boolean, data: true } & { snapshot?: typeof snapshot }, slots: {}, events: {} }}
+return { props: {} as any as { data: import('./$types.js').PageData, form: import('./$types.js').ActionData } & { snapshot?: typeof snapshot }, slots: {}, events: {} }}
 
 export default class Page__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
     get snapshot() { return __sveltets_2_nonNullable(this.$$prop_def.snapshot) }


### PR DESCRIPTION
Generate a virtual type that is reused for the type/generics and the generated props type which makes renaming/find references etc "just work" without additional code in the language server
#2253

While implementing this I discovered a TS bug which I've reported here https://github.com/microsoft/TypeScript/issues/57022