### PR TITLE
fix: ensure correct types for media bindings

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Binding.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Binding.ts
@@ -10,34 +10,35 @@ import { Element } from './Element';
 import { InlineComponent } from './InlineComponent';
 import { surroundWithIgnoreComments } from '../../utils/ignore';
 
+/**
+ * List of binding names that are transformed to sth like `binding = variable`.
+ */
 const oneWayBindingAttributes: Set<string> = new Set([
     'clientWidth',
     'clientHeight',
     'offsetWidth',
     'offsetHeight',
     'duration',
-    'buffered',
-    'seekable',
     'seeking',
-    'played',
     'ended',
     'readyState',
     'naturalWidth',
     'naturalHeight'
 ]);
 
+/**
+ * List of binding names that are transformed to sth like `binding = variable as GeneratedCode`.
+ */
 const oneWayBindingAttributesNotOnElement: Map<string, string> = new Map([
     ['contentRect', 'DOMRectReadOnly'],
     ['contentBoxSize', 'ResizeObserverSize[]'],
     ['borderBoxSize', 'ResizeObserverSize[]'],
-    ['devicePixelContentBoxSize', 'ResizeObserverSize[]']
+    ['devicePixelContentBoxSize', 'ResizeObserverSize[]'],
+    // available on the element, but with a different type
+    ['buffered', "import('svelte/elements').SvelteMediaTimeRange[]"],
+    ['played', "import('svelte/elements').SvelteMediaTimeRange[]"],
+    ['seekable', "import('svelte/elements').SvelteMediaTimeRange[]"]
 ]);
-
-/**
- * List of all binding names that are transformed to sth like `binding = variable`.
- * This applies to readonly bindings and the this binding.
- */
-export const assignmentBindings = new Set([...oneWayBindingAttributes.keys(), 'this']);
 
 const supportsBindThis = [
     'InlineComponent',

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-oneway/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-oneway/expectedv2.js
@@ -1,3 +1,3 @@
  { const $$_div0 = svelteHTML.createElement("div", {      "type":`text`,});width= $$_div0.clientWidth;height= $$_div0.clientHeight;offsetWidth= $$_div0.offsetWidth;offsetHeight= $$_div0.offsetHeight;}
 
- { const $$_video0 = svelteHTML.createElement("video", {        "src":clip,});duration= $$_video0.duration;buffered= $$_video0.buffered;seekable= $$_video0.seekable;seeking= $$_video0.seeking;played= $$_video0.played;ended= $$_video0.ended; }
+ { const $$_video0 = svelteHTML.createElement("video", {        "src":clip,});duration= $$_video0.duration;buffered= /*Ωignore_startΩ*/null as import('svelte/elements').SvelteMediaTimeRange[]/*Ωignore_endΩ*/;seekable= /*Ωignore_startΩ*/null as import('svelte/elements').SvelteMediaTimeRange[]/*Ωignore_endΩ*/;seeking= $$_video0.seeking;played= /*Ωignore_startΩ*/null as import('svelte/elements').SvelteMediaTimeRange[]/*Ωignore_endΩ*/;ended= $$_video0.ended; }


### PR DESCRIPTION
buffered/played/seekable exist on the DOM element but their types are different to the ones Svelte uses for its bindings - adjust them accordingly.
#2272