### PR TITLE
fix: account for added code in the request range of ts-plugin inlay hint

### DIFF
--- a/packages/typescript-plugin/src/language-service/inlay-hints.ts
+++ b/packages/typescript-plugin/src/language-service/inlay-hints.ts
@@ -18,12 +18,13 @@ export function decorateInlayHints(
         }
 
         const { languageService, toVirtualPos, toOriginalPos } = result;
+        const start = toVirtualPos(span.start);
         return languageService
             .provideInlayHints(
                 fileName,
                 {
-                    start: toVirtualPos(span.start),
-                    length: span.length
+                    start,
+                    length: toVirtualPos(span.start + span.length) - start
                 },
                 preferences
             )


### PR DESCRIPTION
https://discord.com/channels/457912077277855764/689494103380983930/1246860009699283065

It isn't because the variable is unused but because the text span doesn't account for added code so the variable isn't in the range. 