### PR TITLE
chore: remove undocumented filePathsToIgnore option

### DIFF
--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -26,6 +26,7 @@ type Result = {
 };
 
 async function openAllDocuments(workspaceUri: URI, svelteCheck: SvelteCheck) {
+    // TODO: replace glob with smaller implementation
     const files = await glob('**/*.svelte', {
         cwd: workspaceUri.fsPath,
         ignore: ['node_modules/**']

--- a/packages/svelte-check/src/options.ts
+++ b/packages/svelte-check/src/options.ts
@@ -9,7 +9,6 @@ export interface SvelteCheckCliOptions {
     watch: boolean;
     preserveWatchOutput: boolean;
     tsconfig?: string;
-    filePathsToIgnore: string[];
     failOnWarnings: boolean;
     compilerWarnings: Record<string, 'error' | 'ignore'>;
     diagnosticSources: DiagnosticSource[];
@@ -73,7 +72,6 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
                 watch: !!opts.watch,
                 preserveWatchOutput: !!opts.preserveWatchOutput,
                 tsconfig: getTsconfig(opts, workspaceUri.fsPath),
-                filePathsToIgnore: getFilepathsToIgnore(opts),
                 failOnWarnings: !!opts['fail-on-warnings'],
                 compilerWarnings: getCompilerWarnings(opts),
                 diagnosticSources: getDiagnosticSources(opts),


### PR DESCRIPTION
ref https://github.com/sveltejs/language-tools/issues/2397

I did a search on GitHub and can't find anyone using this. If no one complains about it that will free us up to swap `fast-glob` with a lighter library. For now I left `fast-glob` in place, but we can follow up to remove it later on assuming no one misses this option