### PR TITLE
fix: revert waiting for config request in ts plugin

### DIFF
--- a/packages/typescript-plugin/src/config-manager.ts
+++ b/packages/typescript-plugin/src/config-manager.ts
@@ -30,12 +30,13 @@ export class ConfigManager {
     }
 
     updateConfigFromPluginConfig(config: Configuration) {
-        const shouldWaitForConfigRequest = config.global == true;
-        const enable = config.enable ?? !shouldWaitForConfigRequest;
+        // TODO this doesn't work because TS will resolve/load files already before we get the config request,
+        // which leads to TS files that use Svelte files getting all kinds of type errors
+        // const shouldWaitForConfigRequest = config.global == true;
+        // const enable = config.enable ?? !shouldWaitForConfigRequest;
         this.config = {
             ...this.config,
-            ...config,
-            enable
+            ...config
         };
         this.emitter.emit(configurationEventName, config);
     }


### PR DESCRIPTION
The change in #2317 to wait for the "enable" request the extension sends lead to all TS files that use Svelte files and part of the initial tsconfig files getting all kinds of type errors because they were already loaded before the enable kicks in

FYI @jasonlyu123 