### PR TITLE
fix: map optionalReplacementSpan for typescript-language-server

### DIFF
--- a/packages/typescript-plugin/src/language-service/completions.ts
+++ b/packages/typescript-plugin/src/language-service/completions.ts
@@ -40,6 +40,13 @@ export function decorateCompletions(
                     }
                     return c;
                 });
+
+                if (completions.optionalReplacementSpan) {
+                    completions.optionalReplacementSpan = {
+                        ...completions.optionalReplacementSpan,
+                        start: toOriginalPos(completions.optionalReplacementSpan.start).pos
+                    };
+                }
             }
         }
 


### PR DESCRIPTION
#2251 For typescript plugin

The reason is that `ts.CompletionInfo.optionalReplacementSpan` is still generated position, and the typescript-language-server used it to create TextEdit, but the position doesn't exist. Neovim probably filters it out because it is invalid. VSCode doesn't use `ts.CompletionInfo.optionalReplacementSpan`, so we never map it.

https://github.com/typescript-language-server/typescript-language-server/blob/80ef6149cd64b9859e402adb1ca3e7c410ab52b5/src/lsp-server.ts#L529
https://github.com/typescript-language-server/typescript-language-server/blob/80ef6149cd64b9859e402adb1ca3e7c410ab52b5/src/completion.ts#L154
