### PR TITLE
feat: allow `as` expressions for bindable props

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element-error/expected_svelte_5.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/svelte-element-error/expected_svelte_5.json
@@ -3,7 +3,7 @@
         "range": { "start": { "line": 4, "character": 0 }, "end": { "line": 4, "character": 0 } },
         "severity": 1,
         "source": "ts",
-        "message": "`<svelte:element>` must have a 'this' attribute",
+        "message": "`<svelte:element>` must have a 'this' attribute with a value",
         "code": -1
     }
 ]

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -153,7 +153,12 @@ export class ExportedNames {
                         : element.name.text;
 
                     if (element.initializer) {
-                        const call = element.initializer;
+                        let call = element.initializer;
+                        // if it's an as expression we need to check wether the as
+                        // expression expression is a call
+                        if (ts.isAsExpression(call)) {
+                            call = call.expression;
+                        }
                         if (ts.isCallExpression(call) && ts.isIdentifier(call.expression)) {
                             if (call.expression.text === '$bindable') {
                                 this.$props.bindings.push(name);

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable/expectedv2.ts
@@ -1,12 +1,12 @@
 ///<reference types="svelte" />
 ;function render() {
 /*Ωignore_startΩ*/;type $$ComponentProps = { a: unknown, b?: unknown, c?: number };/*Ωignore_endΩ*/
-	let { a, b = $bindable(), c = $bindable(0) as number }: $$ComponentProps = $props();
+    let { a, b = $bindable(), c = $bindable(0) as number }: $$ComponentProps = $props();
 ;
 async () => {};
 return { props: {} as any as $$ComponentProps, slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
-	constructor(options = __sveltets_2_runes_constructor(__sveltets_2_with_any_event(render()))) { super(options); }
-	$$bindings = __sveltets_$$bindings('b', 'c');
+    constructor(options = __sveltets_2_runes_constructor(__sveltets_2_with_any_event(render()))) { super(options); }
+    $$bindings = __sveltets_$$bindings('b', 'c');
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable/expectedv2.ts
@@ -1,12 +1,12 @@
 ///<reference types="svelte" />
 ;function render() {
-/*Ωignore_startΩ*/;type $$ComponentProps = { a: unknown, b?: unknown };/*Ωignore_endΩ*/
-    let { a, b = $bindable() }: $$ComponentProps = $props();
-;
-async () => {};
-return { props: {} as any as $$ComponentProps, slots: {}, events: {} }}
-
-export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
-    constructor(options = __sveltets_2_runes_constructor(__sveltets_2_with_any_event(render()))) { super(options); }
-    $$bindings = __sveltets_$$bindings('b');
-}
+	/*Ωignore_startΩ*/;type $$ComponentProps = { a: unknown, b?: unknown, c?: number };/*Ωignore_endΩ*/
+		let { a, b = $bindable(), c = $bindable(0) as number }: $$ComponentProps = $props();
+	;
+	async () => {};
+	return { props: {} as any as $$ComponentProps, slots: {}, events: {} }}
+	
+	export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
+		constructor(options = __sveltets_2_runes_constructor(__sveltets_2_with_any_event(render()))) { super(options); }
+		$$bindings = __sveltets_$$bindings('b', 'c');
+	}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable/expectedv2.ts
@@ -1,12 +1,12 @@
 ///<reference types="svelte" />
 ;function render() {
-	/*Ωignore_startΩ*/;type $$ComponentProps = { a: unknown, b?: unknown, c?: number };/*Ωignore_endΩ*/
-		let { a, b = $bindable(), c = $bindable(0) as number }: $$ComponentProps = $props();
-	;
-	async () => {};
-	return { props: {} as any as $$ComponentProps, slots: {}, events: {} }}
-	
-	export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
-		constructor(options = __sveltets_2_runes_constructor(__sveltets_2_with_any_event(render()))) { super(options); }
-		$$bindings = __sveltets_$$bindings('b', 'c');
-	}
+/*Ωignore_startΩ*/;type $$ComponentProps = { a: unknown, b?: unknown, c?: number };/*Ωignore_endΩ*/
+	let { a, b = $bindable(), c = $bindable(0) as number }: $$ComponentProps = $props();
+;
+async () => {};
+return { props: {} as any as $$ComponentProps, slots: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_with_any_event(render())) {
+	constructor(options = __sveltets_2_runes_constructor(__sveltets_2_with_any_event(render()))) { super(options); }
+	$$bindings = __sveltets_$$bindings('b', 'c');
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable/input.svelte
@@ -1,3 +1,3 @@
 <script lang="ts">
-    let { a, b = $bindable() } = $props();
+    let { a, b = $bindable(), c = $bindable(0) as number } = $props();
 </script>


### PR DESCRIPTION
As per [discussion on discord](https://discord.com/channels/457912077277855764/1153350350158450758/1240321241290899507) this change allow for declaring the type of a bindable prop using the `as type` expression

eg.

```svelte
<!-- Parent Component -->
<script lang=ts>
  import Child from './Child.svelte';
  let amount = $state(10);
</script>
<Child bind:amount />

<!-- Child Component -->
<script lang=ts>
  import Child from './Child.svelte';
  let {
    amount = $bindable(0) as number,
  } = $props();
</script>
{amount}
```

i would just need a bit of guidance to determine where to write the test.