### PR TITLE
feat: syntax highlight for svelte code block in mdx

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -492,7 +492,8 @@
                 "scopeName": "markdown.svelte.codeblock",
                 "path": "./syntaxes/markdown-svelte.json",
                 "injectTo": [
-                    "text.html.markdown"
+                    "text.html.markdown",
+                    "source.mdx"
                 ],
                 "embeddedLanguages": {
                     "meta.embedded.block.svelte": "svelte"
@@ -502,14 +503,16 @@
                 "scopeName": "markdown.svelte.codeblock.script",
                 "path": "./syntaxes/markdown-svelte-js.json",
                 "injectTo": [
-                    "text.html.markdown"
+                    "text.html.markdown",
+                    "source.mdx"
                 ]
             },
             {
                 "scopeName": "markdown.svelte.codeblock.style",
                 "path": "./syntaxes/markdown-svelte-css.json",
                 "injectTo": [
-                    "text.html.markdown"
+                    "text.html.markdown",
+                    "source.mdx"
                 ]
             },
             {

--- a/packages/svelte-vscode/syntaxes/markdown-svelte.json
+++ b/packages/svelte-vscode/syntaxes/markdown-svelte.json
@@ -1,7 +1,7 @@
 {
     "scopeName": "markdown.svelte.codeblock",
     "fileTypes": [],
-    "injectionSelector": "L:text.html.markdown",
+    "injectionSelector": "L:text.html.markdown, L:source.mdx",
     "patterns": [
         {
             "include": "#svelte-code-block"


### PR DESCRIPTION
#2322 

![圖片](https://github.com/sveltejs/language-tools/assets/36730922/45298001-40b4-4c14-b52e-625deb0fe62b)
