### PR TITLE
fix: prevent false positive store declarations

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -203,7 +203,10 @@ export function processInstanceScriptContent(
         if (ts.isVariableDeclaration(node)) {
             events.checkIfIsStringLiteralDeclaration(node);
             events.checkIfDeclarationInstantiatedEventDispatcher(node);
-            implicitStoreValues.addVariableDeclaration(node);
+            // Only top level declarations can be stores
+            if (node.parent?.parent?.parent === tsAst) {
+                implicitStoreValues.addVariableDeclaration(node);
+            }
         }
 
         if (ts.isCallExpression(node)) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-nested-declaration/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-nested-declaration/expectedv2.ts
@@ -1,0 +1,14 @@
+///<reference types="svelte" />
+;function render() {
+
+    function x(tr) {
+        for (let notAStore of tr.effects) {}
+    }
+
+    $notAStore;
+;
+async () => {};
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event(render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/$store-nested-declaration/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/$store-nested-declaration/input.svelte
@@ -1,0 +1,7 @@
+<script>
+    function x(tr) {
+        for (let notAStore of tr.effects) {}
+    }
+
+    $notAStore;
+</script>


### PR DESCRIPTION
variable declarations not at the top level can't be subscribed to using the `$` prefix