### PR TITLE
feat: Svelte 5 component class/function interop

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
@@ -206,7 +206,7 @@ function addSimpleComponentExport({
                 // `const ${className || '$$Component'} = __sveltets_2_isomorphic_component($$Component_, ${exportedNames.createBindingsStr2()});\n` +
                 `const ${className || '$$Component'} = __sveltets_2_isomorphic_component${usesSlots ? '_slots' : '2'}(${propDef});\n` +
                 surroundWithIgnoreComments(
-                    `type ${className || '$$Component'} = typeof ${className || '$$Component'};\n`
+                    `type ${className || '$$Component'} = InstanceType<typeof ${className || '$$Component'}>;\n`
                 ) +
                 `export default ${className || '$$Component'};`;
         } else {

--- a/packages/svelte2tsx/src/svelte2tsx/index.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/index.ts
@@ -370,7 +370,7 @@ export function svelte2tsx(
         : instanceScriptTarget;
     const implicitStoreValues = new ImplicitStoreValues(resolvedStores, renderFunctionStart);
     //move the instance script and process the content
-    let exportedNames = new ExportedNames(str, 0, basename, options?.isTsFile);
+    let exportedNames = new ExportedNames(str, 0, basename, options?.isTsFile, svelte5Plus);
     let generics = new Generics(str, 0, { attributes: [] } as any);
     let uses$$SlotsInterface = false;
     if (scriptTag) {
@@ -386,7 +386,8 @@ export function svelte2tsx(
             options.mode,
             /**hasModuleScripts */ !!moduleScriptTag,
             options?.isTsFile,
-            basename
+            basename,
+            svelte5Plus
         );
         uses$$props = uses$$props || res.uses$$props;
         uses$$restProps = uses$$restProps || res.uses$$restProps;
@@ -442,6 +443,7 @@ export function svelte2tsx(
         componentDocumentation,
         mode: options.mode,
         generics,
+        isSvelte5: svelte5Plus,
         noSvelteComponentTyped: options.noSvelteComponentTyped
     });
 

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -52,7 +52,8 @@ export class ExportedNames {
         private str: MagicString,
         private astOffset: number,
         private basename: string,
-        private isTsFile: boolean
+        private isTsFile: boolean,
+        private isSvelte5Plus: boolean
     ) {}
 
     handleVariableStatement(node: ts.VariableStatement, parent: ts.Node): void {
@@ -680,9 +681,15 @@ export class ExportedNames {
         return `\n    $$bindings = __sveltets_$$bindings('${this.$props.bindings.join("', '")}');`;
     }
 
+    createBindingsStr2(): string {
+        // will be just the empty strings for zero bindings, which is impossible to create a binding for, so it works out fine
+        return `__sveltets_$$bindings('${this.$props.bindings.join("', '")}')`;
+    }
+
     /**
      * In runes mode, exports are no longer part of props because you cannot `bind:` to them,
-     * which is why we need a separate return type for them.
+     * which is why we need a separate return type for them. In Svelte 5, the isomorphic component
+     * needs them separate, too.
      */
     createExportsStr(): string {
         const names = Array.from(this.exports.entries());
@@ -755,7 +762,7 @@ export class ExportedNames {
         this.hasRunesGlobals = globals.some((global) => runes.includes(global));
     }
 
-    private usesRunes() {
+    usesRunes() {
         return this.hasRunesGlobals || this.hasPropsRune();
     }
 }

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -695,7 +695,7 @@ export class ExportedNames {
         const names = Array.from(this.exports.entries());
         const others = names.filter(([, { isLet }]) => !isLet);
 
-        if (this.usesRunes() && others.length > 0) {
+        if (this.isSvelte5Plus && others.length > 0) {
             if (this.isTsFile) {
                 return (
                     ', exports: {} as any as { ' +
@@ -703,7 +703,7 @@ export class ExportedNames {
                     ' }'
                 );
             } else {
-                return `, exports: /** @type {${this.createReturnElementsType(others, false, true)}} */ ({})`;
+                return `, exports: /** @type {{${this.createReturnElementsType(others, false, true)}}} */ ({})`;
             }
         }
 

--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -41,7 +41,8 @@ export function processInstanceScriptContent(
     mode: 'ts' | 'dts',
     hasModuleScript: boolean,
     isTSFile: boolean,
-    basename: string
+    basename: string,
+    isSvelte5Plus: boolean
 ): InstanceScriptProcessResult {
     const htmlx = str.original;
     const scriptContent = htmlx.substring(script.content.start, script.content.end);
@@ -53,7 +54,7 @@ export function processInstanceScriptContent(
         ts.ScriptKind.TS
     );
     const astOffset = script.content.start;
-    const exportedNames = new ExportedNames(str, astOffset, basename, isTSFile);
+    const exportedNames = new ExportedNames(str, astOffset, basename, isTSFile, isSvelte5Plus);
     const generics = new Generics(str, astOffset, script);
     const interfacesAndTypes = new InterfacesAndTypes();
 

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -70,30 +70,30 @@ declare function __sveltets_2_slotsType<Slots, Key extends keyof Slots>(slots: S
 // An empty array of optionalProps makes OptionalProps type any, which means we lose the prop typing.
 // optionalProps need to be first or its type cannot be infered correctly.
 
-declare function __sveltets_2_partial<Props = {}, Events = {}, Slots = {}>(
-    render: {props: Props, events: Events, slots: Slots }
-): {props: Expand<SveltePropsAnyFallback<Props>>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>> }
-declare function __sveltets_2_partial<Props = {}, Events = {}, Slots = {}, OptionalProps extends keyof Props = any>(
+declare function __sveltets_2_partial<Props = {}, Events = {}, Slots = {}, Exports = {}>(
+    render: {props: Props, events: Events, slots: Slots, exports?: Exports }
+): {props: Expand<SveltePropsAnyFallback<Props>>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>>, exports?: Exports }
+declare function __sveltets_2_partial<Props = {}, Events = {}, Slots = {}, Exports = {}, OptionalProps extends keyof Props = any>(
     optionalProps: OptionalProps[],
-    render: {props: Props, events: Events, slots: Slots }
-): {props: Expand<SvelteWithOptionalProps<SveltePropsAnyFallback<Props>, OptionalProps>>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>> }
+    render: {props: Props, events: Events, slots: Slots, exports?: Exports }
+): {props: Expand<SvelteWithOptionalProps<SveltePropsAnyFallback<Props>, OptionalProps>>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>>, exports?: Exports }
 
-declare function __sveltets_2_partial_with_any<Props = {}, Events = {}, Slots = {}>(
-    render: {props: Props, events: Events, slots: Slots }
-): {props: Expand<SveltePropsAnyFallback<Props> & SvelteAllProps>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>> }
-declare function __sveltets_2_partial_with_any<Props = {}, Events = {}, Slots = {}, OptionalProps extends keyof Props = any>(
+declare function __sveltets_2_partial_with_any<Props = {}, Events = {}, Slots = {}, Exports = {}>(
+    render: {props: Props, events: Events, slots: Slots, exports?: Exports }
+): {props: Expand<SveltePropsAnyFallback<Props> & SvelteAllProps>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>>, exports?: Exports }
+declare function __sveltets_2_partial_with_any<Props = {}, Events = {}, Slots = {}, Exports = {}, OptionalProps extends keyof Props = any>(
     optionalProps: OptionalProps[],
-    render: {props: Props, events: Events, slots: Slots }
-): {props: Expand<SvelteWithOptionalProps<SveltePropsAnyFallback<Props>, OptionalProps> & SvelteAllProps>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>> }
+    render: {props: Props, events: Events, slots: Slots, exports?: Exports }
+): {props: Expand<SvelteWithOptionalProps<SveltePropsAnyFallback<Props>, OptionalProps> & SvelteAllProps>, events: Events, slots: Expand<SvelteSlotsAnyFallback<Slots>>, exports?: Exports }
 
 
-declare function __sveltets_2_with_any<Props = {}, Events = {}, Slots = {}>(
-    render: {props: Props, events: Events, slots: Slots }
-): {props: Expand<Props & SvelteAllProps>, events: Events, slots: Slots }
+declare function __sveltets_2_with_any<Props = {}, Events = {}, Slots = {}, Exports = {}>(
+    render: {props: Props, events: Events, slots: Slots, exports?: Exports }
+): {props: Expand<Props & SvelteAllProps>, events: Events, slots: Slots, exports?: Exports }
 
-declare function __sveltets_2_with_any_event<Props = {}, Events = {}, Slots = {}>(
-    render: {props: Props, events: Events, slots: Slots }
-): {props: Props, events: Events & {[evt: string]: CustomEvent<any>;}, slots: Slots }
+declare function __sveltets_2_with_any_event<Props = {}, Events = {}, Slots = {}, Exports = {}>(
+    render: {props: Props, events: Events, slots: Slots, exports?: Exports }
+): {props: Props, events: Events & {[evt: string]: CustomEvent<any>;}, slots: Slots, exports?: Exports }
 
 declare function __sveltets_2_store_get<T = any>(store: SvelteStore<T>): T
 declare function __sveltets_2_store_get<Store extends SvelteStore<any> | undefined | null>(store: Store): Store extends SvelteStore<infer T> ? T : Store;
@@ -245,18 +245,18 @@ declare function __sveltets_2_runes_constructor<Props extends {}>(render: {props
 
 declare function __sveltets_$$bindings<Bindings extends string[]>(...bindings: Bindings): Bindings[number];
 
-interface __sveltets_2_IsomorphicComponent<Props = any, Events = any, Slots = any, Bindings = string> {
-    new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings };
-    (internal: unknown, props: Props & {'$$events'?: Events, '$$slots'?: Slots}): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings };
+interface __sveltets_2_IsomorphicComponent<Props = any, Events = any, Slots = any, Exports = {}, Bindings = string> {
+    new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
+    (internal: unknown, props: Props & {'$$events'?: Events, '$$slots'?: Slots}): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
 }
 declare function __sveltets_2_isomorphic_component<
     Props extends Record<string, any>, Events extends Record<string, any>, Slots extends Record<string, any>, Bindings extends string
 >(klass: typeof import('svelte').SvelteComponent<Props, Events, Slots>, bindings: Bindings): __sveltets_2_IsomorphicComponent<Props, Events, Slots, Bindings>;
 
 declare function __sveltets_2_isomorphic_component2<
-    Props extends Record<string, any>, Events extends Record<string, any>, Slots extends Record<string, any>, Bindings extends string
->(klass: {props: Props, events: Events, slots: Slots }): __sveltets_2_IsomorphicComponent<Props, Events, Slots, Bindings>;
+    Props extends Record<string, any>, Events extends Record<string, any>, Slots extends Record<string, any>, Exports extends Record<string, any>, Bindings extends string
+>(klass: {props: Props, events: Events, slots: Slots, exports?: Exports }): __sveltets_2_IsomorphicComponent<Props, Events, Slots, Exports, Bindings>;
 
 declare function __sveltets_2_isomorphic_component_slots<
-    Props extends Record<string, any>, Events extends Record<string, any>, Slots extends Record<string, any>, Bindings extends string
->(klass: {props: Props, events: Events, slots: Slots }): __sveltets_2_IsomorphicComponent<__sveltets_2_PropsWithChildren<Props, Slots>, Events, Slots, Bindings>;
+    Props extends Record<string, any>, Events extends Record<string, any>, Slots extends Record<string, any>, Exports extends Record<string, any>, Bindings extends string
+>(klass: {props: Props, events: Events, slots: Slots, exports?: Exports }): __sveltets_2_IsomorphicComponent<__sveltets_2_PropsWithChildren<Props, Slots>, Events, Slots, Exports, Bindings>;

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -225,7 +225,10 @@ declare type ATypedSvelteComponent = {
  * ```
  */
 declare type ConstructorOfATypedSvelteComponent = new (args: {target: any, props?: any}) => ATypedSvelteComponent
-declare function __sveltets_2_ensureComponent<T extends ConstructorOfATypedSvelteComponent | null | undefined>(type: T): NonNullable<T>;
+declare function __sveltets_2_ensureComponent<
+    // TODO svelte.Component doesn't exist in Svelte 4 and thus this will be any which likely messes up the type constraint
+    T extends ConstructorOfATypedSvelteComponent | import('svelte').Component | null | undefined
+>(type: T): NonNullable<T extends import('svelte').Component<infer Props> ? typeof import('svelte').SvelteComponent<Props, Props['$$events'], Props['$$slots']> : T>;
 
 declare function __sveltets_2_ensureArray<T extends ArrayLike<unknown> | Iterable<unknown>>(array: T): T extends ArrayLike<infer U> ? U[] : T extends Iterable<infer U> ? Iterable<U> : any[];
 
@@ -241,3 +244,19 @@ type __sveltets_2_PropsWithChildren<Props, Slots> = Props &
 declare function __sveltets_2_runes_constructor<Props extends {}>(render: {props: Props }): import("svelte").ComponentConstructorOptions<Props>;
 
 declare function __sveltets_$$bindings<Bindings extends string[]>(...bindings: Bindings): Bindings[number];
+
+interface __sveltets_2_IsomorphicComponent<Props = any, Events = any, Slots = any, Bindings = string> {
+    new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings };
+    (internal: unknown, props: Props & {'$$events'?: Events, '$$slots'?: Slots}): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings };
+}
+declare function __sveltets_2_isomorphic_component<
+    Props extends Record<string, any>, Events extends Record<string, any>, Slots extends Record<string, any>, Bindings extends string
+>(klass: typeof import('svelte').SvelteComponent<Props, Events, Slots>, bindings: Bindings): __sveltets_2_IsomorphicComponent<Props, Events, Slots, Bindings>;
+
+declare function __sveltets_2_isomorphic_component2<
+    Props extends Record<string, any>, Events extends Record<string, any>, Slots extends Record<string, any>, Bindings extends string
+>(klass: {props: Props, events: Events, slots: Slots }): __sveltets_2_IsomorphicComponent<Props, Events, Slots, Bindings>;
+
+declare function __sveltets_2_isomorphic_component_slots<
+    Props extends Record<string, any>, Events extends Record<string, any>, Slots extends Record<string, any>, Bindings extends string
+>(klass: {props: Props, events: Events, slots: Slots }): __sveltets_2_IsomorphicComponent<__sveltets_2_PropsWithChildren<Props, Slots>, Events, Slots, Bindings>;


### PR DESCRIPTION
Svelte 5 uses functions to define components under the hood. This should be represented in the types. We can't just switch to using functions though because `d.ts` files created from Svelte 4 libraries should still work, and those contain classes. So we need interop between functions and classes. The idea is therefore:
- Svelte 5 creates a default export which is both a function and a class constructor
- Various places are adjusted to support the new default exports
