### PR TITLE
fix: always set bindings/exports in Svelte 5

### DIFF
--- a/packages/svelte2tsx/test/helpers.ts
+++ b/packages/svelte2tsx/test/helpers.ts
@@ -330,7 +330,11 @@ export function test_samples(dir: string, transform: TransformSampleFn, js: 'js'
                         // retry with the last part (the returned default export) stripped because it's always differing between old and new,
                         // and if that fails then we're going to rethrow the original error
                         const expectedModified = expected.substring(0, expectDefaultExportPosition);
-                        const actualModified = actual.substring(0, actual.lastIndexOf('\nconst '));
+                        const actualModified = actual
+                            .substring(0, actual.lastIndexOf('\nconst '))
+                            // not added in Svelte 4
+                            .replace(', exports: {}', '')
+                            .replace(', bindings: ""', '');
                         try {
                             assert.strictEqual(
                                 actualModified,

--- a/packages/svelte2tsx/test/svelte2tsx/samples/accessors-config/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/accessors-config/expected-svelte5.ts
@@ -4,7 +4,7 @@
 	 let foo: number = undefined/*Ωignore_startΩ*/;foo = __sveltets_2_any(foo);/*Ωignore_endΩ*/;
 ;
 async () => {};
-return { props: {foo: foo}, exports: /** @type {{foo: number}} */ ({}), slots: {}, events: {} }}
+return { props: {foo: foo}, exports: /** @type {{foo: number}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['foo'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-forward-with-props/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-forward-with-props/expected-svelte5.ts
@@ -4,7 +4,7 @@
 async () => { { const $$_tneraP0C = __sveltets_2_ensureComponent(Parent); const $$_tneraP0 = new $$_tneraP0C({ target: __sveltets_2_any(), props: {      children:() => { return __sveltets_2_any(0); },"propA":true,propB,"propC":`val1`,"propD":`val2`,"propE":`a${a}b${b}`,}});{const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,foo,} = $$_tneraP0.$$slot_def.default;$$_$$;
      { __sveltets_createSlot("default", { foo,});}
  }Parent}};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {foo:__sveltets_2_instanceOf(Parent).$$slot_def['default'].foo}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {'default': {foo:__sveltets_2_instanceOf(Parent).$$slot_def['default'].foo}}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component_slots(__sveltets_2_partial(__sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-let-forward/expected-svelte5.ts
@@ -4,7 +4,7 @@
 async () => { { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); const $$_tnenopmoC0 = new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {     children:() => { return __sveltets_2_any(0); },}});{const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,name:n,thing,whatever:{ bla },} = $$_tnenopmoC0.$$slot_def.default;$$_$$;
      { __sveltets_createSlot("default", {   n,thing,bla,});}
  }Component}};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {n:__sveltets_2_instanceOf(Component).$$slot_def['default'].name, thing:__sveltets_2_instanceOf(Component).$$slot_def['default'].thing, bla:(({ bla }) => bla)(__sveltets_2_instanceOf(Component).$$slot_def['default'].whatever)}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {'default': {n:__sveltets_2_instanceOf(Component).$$slot_def['default'].name, thing:__sveltets_2_instanceOf(Component).$$slot_def['default'].thing, bla:(({ bla }) => bla)(__sveltets_2_instanceOf(Component).$$slot_def['default'].whatever)}}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component_slots(__sveltets_2_partial(__sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-nest-scope/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-nest-scope/expected-svelte5.ts
@@ -12,7 +12,7 @@ async () => {  for(let item of __sveltets_2_ensureArray(items)){
     d;
 }}
  { __sveltets_createSlot("third", {   d,c,}); }};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {a:(({ a }) => a)(__sveltets_2_unwrapArr(__sveltets_2_unwrapArr(items)))}, 'second': {a:a}, 'third': {d:d, c:c}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {'default': {a:(({ a }) => a)(__sveltets_2_unwrapArr(__sveltets_2_unwrapArr(items)))}, 'second': {a:a}, 'third': {d:d, c:c}}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component_slots(__sveltets_2_partial(__sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-no-space/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-slot-no-space/expected-svelte5.ts
@@ -8,7 +8,7 @@ function render() {
 async () => {
 
  { svelteHTML.createElement("div", {}); { const $$_tseT1C = __sveltets_2_ensureComponent(Test); const $$_tseT1 = new $$_tseT1C({ target: __sveltets_2_any(), props: { children:() => { return __sveltets_2_any(0); },}});{const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,t,} = $$_tseT1.$$slot_def.default;$$_$$;  }Test} }};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-documentation/expected-svelte5.ts
@@ -3,7 +3,7 @@
 async () => {
 
  { svelteHTML.createElement("main", {});     }};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
 /** This component does nothing at all */
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-indented-multiline-documentation/expected-svelte5.ts
@@ -3,7 +3,7 @@
 async () => {
 
  { svelteHTML.createElement("main", {});     }};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
 /**
  * This component has indented multiline documentation:
  *

--- a/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/component-with-multiline-documentation/expected-svelte5.ts
@@ -3,7 +3,7 @@
 async () => {
 
  { svelteHTML.createElement("main", {});     }};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
 /**
  * This component has multiline documentation:
  *

--- a/packages/svelte2tsx/test/svelte2tsx/samples/const-tag-component/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/const-tag-component/expected-svelte5.ts
@@ -63,7 +63,7 @@ async () => {
 	const [_width, _height, sum] = [width * constant, height, width * constant + height];	
 	 { svelteHTML.createElement("div", {});area; volume; perimeter; _width; _height; sum; }
  }Component}};
-return { props: {box: box , constant: constant}, slots: {}, events: {} }}
+return { props: {box: box , constant: constant}, exports: {}, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['box','constant'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/creates-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/creates-dts/expected-svelte5.ts
@@ -23,7 +23,7 @@ async () => {
  { svelteHTML.createElement("button", { "on:click":undefined,});  }
  { __sveltets_createSlot("default", {bar,}); }};
 return { props: {
-/** @type {boolean} */bar: bar , foobar: foobar}, slots: {'default': {bar:bar}}, events: {'click':__sveltets_2_mapElementEvent('click'), 'hi': __sveltets_2_customEvent} }}
+/** @type {boolean} */bar: bar , foobar: foobar}, exports: {}, bindings: "", slots: {'default': {bar:bar}}, events: {'click':__sveltets_2_mapElementEvent('click'), 'hi': __sveltets_2_customEvent} }}
 interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
     (internal: unknown, props: Props & {$$events?: Events, $$slots?: Slots}): Exports;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/creates-no-script-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/creates-no-script-dts/expected-svelte5.ts
@@ -5,7 +5,7 @@ async () => { { svelteHTML.createElement("button", { "on:click":undefined,}); { 
    { const $$_value = await (Promise.resolve(0));{ const n = $$_value; 
   n;
 }}};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {}}, events: {'click':__sveltets_2_mapElementEvent('click')} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {'default': {}}, events: {'click':__sveltets_2_mapElementEvent('click')} }}
 interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
     (internal: unknown, props: {$$events?: Events, $$slots?: Slots}): Exports;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-class/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-class/expected-svelte5.ts
@@ -4,7 +4,7 @@
      class Foo {};
 ;
 async () => {};
-return { props: {Foo: Foo}, exports: /** @type {{Foo: typeof Foo}} */ ({}), slots: {}, events: {} }}
+return { props: {Foo: Foo}, exports: /** @type {{Foo: typeof Foo}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['Foo'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-const-array-destructuring/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-const-array-destructuring/expected-svelte5.ts
@@ -6,7 +6,7 @@ const array = [1, 2, 3, [4]];
  const [a, b, c, [d]] = array;
 ;
 async () => {};
-return { props: {a: a , b: b , c: c , d: d}, exports: /** @type {{a: typeof a,b: typeof b,c: typeof c,d: typeof d}} */ ({}), slots: {}, events: {} }}
+return { props: {a: a , b: b , c: c , d: d}, exports: /** @type {{a: typeof a,b: typeof b,c: typeof c,d: typeof d}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['a','b','c','d'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-const-object-destructuring/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-const-object-destructuring/expected-svelte5.ts
@@ -15,7 +15,7 @@ const obj = {
 } = obj;
 ;
 async () => {};
-return { props: {a: a , b: b , c: c , g: g}, exports: /** @type {{a: typeof a,b: typeof b,c: typeof c,g: typeof g}} */ ({}), slots: {}, events: {} }}
+return { props: {a: a , b: b , c: c , g: g}, exports: /** @type {{a: typeof a,b: typeof b,c: typeof c,g: typeof g}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['a','b','c','g'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-list/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-list/expected-svelte5.ts
@@ -18,7 +18,7 @@
     
 ;
 async () => {};
-return { props: {name1: name1 , name2: name2 , renamed1: rename1 , renamed2: rename2 , Foo: Foo , bar: bar , baz: baz , RenamedFoo: RenameFoo , renamedbar: renamebar , renamedbaz: renamebaz}, exports: /** @type {{Foo: typeof Foo,bar: typeof bar,baz: typeof baz,RenamedFoo: typeof RenameFoo,renamedbar: typeof renamebar,renamedbaz: typeof renamebaz}} */ ({}), slots: {}, events: {} }}
+return { props: {name1: name1 , name2: name2 , renamed1: rename1 , renamed2: rename2 , Foo: Foo , bar: bar , baz: baz , RenamedFoo: RenameFoo , renamedbar: renamebar , renamedbaz: renamebaz}, exports: /** @type {{Foo: typeof Foo,bar: typeof bar,baz: typeof baz,RenamedFoo: typeof RenameFoo,renamedbar: typeof renamebar,renamedbaz: typeof renamebaz}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['name1','renamed1','Foo','bar','baz','RenamedFoo','renamedbar','renamedbaz'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/generic-attribute-const-modifier/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/generic-attribute-const-modifier/expected-svelte5.ts
@@ -4,7 +4,7 @@
  let items: T/*Ωignore_startΩ*/;items = __sveltets_2_any(items);/*Ωignore_endΩ*/;
 ;
 async () => {};
-return { props: {items: items}, slots: {}, events: {} }}
+return { props: {items: items}, exports: {}, bindings: "", slots: {}, events: {} }}
 class __sveltets_Render<const T extends readonly string[]> {
     props() {
         return render<T>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-best-effort-types.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-best-effort-types.v5/expectedv2.ts
@@ -4,7 +4,7 @@
     let/** @typedef {{ a: unknown, b?: boolean, c?: number, d?: string, e?: unknown, f?: unknown, g?: typeof foo }} $$ComponentProps *//** @type {$$ComponentProps} */ { a, b = true, c = 1, d = '', e = null, f = {}, g = foo } = $props(); 
 ;
 async () => {};
-return { props: /** @type {$$ComponentProps} */({}), bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-bindable.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-bindable.v5/expectedv2.ts
@@ -4,7 +4,7 @@
     let/** @typedef {{ a: unknown, b?: unknown }} $$ComponentProps *//** @type {$$ComponentProps} */ { a, b = $bindable() } = $props();
 ;
 async () => {};
-return { props: /** @type {$$ComponentProps} */({}), bindings: __sveltets_$$bindings('b'), slots: {}, events: {} }}
+return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings('b'), slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-looking-like-stores.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-looking-like-stores.v5/expectedv2.ts
@@ -8,7 +8,7 @@
 async () => {
 
 state; derived;};
-return { props: /** @type {$$ComponentProps} */({}), bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-with-slots.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-with-slots.v5/expectedv2.ts
@@ -10,7 +10,7 @@
 async () => {
 
  { __sveltets_createSlot("default", {  x,y,});}};
-return { props: /** @type {SomeType} */({}), bindings: __sveltets_$$bindings(''), slots: {'default': {x:x, y:y}}, events: {} }}
+return { props: /** @type {SomeType} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {'default': {x:x, y:y}}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component_slots(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes.v5/expectedv2.ts
@@ -7,7 +7,7 @@
     let y = $derived(x * 2);
 ;
 async () => {};
-return { props: /** @type {$$ComponentProps} */({}), bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-style-like-component/expected-svelte5.ts
@@ -9,7 +9,7 @@ async () => {
      { svelteHTML.createElement("p", {}); }
  Script}
  { const $$_elytS0C = __sveltets_2_ensureComponent(Style); new $$_elytS0C({ target: __sveltets_2_any(), props: {}});}};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes/expected-svelte5.ts
@@ -10,7 +10,7 @@
      let data: number/*Ωignore_startΩ*/;data = __sveltets_2_any(data);/*Ωignore_endΩ*/;
 ;
 async () => {};
-return { props: {data: data , form: form , snapshot: snapshot , nope: nope}, exports: /** @type {{snapshot: typeof snapshot}} */ ({}), slots: {}, events: {} }}
+return { props: {data: data , form: form , snapshot: snapshot , nope: nope}, exports: /** @type {{snapshot: typeof snapshot}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Page__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['form','snapshot'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Page__SvelteComponent_ = InstanceType<typeof Page__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Page__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/transforms-interfaces-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/transforms-interfaces-dts/expected-svelte5.ts
@@ -21,7 +21,7 @@ function render() {
      let bar: Bar3/*Ωignore_startΩ*/;bar = __sveltets_2_any(bar);/*Ωignore_endΩ*/;
 ;
 async () => {};
-return { props: {foo: foo , bar: bar}, slots: {}, events: {} }}
+return { props: {foo: foo , bar: bar}, exports: {}, bindings: "", slots: {}, events: {} }}
 interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
     (internal: unknown, props: Props & {$$events?: Events, $$slots?: Slots}): Exports;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-interface/expected-svelte5.ts
@@ -31,7 +31,7 @@
     
 ;
 async () => {};
-return { props: { ...__sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props)} as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, exports: {} as any as { Foo: typeof Foo,bar: typeof bar,baz: string,RenamedFoo: typeof RenameFoo,renamedbar: typeof renamebar,renamedbaz: string }, slots: {}, events: {} }}
+return { props: { ...__sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props)} as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, exports: {} as any as { Foo: typeof Foo,bar: typeof bar,baz: string,RenamedFoo: typeof RenameFoo,renamedbar: typeof renamebar,renamedbaz: string }, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-type/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-type/expected-svelte5.ts
@@ -31,7 +31,7 @@
     
 ;
 async () => {};
-return { props: { ...__sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props)} as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, exports: {} as any as { Foo: typeof Foo,bar: typeof bar,baz: string,RenamedFoo: typeof RenameFoo,renamedbar: typeof renamebar,renamedbaz: string }, slots: {}, events: {} }}
+return { props: { ...__sveltets_2_ensureRightProps<{exported1: string,exported2?: string,name1?: string,name2: string,renamed1?: string,renamed2: string}>(__sveltets_2_any("") as $$Props)} as {Foo?: typeof Foo,bar?: typeof bar,baz?: string,RenamedFoo?: typeof RenameFoo,renamedbar?: typeof renamebar,renamedbaz?: string} & $$Props, exports: {} as any as { Foo: typeof Foo,bar: typeof bar,baz: string,RenamedFoo: typeof RenameFoo,renamedbar: typeof renamebar,renamedbaz: string }, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-with-$$props/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$Props-with-$$props/expected-svelte5.ts
@@ -13,7 +13,7 @@
 async () => {
 
 $$props;};
-return { props: { ...__sveltets_2_ensureRightProps<{}>(__sveltets_2_any("") as $$Props)} as {c?: typeof c} & $$Props, exports: {} as any as { c: typeof c }, slots: {}, events: {} }}
+return { props: { ...__sveltets_2_ensureRightProps<{}>(__sveltets_2_any("") as $$Props)} as {c?: typeof c} & $$Props, exports: {} as any as { c: typeof c }, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-accessor-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-accessor-dts/expected-svelte5.ts
@@ -9,7 +9,7 @@ import { SvelteComponentTyped } from "svelte"
 async () => {
 
   { svelteHTML.createElement("svelte:options", {"accessors":true,});}};
-return { props: {a: a} as {a: A}, exports: {} as any as { a: A }, slots: {}, events: {} }}
+return { props: {a: a} as {a: A}, exports: {} as any as { a: A }, bindings: "", slots: {}, events: {} }}
 class __sveltets_Render<A> {
     props() {
         return render<A>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-accessor/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-accessor/expected-svelte5.ts
@@ -8,7 +8,7 @@
 async () => {
 
   { svelteHTML.createElement("svelte:options", {"accessors":true,});}};
-return { props: {a: a} as {a: A}, exports: {} as any as { a: A }, slots: {}, events: {} }}
+return { props: {a: a} as {a: A}, exports: {} as any as { a: A }, bindings: "", slots: {}, events: {} }}
 class __sveltets_Render<A> {
     props() {
         return render<A>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-dts/expected-svelte5.ts
@@ -23,7 +23,7 @@ function render/*Ωignore_startΩ*/<A,B extends keyof A,C extends boolean>/*Ωig
 async () => {
 
  { __sveltets_createSlot("default", { c,});}};
-return { props: {a: a , b: b , c: c , getA: getA} as {a: A, b: B, c: C, getA?: typeof getA}, exports: {} as any as { getA: typeof getA }, slots: {'default': {c:c}}, events: {...__sveltets_2_toEventTypings<{a: A}>()} }}
+return { props: {a: a , b: b , c: c , getA: getA} as {a: A, b: B, c: C, getA?: typeof getA}, exports: {} as any as { getA: typeof getA }, bindings: "", slots: {'default': {c:c}}, events: {...__sveltets_2_toEventTypings<{a: A}>()} }}
 class __sveltets_Render<A,B extends keyof A,C extends boolean> {
     props() {
         return render<A,B,C>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-interface-references/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics-interface-references/expected-svelte5.ts
@@ -20,7 +20,7 @@ function render/*Ωignore_startΩ*/<A,B extends ReferencedByGeneric>/*Ωignore_e
      let b: B/*Ωignore_startΩ*/;b = __sveltets_2_any(b);/*Ωignore_endΩ*/;
 ;
 async () => {};
-return { props: {a: a , b: b} as {a: ReferencesGeneric, b: B}, slots: {}, events: {} }}
+return { props: {a: a , b: b} as {a: ReferencesGeneric, b: B}, exports: {}, bindings: "", slots: {}, events: {} }}
 class __sveltets_Render<A,B extends ReferencedByGeneric> {
     props() {
         return render<A,B>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-$$generics/expected-svelte5.ts
@@ -23,7 +23,7 @@ function render/*Ωignore_startΩ*/<A,B extends keyof A,C extends boolean>/*Ωig
 async () => {
 
  { __sveltets_createSlot("default", { c,});}};
-return { props: {a: a , b: b , c: c , getA: getA} as {a: A, b: B, c: C, getA?: typeof getA}, exports: {} as any as { getA: typeof getA }, slots: {'default': {c:c}}, events: {...__sveltets_2_toEventTypings<{a: A}>()} }}
+return { props: {a: a , b: b , c: c , getA: getA} as {a: A, b: B, c: C, getA?: typeof getA}, exports: {} as any as { getA: typeof getA }, bindings: "", slots: {'default': {c:c}}, events: {...__sveltets_2_toEventTypings<{a: A}>()} }}
 class __sveltets_Render<A,B extends keyof A,C extends boolean> {
     props() {
         return render<A,B,C>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-creates-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-creates-dts/expected-svelte5.ts
@@ -22,7 +22,7 @@ async () => {
 
  { svelteHTML.createElement("button", { "on:click":undefined,});  }
  { __sveltets_createSlot("default", {bar,}); }};
-return { props: {bar: bar , foobar: foobar} as {bar: Bar, foobar?: typeof foobar}, slots: {'default': {bar:bar}}, events: {...__sveltets_2_toEventTypings<{swipe: string}>(), 'click':__sveltets_2_mapElementEvent('click')} }}
+return { props: {bar: bar , foobar: foobar} as {bar: Bar, foobar?: typeof foobar}, exports: {}, bindings: "", slots: {'default': {bar:bar}}, events: {...__sveltets_2_toEventTypings<{swipe: string}>(), 'click':__sveltets_2_mapElementEvent('click')} }}
 interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
     (internal: unknown, props: Props & {$$events?: Events, $$slots?: Slots}): Exports;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-const/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-const/expected-svelte5.ts
@@ -5,7 +5,7 @@
      const SOME = 1, CONSTANT = 2;
 ;
 async () => {};
-return { props: {name: name , SOME: SOME , CONSTANT: CONSTANT} as {name?: string, SOME?: typeof SOME, CONSTANT?: typeof CONSTANT}, exports: {} as any as { name: string,SOME: typeof SOME,CONSTANT: typeof CONSTANT }, slots: {}, events: {} }}
+return { props: {name: name , SOME: SOME , CONSTANT: CONSTANT} as {name?: string, SOME?: typeof SOME, CONSTANT?: typeof CONSTANT}, exports: {} as any as { name: string,SOME: typeof SOME,CONSTANT: typeof CONSTANT }, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-list/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-list/expected-svelte5.ts
@@ -19,7 +19,7 @@
     
 ;
 async () => {};
-return { props: {name1: name1 , name2: name2 , name3: name3 , name4: name4 , renamed1: rename1 , renamed2: rename2 , Foo: Foo , bar: bar , baz: baz , RenamedFoo: RenameFoo , renamedbar: renamebar , renamedbaz: renamebaz} as {name1?: string, name2: string, name3?: string, name4: string, renamed1?: string, renamed2: string, Foo?: typeof Foo, bar?: typeof bar, baz?: string, RenamedFoo?: typeof RenameFoo, renamedbar?: typeof renamebar, renamedbaz?: string}, exports: {} as any as { Foo: typeof Foo,bar: typeof bar,baz: string,RenamedFoo: typeof RenameFoo,renamedbar: typeof renamebar,renamedbaz: string }, slots: {}, events: {} }}
+return { props: {name1: name1 , name2: name2 , name3: name3 , name4: name4 , renamed1: rename1 , renamed2: rename2 , Foo: Foo , bar: bar , baz: baz , RenamedFoo: RenameFoo , renamedbar: renamebar , renamedbaz: renamebaz} as {name1?: string, name2: string, name3?: string, name4: string, renamed1?: string, renamed2: string, Foo?: typeof Foo, bar?: typeof bar, baz?: string, RenamedFoo?: typeof RenameFoo, renamedbar?: typeof renamebar, renamedbaz?: string}, exports: {} as any as { Foo: typeof Foo,bar: typeof bar,baz: string,RenamedFoo: typeof RenameFoo,renamedbar: typeof renamebar,renamedbaz: string }, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-generics-attribute1/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-generics-attribute1/expected-svelte5.ts
@@ -19,7 +19,7 @@ function render<A, B extends keyof A, C extends boolean>() {
 async () => {
 
  { __sveltets_createSlot("default", { c,});}};
-return { props: {a: a , b: b , c: c , getA: getA} as {a: A, b: B, c: C, getA?: typeof getA}, exports: {} as any as { getA: typeof getA }, slots: {'default': {c:c}}, events: {...__sveltets_2_toEventTypings<{a: A}>()} }}
+return { props: {a: a , b: b , c: c , getA: getA} as {a: A, b: B, c: C, getA?: typeof getA}, exports: {} as any as { getA: typeof getA }, bindings: "", slots: {'default': {c:c}}, events: {...__sveltets_2_toEventTypings<{a: A}>()} }}
 class __sveltets_Render<A,B extends keyof A,C extends boolean> {
     props() {
         return render<A,B,C>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-generics-attribute2/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-generics-attribute2/expected-svelte5.ts
@@ -4,7 +4,7 @@
      let a: T/*Ωignore_startΩ*/;a = __sveltets_2_any(a);/*Ωignore_endΩ*/;
 ;
 async () => {};
-return { props: {a: a} as {a: T}, slots: {}, events: {} }}
+return { props: {a: a} as {a: T}, exports: {}, bindings: "", slots: {}, events: {} }}
 class __sveltets_Render<T> {
     props() {
         return render<T>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-best-effort-types.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-best-effort-types.v5/expectedv2.ts
@@ -4,7 +4,7 @@
     let { a, b = true, c = 1, d = '', e = null, f = {}, g = foo, h = null as Bar, i = null as any as Baz }: $$ComponentProps = $props(); 
 ;
 async () => {};
-return { props: {} as any as $$ComponentProps, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable.v5/expectedv2.ts
@@ -4,7 +4,7 @@
     let { a, b = $bindable(), c = $bindable(0) as number }: $$ComponentProps = $props();
 ;
 async () => {};
-return { props: {} as any as $$ComponentProps, bindings: __sveltets_$$bindings('b', 'c'), slots: {}, events: {} }}
+return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings('b', 'c'), slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-generics.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-generics.v5/expectedv2.ts
@@ -6,7 +6,7 @@
     let y = $derived(x * 2);
 ;
 async () => {};
-return { props: {} as any as $$ComponentProps, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
 class __sveltets_Render<T> {
     props() {
         return render<T>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-with-slot.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-with-slot.v5/expectedv2.ts
@@ -10,7 +10,7 @@
 async () => {
 
  { __sveltets_createSlot("default", {  x,y,});}};
-return { props: {} as any as Props, bindings: __sveltets_$$bindings(''), slots: {'default': {x:x, y:y}}, events: {} }}
+return { props: {} as any as Props, exports: {}, bindings: __sveltets_$$bindings(''), slots: {'default': {x:x, y:y}}, events: {} }}
 class __sveltets_Render<T> {
     props() {
         return render<T>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes.v5/expectedv2.ts
@@ -6,7 +6,7 @@
     let y = $derived(x * 2);
 ;
 async () => {};
-return { props: {} as any as $$ComponentProps, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-script-tag-generics/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-script-tag-generics/expected-svelte5.ts
@@ -4,7 +4,7 @@
      let init: T/*Ωignore_startΩ*/;init = __sveltets_2_any(init);/*Ωignore_endΩ*/;
 ;
 async () => {};
-return { props: {init: init} as {init: T}, slots: {}, events: {} }}
+return { props: {init: init} as {init: T}, exports: {}, bindings: "", slots: {}, events: {} }}
 class __sveltets_Render<T extends Record<string, any>> {
     props() {
         return render<T>().props;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-attr-not-present/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-attr-not-present/expected-svelte5.ts
@@ -6,7 +6,7 @@
 ;
 async () => { { svelteHTML.createElement("svelte:options", {});}
 };
-return { props: {foo: foo , bar: bar}, exports: /** @type {{bar: string}} */ ({}), slots: {}, events: {} }}
+return { props: {foo: foo , bar: bar}, exports: /** @type {{bar: string}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['foo','bar'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-attr-present/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-attr-present/expected-svelte5.ts
@@ -9,7 +9,7 @@
 ;
 async () => {  { svelteHTML.createElement("svelte:options", {"accessors":true,});}
 };
-return { props: {foo: foo , foo2: foo2 , class: clazz , bar: bar}, exports: /** @type {{foo: number,foo2: typeof foo2,class: string,bar: string}} */ ({}), slots: {}, events: {} }}
+return { props: {foo: foo , foo2: foo2 , class: clazz , bar: bar}, exports: /** @type {{foo: number,foo2: typeof foo2,class: string,bar: string}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['foo','foo2','bar'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-mustachetag-false/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-mustachetag-false/expected-svelte5.ts
@@ -6,7 +6,7 @@
 ;
 async () => { { svelteHTML.createElement("svelte:options", {  "accessors":false,});}
 };
-return { props: {foo: foo , bar: bar}, exports: /** @type {{bar: string}} */ ({}), slots: {}, events: {} }}
+return { props: {foo: foo , bar: bar}, exports: /** @type {{bar: string}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['foo','bar'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-mustachetag-true/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-mustachetag-true/expected-svelte5.ts
@@ -9,7 +9,7 @@
 ;
 async () => { { svelteHTML.createElement("svelte:options", {  "accessors":true,});}
 };
-return { props: {foo: foo , foo2: foo2 , class: clazz , bar: bar}, exports: /** @type {{foo: number,foo2: typeof foo2,class: string,bar: string}} */ ({}), slots: {}, events: {} }}
+return { props: {foo: foo , foo2: foo2 , class: clazz , bar: bar}, exports: /** @type {{foo: number,foo2: typeof foo2,class: string,bar: string}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['foo','foo2','bar'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-no-svelte-options/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-accessors-no-svelte-options/expected-svelte5.ts
@@ -5,7 +5,7 @@
 	 const bar: string = ''
 ;
 async () => {};
-return { props: {foo: foo , bar: bar}, exports: /** @type {{bar: string}} */ ({}), slots: {}, events: {} }}
+return { props: {foo: foo , bar: bar}, exports: /** @type {{bar: string}} */ ({}), bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['foo','bar'], __sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components-let-forward/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components-let-forward/expected-svelte5.ts
@@ -9,7 +9,7 @@ async () => {if(true){
  { const $$_tnenopmoc_etlevs0C = __sveltets_2_ensureComponent(testComponent); const $$_tnenopmoc_etlevs0 = new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: {  children:() => { return __sveltets_2_any(0); },}});{const {/*Ωignore_startΩ*/$$_$$/*Ωignore_endΩ*/,prop,} = $$_tnenopmoc_etlevs0.$$slot_def.default;$$_$$;
      { __sveltets_createSlot("default", { prop,});}
  }}};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {'default': {prop:__sveltets_2_instanceOf(__sveltets_1_componentType()).$$slot_def['default'].prop}}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {'default': {prop:__sveltets_2_instanceOf(__sveltets_1_componentType()).$$slot_def['default'].prop}}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component_slots(__sveltets_2_partial(__sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/uses-svelte-components/expected-svelte5.ts
@@ -14,7 +14,7 @@ async () => {if(true){
  { svelteHTML.createElement("svelte:options", {});}
  { svelteHTML.createElement("svelte:fragment", {});}
  { svelteHTML.createElement("svelte:document", {    "foo":`bar`,"on:click":e => {},});}};
-return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event(render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
 /*Ωignore_endΩ*/export default Input__SvelteComponent_;


### PR DESCRIPTION
Those two methods are needed in Svelte 5, but we don't always set them. That was fine until TS 5.5, which infers generics slightly differently and turns `Exports` and `Bindings` to `never` if they don't show up in the input (before they were not)