### PR TITLE
fix: snippets with TS incorrect transformation

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/SnippetBlock.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/SnippetBlock.ts
@@ -47,7 +47,7 @@ export function handleSnippet(
     const startEnd =
         str.original.indexOf(
             '}',
-            lastParameter?.typeAnnotation.end ?? lastParameter?.end ?? snippetBlock.expression.end
+            lastParameter?.typeAnnotation?.end ?? lastParameter?.end ?? snippetBlock.expression.end
         ) + 1;
 
     if (isImplicitProp) {

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/SnippetBlock.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/SnippetBlock.ts
@@ -81,15 +81,23 @@ export function handleSnippet(
         let generic = '';
         if (snippetBlock.parameters?.length) {
             generic = `<[${snippetBlock.parameters
-                .map((p) =>
-                    p.typeAnnotation?.typeAnnotation
+                .map((p) => {
+                    let type_annotation = p.typeAnnotation;
+                    if (!type_annotation && p.type === 'AssignmentPattern') {
+                        type_annotation = p.left?.typeAnnotation;
+                        if (!type_annotation) {
+                            type_annotation = p.right?.typeAnnotation;
+                        }
+                    }
+                    if (!type_annotation) return 'any';
+                    return type_annotation.typeAnnotation
                         ? str.original.slice(
-                              p.typeAnnotation.typeAnnotation.start,
-                              p.typeAnnotation.typeAnnotation.end
+                              type_annotation.typeAnnotation.start,
+                              type_annotation.typeAnnotation.end
                           )
                         : // slap any on to it to silence "implicit any" errors; JSDoc people can't add types to snippets
-                          'any'
-                )
+                          'any';
+                })
                 .join(', ')}]>`;
         }
 

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/SnippetBlock.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/SnippetBlock.ts
@@ -42,11 +42,17 @@ export function handleSnippet(
         }
     );
 
+    const last_parameter = snippetBlock.parameters?.at(-1);
+
     const startEnd =
         str.original.indexOf(
             '}',
             // context was the first iteration in a .next release, remove at some point
-            snippetBlock.parameters?.at(-1)?.end || snippetBlock.expression.end
+            (last_parameter?.typeAnnotation
+                ? // if it has a type annotation use the end of the type annotation
+                  // else the end of the parameter
+                  last_parameter?.typeAnnotation.end
+                : last_parameter?.end) || snippetBlock.expression.end
         ) + 1;
 
     if (isImplicitProp) {
@@ -54,7 +60,9 @@ export function handleSnippet(
         const transforms: TransformationArray = ['('];
         if (snippetBlock.parameters?.length) {
             const start = snippetBlock.parameters?.[0].start;
-            const end = snippetBlock.parameters.at(-1).end;
+            const end = last_parameter.typeAnnotation
+                ? last_parameter?.typeAnnotation.end
+                : last_parameter.end;
             transforms.push([start, end]);
             str.overwrite(snippetBlock.expression.end, start, '', {
                 contentOnly: true
@@ -94,7 +102,9 @@ export function handleSnippet(
 
         if (snippetBlock.parameters?.length) {
             const start = snippetBlock.parameters[0].start;
-            const end = snippetBlock.parameters.at(-1).end;
+            const end = last_parameter.typeAnnotation
+                ? last_parameter?.typeAnnotation.end
+                : last_parameter.end;
             transforms.push([start, end]);
         }
 

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/SnippetBlock.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/SnippetBlock.ts
@@ -42,27 +42,20 @@ export function handleSnippet(
         }
     );
 
-    const last_parameter = snippetBlock.parameters?.at(-1);
+    const lastParameter = snippetBlock.parameters?.at(-1);
 
     const startEnd =
         str.original.indexOf(
             '}',
-            // context was the first iteration in a .next release, remove at some point
-            (last_parameter?.typeAnnotation
-                ? // if it has a type annotation use the end of the type annotation
-                  // else the end of the parameter
-                  last_parameter?.typeAnnotation.end
-                : last_parameter?.end) || snippetBlock.expression.end
+            lastParameter?.typeAnnotation.end ?? lastParameter?.end ?? snippetBlock.expression.end
         ) + 1;
 
     if (isImplicitProp) {
         str.overwrite(snippetBlock.start, snippetBlock.expression.start, '', { contentOnly: true });
         const transforms: TransformationArray = ['('];
         if (snippetBlock.parameters?.length) {
-            const start = snippetBlock.parameters?.[0].start;
-            const end = last_parameter.typeAnnotation
-                ? last_parameter?.typeAnnotation.end
-                : last_parameter.end;
+            const start = snippetBlock.parameters[0].start;
+            const end = lastParameter.typeAnnotation?.end ?? lastParameter.end;
             transforms.push([start, end]);
             str.overwrite(snippetBlock.expression.end, start, '', {
                 contentOnly: true
@@ -82,18 +75,18 @@ export function handleSnippet(
         if (snippetBlock.parameters?.length) {
             generic = `<[${snippetBlock.parameters
                 .map((p) => {
-                    let type_annotation = p.typeAnnotation;
-                    if (!type_annotation && p.type === 'AssignmentPattern') {
-                        type_annotation = p.left?.typeAnnotation;
-                        if (!type_annotation) {
-                            type_annotation = p.right?.typeAnnotation;
+                    let typeAnnotation = p.typeAnnotation;
+                    if (!typeAnnotation && p.type === 'AssignmentPattern') {
+                        typeAnnotation = p.left?.typeAnnotation;
+                        if (!typeAnnotation) {
+                            typeAnnotation = p.right?.typeAnnotation;
                         }
                     }
-                    if (!type_annotation) return 'any';
-                    return type_annotation.typeAnnotation
+                    if (!typeAnnotation) return 'any';
+                    return typeAnnotation.typeAnnotation
                         ? str.original.slice(
-                              type_annotation.typeAnnotation.start,
-                              type_annotation.typeAnnotation.end
+                              typeAnnotation.typeAnnotation.start,
+                              typeAnnotation.typeAnnotation.end
                           )
                         : // slap any on to it to silence "implicit any" errors; JSDoc people can't add types to snippets
                           'any';
@@ -110,9 +103,7 @@ export function handleSnippet(
 
         if (snippetBlock.parameters?.length) {
             const start = snippetBlock.parameters[0].start;
-            const end = last_parameter.typeAnnotation
-                ? last_parameter?.typeAnnotation.end
-                : last_parameter.end;
+            const end = lastParameter.typeAnnotation?.end ?? lastParameter.end;
             transforms.push([start, end]);
         }
 

--- a/packages/svelte2tsx/test/helpers.ts
+++ b/packages/svelte2tsx/test/helpers.ts
@@ -225,8 +225,6 @@ const enum TestError {
 
 const isSvelte5Plus = Number(VERSION[0]) >= 5;
 
-console.log('IS SVELTE 5 +', isSvelte5Plus);
-
 export function test_samples(dir: string, transform: TransformSampleFn, js: 'js' | 'ts') {
     for (const sample of each_sample(dir)) {
         if (sample.name.endsWith('.v5') && !isSvelte5Plus) continue;

--- a/packages/svelte2tsx/test/helpers.ts
+++ b/packages/svelte2tsx/test/helpers.ts
@@ -225,6 +225,8 @@ const enum TestError {
 
 const isSvelte5Plus = Number(VERSION[0]) >= 5;
 
+console.log('IS SVELTE 5 +', isSvelte5Plus);
+
 export function test_samples(dir: string, transform: TransformSampleFn, js: 'js' | 'ts') {
     for (const sample of each_sample(dir)) {
         if (sample.name.endsWith('.v5') && !isSvelte5Plus) continue;
@@ -320,12 +322,16 @@ export function test_samples(dir: string, transform: TransformSampleFn, js: 'js'
                     try {
                         assert.strictEqual(actual, expected, TestError.WrongExpected);
                     } catch (e) {
+                        // html2jsx tests don't have the default export
+                        const expectDefaultExportPosition = expected.lastIndexOf(
+                            '\n\nexport default class'
+                        );
+                        if (expectDefaultExportPosition === -1) {
+                            throw e;
+                        }
                         // retry with the last part (the returned default export) stripped because it's always differing between old and new,
                         // and if that fails then we're going to rethrow the original error
-                        const expectedModified = expected.substring(
-                            0,
-                            expected.lastIndexOf('\n\nexport default class')
-                        );
+                        const expectedModified = expected.substring(0, expectDefaultExportPosition);
                         const actualModified = actual.substring(0, actual.lastIndexOf('\nconst '));
                         try {
                             assert.strictEqual(

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/ts-in-template.v5/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/ts-in-template.v5/expectedv2.js
@@ -24,6 +24,8 @@ item as string;
 
  var foo3/*Ωignore_startΩ*/: import('svelte').Snippet<[string | number, (str: string)=>void]>/*Ωignore_endΩ*/ = (bar    : string | number, baz     : (str: string)=>void) => {async () => { };return __sveltets_2_any(0)};
 
+ var foo3/*Ωignore_startΩ*/: import('svelte').Snippet<[{baz: string}]>/*Ωignore_endΩ*/ = (bar: {baz: string}) => {async () => { };return __sveltets_2_any(0)};
+
 ;__sveltets_2_ensureSnippet(foo(bar as string));
 
  { svelteHTML.createElement("button", { "onclick":(e: Event) => {e as any},});  }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/ts-in-template.v5/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/ts-in-template.v5/input.svelte
@@ -38,6 +38,10 @@
     snippet
 {/snippet}
 
+{#snippet foo3(bar: {baz: string})}
+    snippet
+{/snippet}
+
 {@render foo(bar as string)}
 
 <button onclick={(e: Event) => {e as any}}>click</button>


### PR DESCRIPTION
After https://github.com/sveltejs/svelte/pull/12070 the AST for the SnippetBlock has changed (to be more correct).

The problem is that `svelte2tsx` was using that wrong information for the transformation. This means that currently last version of svelte produces wrong ts code from `svelte2tsx`.

The problem is that before parameter `end` was including the typeAnnotation
<img width="1312" alt="image" src="https://github.com/sveltejs/language-tools/assets/26281609/2f6581c9-519c-4b1e-a6c7-1a440e7f8e64">
while now it stops where it should (at the parameter)
<img width="1282" alt="image" src="https://github.com/sveltejs/language-tools/assets/26281609/7c523cc9-b76f-45f3-ae45-032ec7ab1ae9">

this PR fixes this problem by looking at the end of typeAnnotation if there's one and falling back to the end of the parameter otherwise.

I tried to update a test but despite messing with the expected to make it fail it was still passing so i think i need a bit of guidance over this (sorry).

~Also currently there's one failing test for the language server (in the SemanticTokenProvider so i have to check what's that.~

~Ok by debugging the language server it seems like the type semantic tokens are lost in the snippet...will try to fix~

Lol scratch last one it was failing in master too, i just needed a `pnpm i`