### PR TITLE
fix: adjust snippet code generation for new AST shape

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/EachBlock.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/EachBlock.ts
@@ -27,8 +27,8 @@ export function handleEach(str: MagicString, eachBlock: BaseNode): void {
     const containsComma = str.original
         .substring(eachBlock.expression.start, eachBlock.expression.end)
         .includes(',');
-    const expressionEnd = getEnd(eachBlock.expression, str);
-    const contextEnd = getEnd(eachBlock.context, str);
+    const expressionEnd = getEnd(eachBlock.expression);
+    const contextEnd = getEnd(eachBlock.context);
     const arrayAndItemVarTheSame =
         str.original.substring(eachBlock.expression.start, expressionEnd) ===
         str.original.substring(eachBlock.context.start, contextEnd);
@@ -78,8 +78,6 @@ export function handleEach(str: MagicString, eachBlock: BaseNode): void {
 /**
  * Get the end of the node, excluding the type annotation
  */
-function getEnd(node: any, str: MagicString) {
-    return node.typeAnnotation
-        ? str.original.lastIndexOf(':', node.typeAnnotation.start)
-        : node.end;
+function getEnd(node: any) {
+    return node.typeAnnotation?.start ?? node.end;
 }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/snippet.v5/expected-svelte5.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/snippet.v5/expected-svelte5.js
@@ -1,4 +1,4 @@
- var foo/*Ωignore_startΩ*/: import('svelte').Snippet<any>/*Ωignore_endΩ*/ = (x) => {
+ var foo/*Ωignore_startΩ*/: import('svelte').Snippet<[any]>/*Ωignore_endΩ*/ = (x) => {
 	 { svelteHTML.createElement("div", {}); x; }
 return __sveltets_2_any(0)};
 


### PR DESCRIPTION
Snippets can now take one or more parameters, and their AST shape has changed as a consequence. Adjust it accordingly.
#2281