### PR TITLE
fix: prevent completion using empty cache

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -719,7 +719,10 @@ async function createLanguageService(
 
         dirty = false;
 
-        if (!oldProgram) {
+        // host.getCachedExportInfoMap will create the cache if it doesn't exist
+        // so we need to check the property instead
+        const cache = project?.exportMapCache;
+        if (!oldProgram || !cache || cache.isEmpty()) {
             changedFilesForExportCache.clear();
             return;
         }
@@ -734,10 +737,10 @@ async function createLanguageService(
             }
 
             if (oldFile && newFile) {
-                host.getCachedExportInfoMap?.().onFileChanged?.(oldFile, newFile, false);
+                cache.onFileChanged?.(oldFile, newFile, false);
             } else {
                 // new file or deleted file
-                host.getCachedExportInfoMap?.().clear();
+                cache.clear();
             }
         }
         changedFilesForExportCache.clear();

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -719,14 +719,16 @@ async function createLanguageService(
 
         dirty = false;
 
+        // https://github.com/microsoft/TypeScript/blob/23faef92703556567ddbcb9afb893f4ba638fc20/src/server/project.ts#L1624
         // host.getCachedExportInfoMap will create the cache if it doesn't exist
         // so we need to check the property instead
-        const cache = project?.exportMapCache;
-        if (!oldProgram || !cache || cache.isEmpty()) {
+        const exportMapCache = project?.exportMapCache;
+        if (!oldProgram || !exportMapCache || exportMapCache.isEmpty()) {
             changedFilesForExportCache.clear();
             return;
         }
 
+        exportMapCache.releaseSymbols();
         for (const fileName of changedFilesForExportCache) {
             const oldFile = oldProgram.getSourceFile(fileName);
             const newFile = program?.getSourceFile(fileName);
@@ -737,10 +739,10 @@ async function createLanguageService(
             }
 
             if (oldFile && newFile) {
-                cache.onFileChanged?.(oldFile, newFile, false);
+                exportMapCache.onFileChanged?.(oldFile, newFile, false);
             } else {
                 // new file or deleted file
-                cache.clear();
+                exportMapCache.clear();
             }
         }
         changedFilesForExportCache.clear();

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1460,6 +1460,55 @@ describe('CompletionProviderImpl', function () {
         assert.strictEqual(detail, 'Add import from "./Bar.svelte"\n\nclass Bar');
     });
 
+    it("doesn't use empty cache", async () => {
+        const virtualTestDir = getRandomVirtualDirPath(testFilesDir);
+        const { document, lsAndTsDocResolver, lsConfigManager, docManager } =
+            setupVirtualEnvironment({
+                filename: 'index.svelte',
+                fileContent: '<script>b</script>',
+                testDir: virtualTestDir
+            });
+
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, lsConfigManager);
+
+        await lsAndTsDocResolver.getLSAndTSDoc(document);
+
+        docManager.updateDocument(document, [
+            {
+                range: Range.create(
+                    Position.create(0, document.content.length),
+                    Position.create(0, document.content.length)
+                ),
+                text: ' '
+            }
+        ]);
+
+        docManager.openClientDocument({
+            text: '',
+            uri: pathToUrl(join(virtualTestDir, 'Bar.svelte'))
+        });
+
+        docManager.updateDocument(document, [
+            {
+                range: Range.create(
+                    Position.create(0, document.content.length),
+                    Position.create(0, document.content.length)
+                ),
+                text: ' '
+            }
+        ]);
+
+        const completions = await completionProvider.getCompletions(document, {
+            line: 0,
+            character: 9
+        });
+
+        const item2 = completions?.items.find((item) => item.label === 'Bar');
+        const { detail } = await completionProvider.resolveCompletion(document, item2!);
+
+        assert.strictEqual(detail, 'Add import from "./Bar.svelte"\n\nclass Bar');
+    });
+
     it('can auto import new export', async () => {
         const virtualTestDir = getRandomVirtualDirPath(testFilesDir);
         const { document, lsAndTsDocResolver, lsConfigManager, virtualSystem } =


### PR DESCRIPTION
The export info cache is created with an edit that doesn't trigger auto imports. And then The onFileChanged call marks the cache to be usable even though nothing is cached yet. 

#2260 