### PR TITLE
fix: better `bind:group` transformation

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Binding.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Binding.ts
@@ -61,13 +61,7 @@ export function handleBinding(
     // bind group on input
     if (element instanceof Element && attr.name == 'group' && parent.name == 'input') {
         // add reassignment to force TS to widen the type of the declaration (in case it's never reassigned anywhere else)
-        const expressionStr = str.original.substring(
-            attr.expression.start,
-            getEnd(attr.expression)
-        );
-        element.appendToStartEnd([
-            surroundWithIgnoreComments(`() => ${expressionStr} = __sveltets_2_any(null);`)
-        ]);
+        appendOneWayBinding(attr, ' = __sveltets_2_any(null)', element);
         return;
     }
 

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-group-bare/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-group-bare/expectedv2.js
@@ -1,2 +1,2 @@
-  { svelteHTML.createElement("input", {   "type":`radio`,"value":`Plain`,});/*Ωignore_startΩ*/() => group = __sveltets_2_any(null);/*Ωignore_endΩ*/}
- { svelteHTML.createElement("input", {    "type":`radio`,"value":`Plain`,});/*Ωignore_startΩ*/() => group = __sveltets_2_any(null);/*Ωignore_endΩ*/}
+  { svelteHTML.createElement("input", {   "type":`radio`,"value":`Plain`,});group = __sveltets_2_any(null);}
+ { svelteHTML.createElement("input", {    "type":`radio`,"value":`Plain`,});group = __sveltets_2_any(null);}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/binding-group/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/binding-group/expectedv2.js
@@ -1,1 +1,1 @@
-  { svelteHTML.createElement("input", {   "type":`radio`,"value":`Plain`,});/*Ωignore_startΩ*/() => tortilla = __sveltets_2_any(null);/*Ωignore_endΩ*/}
+  { svelteHTML.createElement("input", {    "type":`radio`,"value":`Plain`,});tortilla = __sveltets_2_any(null);}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-binding/expected-svelte5.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-binding/expected-svelte5.js
@@ -1,3 +1,3 @@
- { svelteHTML.createElement("input", { });/*Ωignore_startΩ*/() => obj = __sveltets_2_any(null);/*Ωignore_endΩ*/}
+  { svelteHTML.createElement("input", { });obj = __sveltets_2_any(null);}
  { svelteHTML.createElement("input", { "bind:value":obj.,});/*Ωignore_startΩ*/() => obj = __sveltets_2_any(null);/*Ωignore_endΩ*/}
  { const $$_tupnI0C = __sveltets_2_ensureComponent(Input); new $$_tupnI0C({ target: __sveltets_2_any(), props: {   value:__sveltets_2_binding(obj.),}});/*Ωignore_startΩ*/() => obj = __sveltets_2_any(null);/*Ωignore_endΩ*/}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-binding/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-binding/expectedv2.js
@@ -1,3 +1,3 @@
- { svelteHTML.createElement("input", { });obj = __sveltets_2_any(null);}
+  { svelteHTML.createElement("input", { });obj = __sveltets_2_any(null);}
  { svelteHTML.createElement("input", { "bind:value":obj.,});/*Ωignore_startΩ*/() => obj = __sveltets_2_any(null);/*Ωignore_endΩ*/}
  { const $$_tupnI0C = __sveltets_2_ensureComponent(Input); new $$_tupnI0C({ target: __sveltets_2_any(), props: {   value:obj.,}});/*Ωignore_startΩ*/() => obj = __sveltets_2_any(null);/*Ωignore_endΩ*/}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/editing-binding/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/editing-binding/expectedv2.js
@@ -1,3 +1,3 @@
- { svelteHTML.createElement("input", { });/*Ωignore_startΩ*/() => obj = __sveltets_2_any(null);/*Ωignore_endΩ*/}
+ { svelteHTML.createElement("input", { });obj = __sveltets_2_any(null);}
  { svelteHTML.createElement("input", { "bind:value":obj.,});/*Ωignore_startΩ*/() => obj = __sveltets_2_any(null);/*Ωignore_endΩ*/}
  { const $$_tupnI0C = __sveltets_2_ensureComponent(Input); new $$_tupnI0C({ target: __sveltets_2_any(), props: {   value:obj.,}});/*Ωignore_startΩ*/() => obj = __sveltets_2_any(null);/*Ωignore_endΩ*/}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/binding-group-store/expectedv2.ts
@@ -1,6 +1,6 @@
 ///<reference types="svelte" />
 ;function render() {
-async () => { { svelteHTML.createElement("input", {     "id":`dom-input`,"type":`radio`,"value":`dom`,});/*Ωignore_startΩ*/() => $compile_options.generate = __sveltets_2_any(null);/*Ωignore_endΩ*/}};
+async () => { { svelteHTML.createElement("input", {      "id":`dom-input`,"type":`radio`,"value":`dom`,});$compile_options.generate = __sveltets_2_any(null);}};
 return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event(render()))) {


### PR DESCRIPTION
reuse the one way binding transformation to get autocompletion, error diagnostics etc #2337