### PR TITLE
fix: add legacy methods to own component shape

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
@@ -167,7 +167,7 @@ function addSimpleComponentExport({
             statement =
                 `\ninterface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
-    (internal: unknown, props: ${!canHaveAnyProp && exportedNames.hasNoProps() ? '{$$events?: Events, $$slots?: Slots}' : 'Props & {$$events?: Events, $$slots?: Slots}'}): Exports;
+    (internal: unknown, props: ${!canHaveAnyProp && exportedNames.hasNoProps() ? '{$$events?: Events, $$slots?: Slots}' : 'Props & {$$events?: Events, $$slots?: Slots}'}): Exports & { $set?: any, $on?: any };
     z_$$bindings?: Bindings;
 }\n` +
                 (usesSlots

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -243,7 +243,7 @@ declare function __sveltets_$$bindings<Bindings extends string[]>(...bindings: B
 
 interface __sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
-    (internal: unknown, props: Props extends Record<string, never> ? {$$events?: Events, $$slots?: Slots} : Props & {$$events?: Events, $$slots?: Slots}): Exports;
+    (internal: unknown, props: Props extends Record<string, never> ? {$$events?: Events, $$slots?: Slots} : Props & {$$events?: Events, $$slots?: Slots}): Exports & { $set?: any, $on?: any };
     z_$$bindings?: Bindings;
 }
 

--- a/packages/svelte2tsx/test/emitDts/samples/javascript-runes.v5/expected/TestRunes.svelte.d.ts
+++ b/packages/svelte2tsx/test/emitDts/samples/javascript-runes.v5/expected/TestRunes.svelte.d.ts
@@ -5,7 +5,10 @@ interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> =
     (internal: unknown, props: Props & {
         $$events?: Events;
         $$slots?: Slots;
-    }): Exports;
+    }): Exports & {
+        $set?: any;
+        $on?: any;
+    };
     z_$$bindings?: Bindings;
 }
 declare const TestRunes: $$__sveltets_2_IsomorphicComponent<{

--- a/packages/svelte2tsx/test/emitDts/samples/typescript-runes.v5/expected/TestRunes.svelte.d.ts
+++ b/packages/svelte2tsx/test/emitDts/samples/typescript-runes.v5/expected/TestRunes.svelte.d.ts
@@ -5,7 +5,10 @@ interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> =
     (internal: unknown, props: Props & {
         $$events?: Events;
         $$slots?: Slots;
-    }): Exports;
+    }): Exports & {
+        $set?: any;
+        $on?: any;
+    };
     z_$$bindings?: Bindings;
 }
 declare const TestRunes: $$__sveltets_2_IsomorphicComponent<{

--- a/packages/svelte2tsx/test/svelte2tsx/samples/creates-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/creates-dts/expected-svelte5.ts
@@ -26,7 +26,7 @@ return { props: {
 /** @type {boolean} */bar: bar , foobar: foobar}, exports: {}, bindings: "", slots: {'default': {bar:bar}}, events: {'click':__sveltets_2_mapElementEvent('click'), 'hi': __sveltets_2_customEvent} }}
 interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
-    (internal: unknown, props: Props & {$$events?: Events, $$slots?: Slots}): Exports;
+    (internal: unknown, props: Props & {$$events?: Events, $$slots?: Slots}): Exports & { $set?: any, $on?: any };
     z_$$bindings?: Bindings;
 }
 type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props &

--- a/packages/svelte2tsx/test/svelte2tsx/samples/creates-no-script-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/creates-no-script-dts/expected-svelte5.ts
@@ -8,7 +8,7 @@ async () => { { svelteHTML.createElement("button", { "on:click":undefined,}); { 
 return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {'default': {}}, events: {'click':__sveltets_2_mapElementEvent('click')} }}
 interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
-    (internal: unknown, props: {$$events?: Events, $$slots?: Slots}): Exports;
+    (internal: unknown, props: {$$events?: Events, $$slots?: Slots}): Exports & { $set?: any, $on?: any };
     z_$$bindings?: Bindings;
 }
 type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props &

--- a/packages/svelte2tsx/test/svelte2tsx/samples/transforms-interfaces-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/transforms-interfaces-dts/expected-svelte5.ts
@@ -24,7 +24,7 @@ async () => {};
 return { props: {foo: foo , bar: bar}, exports: {}, bindings: "", slots: {}, events: {} }}
 interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
-    (internal: unknown, props: Props & {$$events?: Events, $$slots?: Slots}): Exports;
+    (internal: unknown, props: Props & {$$events?: Events, $$slots?: Slots}): Exports & { $set?: any, $on?: any };
     z_$$bindings?: Bindings;
 }
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-creates-dts/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-creates-dts/expected-svelte5.ts
@@ -25,7 +25,7 @@ async () => {
 return { props: {bar: bar , foobar: foobar} as {bar: Bar, foobar?: typeof foobar}, exports: {}, bindings: "", slots: {'default': {bar:bar}}, events: {...__sveltets_2_toEventTypings<{swipe: string}>(), 'click':__sveltets_2_mapElementEvent('click')} }}
 interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
-    (internal: unknown, props: Props & {$$events?: Events, $$slots?: Slots}): Exports;
+    (internal: unknown, props: Props & {$$events?: Events, $$slots?: Slots}): Exports & { $set?: any, $on?: any };
     z_$$bindings?: Bindings;
 }
 type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props &


### PR DESCRIPTION
see https://github.com/sveltejs/svelte/pull/12666 for why we need this