### PR TITLE
Bump TypeScript version in svelte-check

### DIFF
--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -30,7 +30,7 @@
         "picocolors": "^1.0.0",
         "sade": "^1.7.4",
         "svelte-preprocess": "^5.1.3",
-        "typescript": "^5.0.3"
+        "typescript": "^5.4.5"
     },
     "peerDependencies": {
         "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0"


### PR DESCRIPTION
I'm getting errors with svelte-check that don't appear in VS Code, where I'm running the latest TypeScript. I think this should solve them.