### PR TITLE
perf: improve perf in deleteUnresolvedResolutionsFromCache

### DIFF
--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -64,8 +64,11 @@ class ModuleResolutionCache {
         const fileNameWithoutEnding =
             getLastPartOfPath(this.getCanonicalFileName(path)).split('.').shift() || '';
         this.cache.forEach((val, key) => {
+            if (val) {
+                return;
+            }
             const [containingFile, moduleName = ''] = key.split(CACHE_KEY_SEPARATOR);
-            if (!val && moduleName.includes(fileNameWithoutEnding)) {
+            if (moduleName.includes(fileNameWithoutEnding)) {
                 this.cache.delete(key);
                 this.pendingInvalidations.add(containingFile);
             }


### PR DESCRIPTION
Found this problem while checking https://github.com/sveltejs/language-tools/issues/2244#issuecomment-2004061120. This may seem neglectable but because the tabler icon loads 5000+ `.d.ts` files. It is a big difference. In initial loads, the loop count is around `5000 * 5000 * importsPerFile / 2`. Rearranging it cut the init load from 10s to 5s for a SvelteKit default template+ `@tabler/icons-svelte` in my r5 7600.