### PR TITLE
Avoid warning issues with peer dependencies

### DIFF
--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -29,7 +29,7 @@
         "import-fresh": "^3.2.1",
         "picocolors": "^1.0.0",
         "sade": "^1.7.4",
-        "svelte-preprocess": "^5.1.3",
+        "svelte-preprocess": ">=5",
         "typescript": "^5.0.3"
     },
     "peerDependencies": {


### PR DESCRIPTION
Allow  svelte-preprocess ^6 to avoid warnings when using the latest dependencies.

```
 WARN  Issues with peer dependencies found
.
└─┬ svelte-check 3.8.1
  └─┬ svelte-preprocess 5.1.4
    └── ✕ unmet peer postcss-load-config@"^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0": found 6.0.1
```