### PR TITLE
fix: don't debounce document symbol request

### DIFF
--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -279,12 +279,18 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
     ): Promise<SymbolInformation[]> {
         const document = this.getDocument(textDocument.uri);
 
+        // VSCode requested document symbols twice for the outline view and the sticky scroll
+        // Manually delay here and don't use low priority as one of them will return no symbols
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        if (cancellationToken.isCancellationRequested) {
+            return [];
+        }
         return flatten(
             await this.execute<SymbolInformation[]>(
                 'getDocumentSymbols',
                 [document, cancellationToken],
                 ExecuteMode.Collect,
-                'low'
+                'high'
             )
         );
     }


### PR DESCRIPTION
#2353 

The reason is that VSCode requested document symbols twice for the outline view and the sticky scroll. We cancelled one of them so the outline view shows "no symbols found in document 'A.svelte'". It seems the VSCode ts extension also caches the result from tsserver, mostly because it'll also be used in code lens. But the result is mostly fast enough. A 5000-line file takes like 100ms so we probably don't need it now. We can probably reconsider if #2378 lands and see if there is a large performance regression.