### PR TITLE
Fix #2175 - Support multiple style tags in one document

### DIFF
--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -125,7 +125,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
     ): Promise<CompletionList> {
         const document = this.getDocument(textDocument.uri);
 
-        const completions = await Promise.all(
+        let completions = await Promise.all(
             this.plugins.map(async (plugin) => {
                 const result = await this.tryExecutePlugin(
                     plugin,
@@ -168,6 +168,12 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
                 item.sortText = 'Z' + (item.sortText || '');
                 return true;
             });
+        }
+
+        const css = completions.find((completion) => completion.plugin === 'css');
+
+        if(css){
+            completions = completions.filter((completion) => completion.plugin !== 'ts')
         }
 
         let flattenedCompletions = flatten(

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -187,6 +187,8 @@ export class CSSPlugin
         }
 
         const cssDocument = this.getCSSDoc(document);
+        cssDocument.adaptStyleInfo(position);
+
 
         if (cssDocument.isInGenerated(position)) {
             return this.getCompletionsInternal(document, position, cssDocument);


### PR DESCRIPTION
### PR STILL IN PROGRESS, SOLUTION NOT YET READY! ⚠️ 

## Outline
This PR aims to fix #2175, by providing support to have multiple `<style>` tags in one document. The solution we're looking for should cover the following cases:

- [ ] Need to support multiple style tags in one doc
- [ ] Need to support autocompletion
- [ ] Need to support diagnostics
- [ ] Need to add test cases for svelte:head <style> tag

## The how? 🤔 

Initially I was thinking we simply need to select the appropriate style tag when we're at the appropriate position. It turns out it ain't that simple, as we have support for auto completions such as HTML & TS, and they sometimes overlap.

I do not have a clear solution in my head (pun intended) ATM, I certainly have to get familiarized with the code more in order to provide a better quality solution that covers all the use cases we have.