### PR TITLE
fix: component import quick-fix with "did you mean" diagnostics

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -276,7 +276,8 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
             if (
                 diagnostic.range.start.line < 0 ||
                 diagnostic.range.end.line < 0 ||
-                diagnostic.code !== DiagnosticCode.CANNOT_FIND_NAME
+                (diagnostic.code !== DiagnosticCode.CANNOT_FIND_NAME &&
+                    diagnostic.code !== DiagnosticCode.CANNOT_FIND_NAME_X_DID_YOU_MEAN_Y)
             ) {
                 continue;
             }
@@ -314,7 +315,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
         virtualDoc.openedByClient = true;
         // let typescript know about the virtual document
         // getLSAndTSDoc instead of getSnapshot so that project dirty state is correctly tracked by us
-        // otherwise, sometime the applied code fix might not be picked up by the language service 
+        // otherwise, sometime the applied code fix might not be picked up by the language service
         // because we think the project is still dirty and doesn't update the project version
         await this.lsAndTsDocResolver.getLSAndTSDoc(virtualDoc);
 
@@ -858,7 +859,11 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
             if (codeFix.fixName === FIX_IMPORT_FIX_NAME) {
                 const allCannotFindNameDiagnostics = lang
                     .getSemanticDiagnostics(fileName)
-                    .filter((diagnostic) => diagnostic.code === DiagnosticCode.CANNOT_FIND_NAME);
+                    .filter(
+                        (diagnostic) =>
+                            diagnostic.code === DiagnosticCode.CANNOT_FIND_NAME ||
+                            diagnostic.code === DiagnosticCode.CANNOT_FIND_NAME_X_DID_YOU_MEAN_Y
+                    );
 
                 if (allCannotFindNameDiagnostics.length < 2) {
                     checkedFixIds.add(codeFix.fixId);

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -313,10 +313,13 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
         const virtualDoc = new Document(virtualUri, newText);
         virtualDoc.openedByClient = true;
         // let typescript know about the virtual document
-        await this.lsAndTsDocResolver.getSnapshot(virtualDoc);
+        // getLSAndTSDoc instead of getSnapshot so that project dirty state is correctly tracked by us
+        // otherwise, sometime the applied code fix might not be picked up by the language service 
+        // because we think the project is still dirty and doesn't update the project version
+        await this.lsAndTsDocResolver.getLSAndTSDoc(virtualDoc);
 
         return {
-            virtualDoc: new Document(virtualUri, newText),
+            virtualDoc,
             insertedNames: names
         };
     }

--- a/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CodeActionsProvider.ts
@@ -586,7 +586,7 @@ export class CodeActionsProviderImpl implements CodeActionsProvider {
                   )
                 : undefined;
 
-        // either-or situation when it's not a typo quick fix
+        // either-or situation when it's not a "did you mean" fix
         if (
             codeFixes === undefined ||
             errorCodes.includes(DiagnosticCode.CANNOT_FIND_NAME_X_DID_YOU_MEAN_Y)

--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -52,6 +52,7 @@ export enum DiagnosticCode {
     MISSING_PROP = 2741, // "Property '..' is missing in type '..' but required in type '..'."
     NO_OVERLOAD_MATCHES_CALL = 2769, // "No overload matches this call"
     CANNOT_FIND_NAME = 2304, // "Cannot find name 'xxx'"
+    CANNOT_FIND_NAME_X_DID_YOU_MEAN_Y = 2552, // "Cannot find name '...' Did you mean '...'?"
     EXPECTED_N_ARGUMENTS = 2554, // Expected {0} arguments, but got {1}.
     DEPRECATED_SIGNATURE = 6387 // The signature '..' of '..' is deprecated
 }

--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -662,7 +662,7 @@ describe('CodeActionsProvider', function () {
         ]);
     });
 
-    it('provides quickfix for component import with typo diagnostics', async () => {
+    it('provides quickfix for component import with "did you mean" diagnostics', async () => {
         const { provider, document } = setup('codeaction-component-import.svelte');
 
         const codeActions = await provider.getCodeActions(
@@ -1007,7 +1007,7 @@ describe('CodeActionsProvider', function () {
         assert.strictEqual(cannotFindNameDiagnostics.length, 0);
     });
 
-    it('provide quick fix to fix all missing import component with typo diagnostics', async () => {
+    it('provide quick fix to fix all missing import component with "did you mean" diagnostics', async () => {
         const { provider, document } = setup('codeaction-custom-fix-all-component4.svelte');
 
         const range = Range.create(Position.create(4, 1), Position.create(4, 15));

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-component-import.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-component-import.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    class EMpty {}
+</script>
+
+<Empty />

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-custom-fix-all-component4.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-custom-fix-all-component4.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+class FixAllImported3 {}
+</script>
+
+<FixAllImported />
+<FixAllImported2 />


### PR DESCRIPTION
I probably got mixed up with the `fixMissingFunction` quick fix. But TypeScript does provide an import quick fix with the "did you mean" diagnostics. So we can also consider the diagnostics in our workaround. This also fixed an issue with the fix-all code action where the diagnostics won't go away after applying the quick fix. 