### PR TITLE
Ignore all package paths

### DIFF
--- a/packages/language-server/src/svelte-check.ts
+++ b/packages/language-server/src/svelte-check.ts
@@ -211,8 +211,8 @@ export class SvelteCheck {
                     const skipDiagnosticsForFile =
                         (options.skipLibCheck && file.isDeclarationFile) ||
                         (options.skipDefaultLibCheck && file.hasNoDefaultLib) ||
-                        // ignore JS files in node_modules
-                        /\/node_modules\/.+\.(c|m)?js$/.test(file.fileName);
+                        // ignore files in the same common package folders that TypeScript does.
+                        /\/(node_modules|bower_components|jspm_packages)\//.test(file.fileName);
                     const snapshot = lsContainer.snapshotManager.get(file.fileName) as
                         | JSOrTSDocumentSnapshot
                         | undefined;


### PR DESCRIPTION
This is based off of a real issue I faced; I was getting lints for files in node_modules, specifically in `.ts` files that I can't change anyways. It also doesn't show up when I run `tsc` on my own `.ts` files even if they import the same erroring `.ts` files and even if I use `svelte2tsx` to use the same built ts file.

I hope there isn't a reason I'm missing for keeping `.ts` files. In this code path all `node_modules` diagnostics are removed already:
https://github.com/sveltejs/language-tools/blob/527c2adb2fc6f13674bcc73cf52b63370dc0c8db/packages/language-server/src/plugins/PluginHost.ts#L85-L97

And in tsc itself it ignores items in the `commonPackageFolders`:
https://github.com/microsoft/TypeScript/blob/ec7ff812c1b8e4c8f34901da900f9c933b6dfe2a/src/compiler/utilities.ts#L9353-L9355

So I hope this helps rather than being the wrong fix.