### PR TITLE
feat: replace svelte-preprocess with barebones TS preprocessor

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -55,7 +55,6 @@
         "prettier": "~3.2.5",
         "prettier-plugin-svelte": "^3.2.2",
         "svelte": "^3.57.0",
-        "svelte-preprocess": "^5.1.3",
         "svelte2tsx": "workspace:~",
         "typescript": "^5.5.2",
         "typescript-auto-import-cache": "^0.3.3",

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -273,7 +273,7 @@ export class ConfigLoader {
             // User doesn't have svelte-preprocess installed, provide a barebones TS preprocessor
             return {
                 preprocess: {
-                    // @ts-expect-error name property exists in Svelte 4 onwards
+                    // @ts-ignore name property exists in Svelte 4 onwards
                     name: 'svelte-language-tools-ts-fallback-preprocessor',
                     script: ({ content, attributes, filename }) => {
                         if (attributes.lang !== 'ts') return;

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -9,6 +9,7 @@ import _path from 'path';
 import _fs from 'fs';
 import { pathToFileURL, URL } from 'url';
 import { FileMap } from './fileCollection';
+import ts from 'typescript';
 
 export type InternalPreprocessorGroup = PreprocessorGroup & {
     /**
@@ -249,24 +250,49 @@ export class ConfigLoader {
     }
 
     private useFallbackPreprocessor(path: string, foundConfig: boolean): SvelteConfig {
-        Logger.log(
-            (foundConfig
-                ? 'Found svelte.config.js but there was an error loading it. '
-                : 'No svelte.config.js found. ') +
-                'Using https://github.com/sveltejs/svelte-preprocess as fallback'
-        );
-        const sveltePreprocess = importSveltePreprocess(path);
-        return {
-            preprocess: sveltePreprocess({
-                // 4.x does not have transpileOnly anymore, but if the user has version 3.x
-                // in his repo, that one is loaded instead, for which we still need this.
-                typescript: <any>{
-                    transpileOnly: true,
-                    compilerOptions: { sourceMap: true, inlineSourceMap: false }
-                }
-            }),
-            isFallbackConfig: true
-        };
+        try {
+            const sveltePreprocess = importSveltePreprocess(path);
+            Logger.log(
+                (foundConfig
+                    ? 'Found svelte.config.js but there was an error loading it. '
+                    : 'No svelte.config.js found. ') +
+                    'Using https://github.com/sveltejs/svelte-preprocess as fallback'
+            );
+            return {
+                preprocess: sveltePreprocess({
+                    // 4.x does not have transpileOnly anymore, but if the user has version 3.x
+                    // in his repo, that one is loaded instead, for which we still need this.
+                    typescript: {
+                        transpileOnly: true,
+                        compilerOptions: { sourceMap: true, inlineSourceMap: false }
+                    }
+                }),
+                isFallbackConfig: true
+            };
+        } catch (e) {
+            // User doesn't have svelte-preprocess installed, provide a barebones TS preprocessor
+            return {
+                preprocess: {
+                    // @ts-expect-error name property exists in Svelte 4 onwards
+                    name: 'svelte-language-tools-ts-fallback-preprocessor',
+                    script: ({ content, attributes, filename }) => {
+                        if (attributes.lang !== 'ts') return;
+
+                        const { outputText, sourceMapText } = ts.transpileModule(content, {
+                            fileName: filename,
+                            compilerOptions: {
+                                module: ts.ModuleKind.ESNext,
+                                target: ts.ScriptTarget.ESNext,
+                                sourceMap: true,
+                                verbatimModuleSyntax: true
+                            }
+                        });
+                        return { code: outputText, map: sourceMapText };
+                    }
+                },
+                isFallbackConfig: true
+            };
+        }
     }
 }
 

--- a/packages/language-server/src/plugins/svelte/SvelteDocument.ts
+++ b/packages/language-server/src/plugins/svelte/SvelteDocument.ts
@@ -37,6 +37,7 @@ type PositionMapper = Pick<DocumentMapper, 'getGeneratedPosition' | 'getOriginal
 export class SvelteDocument {
     private transpiledDoc: ITranspiledSvelteDocument | undefined;
     private compileResult: SvelteCompileResult | undefined;
+    private svelteVersion: [number, number] | undefined;
 
     public script: TagInformation | null;
     public moduleScript: TagInformation | null;
@@ -69,9 +70,11 @@ export class SvelteDocument {
 
     async getTranspiled(): Promise<ITranspiledSvelteDocument> {
         if (!this.transpiledDoc) {
-            const {
-                version: { major, minor }
-            } = getPackageInfo('svelte', this.getFilePath());
+            if (!this.svelteVersion) {
+                const { major, minor } = getPackageInfo('svelte', this.getFilePath()).version;
+                this.svelteVersion = [major, minor];
+            }
+            const [major, minor] = this.svelteVersion;
 
             if (major > 3 || (major === 3 && minor >= 32)) {
                 this.transpiledDoc = await TranspiledSvelteDocument.create(

--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -63,11 +63,11 @@ async function tryGetDiagnostics(
         }
 
         let ignoreScriptWarnings = false;
-        let ingoreStyleWarnings = false;
+        let ignoreStyleWarnings = false;
         let ignoreTemplateWarnings = false;
         if (!document.config?.preprocess || !!document.config.isFallbackConfig) {
             ignoreTemplateWarnings = !!document.getLanguageAttribute('template');
-            ingoreStyleWarnings = !!document.getLanguageAttribute('style');
+            ignoreStyleWarnings = !!document.getLanguageAttribute('style');
             const scriptAttr = document.getLanguageAttribute('script');
             ignoreScriptWarnings = !!scriptAttr && scriptAttr !== 'ts';
         }
@@ -95,7 +95,7 @@ async function tryGetDiagnostics(
                     diag,
                     document,
                     ignoreScriptWarnings,
-                    ingoreStyleWarnings,
+                    ignoreStyleWarnings,
                     ignoreTemplateWarnings
                 )
             );
@@ -311,7 +311,7 @@ function isNoFalsePositive(
     diag: Diagnostic,
     doc: Document,
     ignoreScriptWarnings: boolean,
-    ingoreStyleWarnings: boolean,
+    ignoreStyleWarnings: boolean,
     ignoreTemplateWarnings: boolean
 ): boolean {
     if (
@@ -322,7 +322,7 @@ function isNoFalsePositive(
     }
 
     if (
-        ingoreStyleWarnings &&
+        ignoreStyleWarnings &&
         (diag.code === 'css-unused-selector' || diag.code === 'css_unused_selector')
     ) {
         return false;

--- a/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
+++ b/packages/language-server/src/plugins/svelte/features/getDiagnostics.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import { Warning } from 'svelte/types/compiler/interfaces';
 import {
     CancellationToken,
     Diagnostic,
@@ -63,6 +61,17 @@ async function tryGetDiagnostics(
         if (cancellationToken?.isCancellationRequested) {
             return [];
         }
+
+        let ignoreScriptWarnings = false;
+        let ingoreStyleWarnings = false;
+        let ignoreTemplateWarnings = false;
+        if (!document.config?.preprocess || !!document.config.isFallbackConfig) {
+            ignoreTemplateWarnings = !!document.getLanguageAttribute('template');
+            ingoreStyleWarnings = !!document.getLanguageAttribute('style');
+            const scriptAttr = document.getLanguageAttribute('script');
+            ignoreScriptWarnings = !!scriptAttr && scriptAttr !== 'ts';
+        }
+
         return (res.warnings || [])
             .filter((warning) => settings[warning.code] !== 'ignore')
             .map((warning) => {
@@ -81,7 +90,15 @@ async function tryGetDiagnostics(
             })
             .map((diag) => mapObjWithRangeToOriginal(transpiled, diag))
             .map((diag) => adjustMappings(diag, document))
-            .filter((diag) => isNoFalsePositive(diag, document));
+            .filter((diag) =>
+                isNoFalsePositive(
+                    diag,
+                    document,
+                    ignoreScriptWarnings,
+                    ingoreStyleWarnings,
+                    ignoreTemplateWarnings
+                )
+            );
     } catch (err) {
         return createParserErrorDiagnostic(err, document)
             .map((diag) => mapObjWithRangeToOriginal(transpiled, diag))
@@ -290,8 +307,28 @@ function getErrorMessage(error: any, source: string, hint = '') {
     );
 }
 
-function isNoFalsePositive(diag: Diagnostic, doc: Document): boolean {
-    if (diag.code !== 'unused-export-let') {
+function isNoFalsePositive(
+    diag: Diagnostic,
+    doc: Document,
+    ignoreScriptWarnings: boolean,
+    ingoreStyleWarnings: boolean,
+    ignoreTemplateWarnings: boolean
+): boolean {
+    if (
+        (ignoreTemplateWarnings || ignoreScriptWarnings) &&
+        (typeof diag.code !== 'string' || !diag.code.startsWith('a11y'))
+    ) {
+        return false;
+    }
+
+    if (
+        ingoreStyleWarnings &&
+        (diag.code === 'css-unused-selector' || diag.code === 'css_unused_selector')
+    ) {
+        return false;
+    }
+
+    if (diag.code !== 'unused-export-let' && diag.code !== 'export_let_unused') {
         return true;
     }
 
@@ -328,7 +365,7 @@ function adjustMappings(diag: Diagnostic, doc: Document): Diagnostic {
     diag.range = moveRangeStartToEndIfNecessary(diag.range);
 
     if (
-        diag.code === 'css-unused-selector' &&
+        (diag.code === 'css-unused-selector' || diag.code === 'css_unused_selector') &&
         doc.styleInfo &&
         !isInTag(diag.range.start, doc.styleInfo)
     ) {

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -31,7 +31,12 @@ describe('SveltePlugin#getDiagnostics', () => {
         docText?: string;
     }) {
         const document = new Document('', docText);
-        const svelteDoc: SvelteDocument = <any>{ getTranspiled, getCompiled, config };
+        const svelteDoc: SvelteDocument = <any>{
+            getTranspiled,
+            getCompiled,
+            config,
+            getSvelteVersion: () => [4, 0]
+        };
         const result = await getDiagnostics(document, svelteDoc, settings);
         return {
             toEqual: (expected: Diagnostic[]) => assert.deepStrictEqual(result, expected)
@@ -298,7 +303,9 @@ describe('SveltePlugin#getDiagnostics', () => {
                             }
                         ]
                     }),
-                config: {}
+                config: {
+                    preprocess: []
+                }
             })
         ).toEqual([
             {
@@ -343,7 +350,9 @@ describe('SveltePlugin#getDiagnostics', () => {
                             ]
                         }
                     }),
-                config: {}
+                config: {
+                    preprocess: []
+                }
             })
         ).toEqual([]);
     });
@@ -372,7 +381,9 @@ describe('SveltePlugin#getDiagnostics', () => {
                             ]
                         }
                     }),
-                config: {}
+                config: {
+                    preprocess: []
+                }
             })
         ).toEqual([]);
     });
@@ -399,7 +410,9 @@ describe('SveltePlugin#getDiagnostics', () => {
                             ]
                         }
                     }),
-                config: {},
+                config: {
+                    preprocess: []
+                },
                 settings: { 123: 'ignore' }
             })
         ).toEqual([]);
@@ -425,7 +438,9 @@ describe('SveltePlugin#getDiagnostics', () => {
                             }
                         ]
                     }),
-                config: {},
+                config: {
+                    preprocess: []
+                },
                 settings: { 123: 'error' }
             })
         ).toEqual([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       svelte:
         specifier: ^3.57.0
         version: 3.57.0
-      svelte-preprocess:
-        specifier: ^5.1.3
-        version: 5.1.3(svelte@3.57.0)(typescript@5.5.2)
       svelte2tsx:
         specifier: workspace:~
         version: link:../svelte2tsx


### PR DESCRIPTION
Removes the need for a dependency on svelte-preprocess in svelte-language-server, since that was all we used it for. Also tightens up the warning filter to account for situations where those could be wrong.

closes:
- #1683 and #1259, because the situation no longer arises (because we no longer have svelte-preprocess inside the VS Code extension)
- #2391

@jasonlyu123 any situation I'm not correctly antipicating here which would make this a bad change? The only cases I see where this could have any change in behavior compared to before is if you're opening a Svelte file with `lang="ts"` and no config and...
-  using import statements that don't adhere to `verbatimModuleSyntax`, but even then I think it will not make a difference because Svelte does not care which imports are left in the file.
- using decorators, because they are not transpiled and lead to a compiler error, but then the "filter out this error" logic should kick in, so it's fine