### PR TITLE
fix: deduplicate generate props/events/slot types correctly

### DIFF
--- a/packages/svelte2tsx/test/emitDts/samples/typescript-deduplicate/expected/Test.svelte.d.ts
+++ b/packages/svelte2tsx/test/emitDts/samples/typescript-deduplicate/expected/Test.svelte.d.ts
@@ -1,4 +1,7 @@
 import { SvelteComponentTyped } from "svelte";
+export interface TestEvents {
+    foo: 'bar';
+}
 import { type TestProps } from './foo';
 declare const __propDef: {
     props: {
@@ -16,7 +19,8 @@ declare const __propDef: {
 };
 type TestProps_ = typeof __propDef.props;
 export { TestProps_ as TestProps };
-export type TestEvents = typeof __propDef.events;
-export type TestSlots = typeof __propDef.slots;
-export default class Test extends SvelteComponentTyped<TestProps, TestEvents, TestSlots> {
+type TestEvents_ = typeof __propDef.events;
+type TestSlots_ = typeof __propDef.slots;
+export { TestSlots_ as TestSlots };
+export default class Test extends SvelteComponentTyped<TestProps_, TestEvents_, TestSlots_> {
 }

--- a/packages/svelte2tsx/test/emitDts/samples/typescript-deduplicate/src/Test.svelte
+++ b/packages/svelte2tsx/test/emitDts/samples/typescript-deduplicate/src/Test.svelte
@@ -1,3 +1,12 @@
+<script context="module" lang="ts">
+    export interface TestEvents {
+        foo: 'bar';
+    }
+    interface TestSlots {
+        foo: 'bar';
+    }
+</script>
+
 <script lang="ts">
     import { eventProps, type TestProps } from './foo';
 


### PR DESCRIPTION
Deduplication that took place when generating in dts mode was flawed