### PR TITLE
breaking: svelte-check v4

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -50,7 +50,7 @@
         "@vscode/emmet-helper": "2.8.4",
         "chokidar": "^3.4.1",
         "estree-walker": "^2.0.1",
-        "fast-glob": "^3.2.7",
+        "fdir": "^6.2.0",
         "lodash": "^4.17.21",
         "prettier": "~3.2.5",
         "prettier-plugin-svelte": "^3.2.2",

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -4,7 +4,7 @@ import { CompileOptions } from 'svelte/types/compiler/interfaces';
 // @ts-ignore
 import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 import { importSveltePreprocess } from '../../importPackage';
-import _glob from 'fast-glob';
+import { fdir } from 'fdir';
 import _path from 'path';
 import _fs from 'fs';
 import { pathToFileURL, URL } from 'url';
@@ -47,6 +47,8 @@ const _dynamicImport = new Function('modulePath', 'return import(modulePath)') a
     modulePath: URL
 ) => Promise<any>;
 
+const configRegex = /\/svelte\.config\.(js|cjs|mjs)$/;
+
 /**
  * Loads svelte.config.{js,cjs,mjs} files. Provides both a synchronous and asynchronous
  * interface to get a config file because snapshots need access to it synchronously.
@@ -61,7 +63,7 @@ export class ConfigLoader {
     private disabled = false;
 
     constructor(
-        private globSync: typeof _glob.sync,
+        private globSync: typeof fdir,
         private fs: Pick<typeof _fs, 'existsSync'>,
         private path: Pick<typeof _path, 'dirname' | 'relative' | 'join'>,
         private dynamicImport: typeof _dynamicImport
@@ -84,12 +86,19 @@ export class ConfigLoader {
         Logger.log('Trying to load configs for', directory);
 
         try {
-            const pathResults = this.globSync('**/svelte.config.{js,cjs,mjs}', {
-                cwd: directory,
-                // the second pattern is necessary because else fast-glob treats .tmp/../node_modules/.. as a valid match for some reason
-                ignore: ['**/node_modules/**', '**/.*/**'],
-                onlyFiles: true
-            });
+            const pathResults = new this.globSync({})
+                .withPathSeparator('/')
+                .exclude((_, path) => {
+                    // no / at the start, path could start with node_modules
+                    return path.includes('node_modules/') || path.includes('/.');
+                })
+                .filter((path, isDir) => {
+                    return !isDir && configRegex.test(path);
+                })
+                .withRelativePaths()
+                .crawl(directory)
+                .sync();
+
             const someConfigIsImmediateFileInDirectory =
                 pathResults.length > 0 && pathResults.some((res) => !this.path.dirname(res));
             if (!someConfigIsImmediateFileInDirectory) {
@@ -296,4 +305,4 @@ export class ConfigLoader {
     }
 }
 
-export const configLoader = new ConfigLoader(_glob.sync, _fs, _path, _dynamicImport);
+export const configLoader = new ConfigLoader(fdir, _fs, _path, _dynamicImport);

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -90,7 +90,7 @@ export class ConfigLoader {
                 .withPathSeparator('/')
                 .exclude((_, path) => {
                     // no / at the start, path could start with node_modules
-                    return path.includes('node_modules/') || path.includes('/.');
+                    return path.includes('node_modules/') || path.includes('/.') || path[0] === '.';
                 })
                 .filter((path, isDir) => {
                     return !isDir && configRegex.test(path);

--- a/packages/language-server/test/lib/documents/configLoader.test.ts
+++ b/packages/language-server/test/lib/documents/configLoader.test.ts
@@ -19,6 +19,29 @@ describe('ConfigLoader', () => {
         return path.join(...filePath.split('/'));
     }
 
+    function mockFdir(results: string[] | (() => string[])): any {
+        return class {
+            withPathSeparator() {
+                return this;
+            }
+            exclude() {
+                return this;
+            }
+            filter() {
+                return this;
+            }
+            withRelativePaths() {
+                return this;
+            }
+            crawl() {
+                return this;
+            }
+            sync() {
+                return typeof results === 'function' ? results() : results;
+            }
+        };
+    }
+
     async function assertFindsConfig(
         configLoader: ConfigLoader,
         filePath: string,
@@ -32,7 +55,7 @@ describe('ConfigLoader', () => {
 
     it('should load all config files below and the one inside/above given directory', async () => {
         const configLoader = new ConfigLoader(
-            (() => ['svelte.config.js', 'below/svelte.config.js']) as any,
+            mockFdir(['svelte.config.js', 'below/svelte.config.js']),
             { existsSync: () => true },
             path,
             (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } })
@@ -63,7 +86,7 @@ describe('ConfigLoader', () => {
 
     it('finds first above if none found inside/below directory', async () => {
         const configLoader = new ConfigLoader(
-            () => [],
+            mockFdir([]),
             {
                 existsSync: (p) =>
                     typeof p === 'string' && p.endsWith(path.join('some', 'svelte.config.js'))
@@ -78,7 +101,7 @@ describe('ConfigLoader', () => {
 
     it('adds fallback if no config found', async () => {
         const configLoader = new ConfigLoader(
-            () => [],
+            mockFdir([]),
             { existsSync: () => false },
             path,
             (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } })
@@ -99,14 +122,14 @@ describe('ConfigLoader', () => {
         let firstGlobCall = true;
         let nrImportCalls = 0;
         const configLoader = new ConfigLoader(
-            (() => {
+            mockFdir(() => {
                 if (firstGlobCall) {
                     firstGlobCall = false;
                     return ['svelte.config.js'];
                 } else {
                     return [];
                 }
-            }) as any,
+            }),
             {
                 existsSync: (p) =>
                     typeof p === 'string' &&
@@ -140,11 +163,8 @@ describe('ConfigLoader', () => {
     });
 
     it('can deal with missing config', () => {
-        const configLoader = new ConfigLoader(
-            () => [],
-            { existsSync: () => false },
-            path,
-            () => Promise.resolve('unimportant')
+        const configLoader = new ConfigLoader(mockFdir([]), { existsSync: () => false }, path, () =>
+            Promise.resolve('unimportant')
         );
         assert.deepStrictEqual(
             configLoader.getConfig(normalizePath('/some/file.svelte')),
@@ -154,7 +174,7 @@ describe('ConfigLoader', () => {
 
     it('should await config', async () => {
         const configLoader = new ConfigLoader(
-            () => [],
+            mockFdir([]),
             { existsSync: () => true },
             path,
             (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } })
@@ -168,7 +188,7 @@ describe('ConfigLoader', () => {
     it('should not load config when disabled', async () => {
         const moduleLoader = spy();
         const configLoader = new ConfigLoader(
-            () => [],
+            mockFdir([]),
             { existsSync: () => true },
             path,
             moduleLoader

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -1,7 +1,7 @@
 {
     "name": "svelte-check",
     "description": "Svelte Code Checker Terminal Interface",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "main": "./dist/src/index.js",
     "bin": "./bin/svelte-check",
     "author": "The Svelte Community",

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -33,7 +33,7 @@
         "svelte-preprocess": "^5.1.3"
     },
     "peerDependencies": {
-        "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0",
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
         "typescript": ">=5.0.0"
     },
     "scripts": {
@@ -53,6 +53,7 @@
         "rollup": "3.7.5",
         "rollup-plugin-cleanup": "^3.2.0",
         "rollup-plugin-copy": "^3.4.0",
+        "svelte": "^3.57.0",
         "svelte-language-server": "workspace:*",
         "typescript": "^5.5.2",
         "vscode-languageserver": "8.0.2",

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -27,11 +27,11 @@
         "chokidar": "^3.4.1",
         "picocolors": "^1.0.0",
         "sade": "^1.7.4",
-        "svelte-preprocess": "^5.1.3",
-        "typescript": "^5.0.3"
+        "svelte-preprocess": "^5.1.3"
     },
     "peerDependencies": {
-        "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0"
+        "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
     },
     "scripts": {
         "build": "rollup -c && node ./dist/src/index.js --workspace ./test --tsconfig ./tsconfig.json",
@@ -51,6 +51,7 @@
         "rollup-plugin-cleanup": "^3.2.0",
         "rollup-plugin-copy": "^3.4.0",
         "svelte-language-server": "workspace:*",
+        "typescript": "^5.5.2",
         "vscode-languageserver": "8.0.2",
         "vscode-languageserver-protocol": "3.17.2",
         "vscode-languageserver-types": "3.17.2",

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -22,6 +22,9 @@
         "url": "https://github.com/sveltejs/language-tools/issues"
     },
     "homepage": "https://github.com/sveltejs/language-tools#readme",
+    "engines": {
+        "node": ">= 18.0.0"
+    },
     "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
         "chokidar": "^3.4.1",

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -28,6 +28,7 @@
     "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
         "chokidar": "^3.4.1",
+        "fdir": "^6.2.0",
         "picocolors": "^1.0.0",
         "sade": "^1.7.4",
         "svelte-preprocess": "^5.1.3"
@@ -49,7 +50,6 @@
         "@rollup/plugin-typescript": "^10.0.0",
         "@types/sade": "^1.7.2",
         "builtin-modules": "^3.3.0",
-        "fast-glob": "^3.2.7",
         "rollup": "3.7.5",
         "rollup-plugin-cleanup": "^3.2.0",
         "rollup-plugin-copy": "^3.4.0",

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -30,8 +30,7 @@
         "chokidar": "^3.4.1",
         "fdir": "^6.2.0",
         "picocolors": "^1.0.0",
-        "sade": "^1.7.4",
-        "svelte-preprocess": "^5.1.3"
+        "sade": "^1.7.4"
     },
     "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",

--- a/packages/svelte-check/rollup.config.mjs
+++ b/packages/svelte-check/rollup.config.mjs
@@ -65,7 +65,6 @@ export default [
             'sade',
             'svelte',
             'svelte/compiler',
-            'svelte-preprocess',
             '@jridgewell/trace-mapping'
             // import-fresh removed some time ago, no dependency uses it anymore.
             // if it creeps back in check if the dependency uses a version that

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -65,8 +65,7 @@ async function openAllDocuments(
     const absFilePaths = await new fdir()
         .filter((path) => path.endsWith('.svelte') && !isIgnored(path))
         .exclude((_, path) => {
-            path = path.slice(offset);
-            return path.startsWith('.') || path.startsWith('node_modules');
+            return path.includes('/node_modules/') || path.includes('/.');
         })
         .withPathSeparator('/')
         .withFullPaths()

--- a/packages/svelte-check/src/options.ts
+++ b/packages/svelte-check/src/options.ts
@@ -73,7 +73,7 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
                 watch: !!opts.watch,
                 preserveWatchOutput: !!opts.preserveWatchOutput,
                 tsconfig: getTsconfig(opts, workspaceUri.fsPath),
-                filePathsToIgnore: getFilepathsToIgnore(opts),
+                filePathsToIgnore: opts.ignore?.split(',') || [],
                 failOnWarnings: !!opts['fail-on-warnings'],
                 compilerWarnings: getCompilerWarnings(opts),
                 diagnosticSources: getDiagnosticSources(opts),
@@ -178,10 +178,6 @@ function getDiagnosticSources(opts: Record<string, any>): DiagnosticSource[] {
               ?.map((s: string) => s.trim())
               .filter((s: any) => diagnosticSources.includes(s))
         : diagnosticSources;
-}
-
-function getFilepathsToIgnore(opts: Record<string, any>): string[] {
-    return opts.ignore?.split(',') || [];
 }
 
 const thresholds = ['warning', 'error'] as const;

--- a/packages/svelte-check/src/options.ts
+++ b/packages/svelte-check/src/options.ts
@@ -67,12 +67,18 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
         )
         .action((opts) => {
             const workspaceUri = getWorkspaceUri(opts);
+            const tsconfig = getTsconfig(opts, workspaceUri.fsPath);
+
+            if (opts.ignore && tsconfig) {
+                throwError('`--ignore` only has an effect when using `--no-tsconfig`');
+            }
+
             cb({
                 workspaceUri,
                 outputFormat: getOutputFormat(opts),
                 watch: !!opts.watch,
                 preserveWatchOutput: !!opts.preserveWatchOutput,
-                tsconfig: getTsconfig(opts, workspaceUri.fsPath),
+                tsconfig,
                 filePathsToIgnore: opts.ignore?.split(',') || [],
                 failOnWarnings: !!opts['fail-on-warnings'],
                 compilerWarnings: getCompilerWarnings(opts),
@@ -141,9 +147,13 @@ function getTsconfig(myArgs: Record<string, any>, workspacePath: string) {
         tsconfig = path.join(workspacePath, tsconfig);
     }
     if (tsconfig && !fs.existsSync(tsconfig)) {
-        throw new Error('Could not find tsconfig/jsconfig file at ' + myArgs.tsconfig);
+        throwError('Could not find tsconfig/jsconfig file at ' + myArgs.tsconfig);
     }
     return tsconfig;
+}
+
+function throwError(msg: string) {
+    throw new Error('Invalid svelte-check CLI args: ' + msg);
 }
 
 function getCompilerWarnings(opts: Record<string, any>) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,9 +127,6 @@ importers:
       sade:
         specifier: ^1.7.4
         version: 1.8.1
-      svelte:
-        specifier: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
-        version: 3.57.0
       svelte-preprocess:
         specifier: ^5.1.3
         version: 5.1.3(svelte@3.57.0)(typescript@5.5.2)
@@ -167,6 +164,9 @@ importers:
       rollup-plugin-copy:
         specifier: ^3.4.0
         version: 3.4.0
+      svelte:
+        specifier: ^3.57.0
+        version: 3.57.0
       svelte-language-server:
         specifier: workspace:*
         version: link:../language-server

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,9 +127,6 @@ importers:
       sade:
         specifier: ^1.7.4
         version: 1.8.1
-      svelte-preprocess:
-        specifier: ^5.1.3
-        version: 5.1.3(svelte@3.57.0)(typescript@5.5.2)
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^24.0.0
@@ -489,9 +486,6 @@ packages:
   '@types/prettier@2.7.2':
     resolution: {integrity: sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==}
 
-  '@types/pug@2.0.6':
-    resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
-
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
@@ -589,9 +583,6 @@ packages:
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
 
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -683,10 +674,6 @@ packages:
     resolution: {integrity: sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==}
     engines: {node: '>=8'}
 
-  detect-indent@6.1.0:
-    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
-
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -708,9 +695,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  es6-promise@3.3.1:
-    resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
 
   escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -954,10 +938,6 @@ packages:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
 
-  magic-string@0.30.7:
-    resolution: {integrity: sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==}
-    engines: {node: '>=12'}
-
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
@@ -969,10 +949,6 @@ packages:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
 
-  min-indent@1.0.1:
-    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
-    engines: {node: '>=4'}
-
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -983,13 +959,6 @@ packages:
   minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
 
   mocha@9.2.2:
     resolution: {integrity: sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==}
@@ -1108,10 +1077,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    hasBin: true
-
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
@@ -1148,9 +1113,6 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  sander@0.5.1:
-    resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}
-
   semver@7.5.1:
     resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
     engines: {node: '>=10'}
@@ -1178,10 +1140,6 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  sorcery@0.11.0:
-    resolution: {integrity: sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==}
-    hasBin: true
-
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
@@ -1204,10 +1162,6 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-indent@3.0.0:
-    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
-    engines: {node: '>=8'}
-
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1227,43 +1181,6 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-
-  svelte-preprocess@5.1.3:
-    resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
-    engines: {node: '>= 16.0.0', pnpm: ^8.0.0}
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0
-      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
-      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
 
   svelte@3.57.0:
     resolution: {integrity: sha512-WMXEvF+RtAaclw0t3bPDTUe19pplMlfyKDsixbHQYgCWi9+O9VN0kXU1OppzrB9gPAvz4NALuoca2LfW2bOjTQ==}
@@ -1578,8 +1495,6 @@ snapshots:
 
   '@types/prettier@2.7.2': {}
 
-  '@types/pug@2.0.6': {}
-
   '@types/resolve@1.20.2': {}
 
   '@types/sade@1.7.4':
@@ -1669,8 +1584,6 @@ snapshots:
       fill-range: 7.0.1
 
   browser-stdout@1.3.1: {}
-
-  buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
 
@@ -1764,8 +1677,6 @@ snapshots:
       rimraf: 3.0.2
       slash: 3.0.0
 
-  detect-indent@6.1.0: {}
-
   diff@4.0.2: {}
 
   diff@5.0.0: {}
@@ -1782,8 +1693,6 @@ snapshots:
       '@emmetio/css-abbreviation': 2.1.8
 
   emoji-regex@8.0.0: {}
-
-  es6-promise@3.3.1: {}
 
   escalade@3.1.1: {}
 
@@ -2012,10 +1921,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  magic-string@0.30.7:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-
   make-error@1.3.6: {}
 
   merge2@1.4.1: {}
@@ -2024,8 +1929,6 @@ snapshots:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-
-  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -2038,12 +1941,6 @@ snapshots:
   minimatch@5.1.6:
     dependencies:
       brace-expansion: 2.0.1
-
-  minimist@1.2.8: {}
-
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
 
   mocha@9.2.2:
     dependencies:
@@ -2168,10 +2065,6 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
-
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
@@ -2212,13 +2105,6 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  sander@0.5.1:
-    dependencies:
-      es6-promise: 3.3.1
-      graceful-fs: 4.2.11
-      mkdirp: 0.5.6
-      rimraf: 2.7.1
-
   semver@7.5.1:
     dependencies:
       lru-cache: 6.0.0
@@ -2246,13 +2132,6 @@ snapshots:
 
   slash@3.0.0: {}
 
-  sorcery@0.11.0:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-      buffer-crc32: 0.2.13
-      minimist: 1.2.8
-      sander: 0.5.1
-
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
@@ -2274,10 +2153,6 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-indent@3.0.0:
-    dependencies:
-      min-indent: 1.0.1
-
   strip-json-comments@3.1.1: {}
 
   supports-color@5.5.0:
@@ -2293,17 +2168,6 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  svelte-preprocess@5.1.3(svelte@3.57.0)(typescript@5.5.2):
-    dependencies:
-      '@types/pug': 2.0.6
-      detect-indent: 6.1.0
-      magic-string: 0.30.7
-      sorcery: 0.11.0
-      strip-indent: 3.0.0
-      svelte: 3.57.0
-    optionalDependencies:
-      typescript: 5.5.2
 
   svelte@3.57.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,9 @@ importers:
       estree-walker:
         specifier: ^2.0.1
         version: 2.0.2
-      fast-glob:
-        specifier: ^3.2.7
-        version: 3.2.12
+      fdir:
+        specifier: ^6.2.0
+        version: 6.2.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -118,6 +118,9 @@ importers:
       chokidar:
         specifier: ^3.4.1
         version: 3.5.3
+      fdir:
+        specifier: ^6.2.0
+        version: 6.2.0
       picocolors:
         specifier: ^1.0.0
         version: 1.0.0
@@ -149,9 +152,6 @@ importers:
       builtin-modules:
         specifier: ^3.3.0
         version: 3.3.0
-      fast-glob:
-        specifier: ^3.2.7
-        version: 3.2.12
       rollup:
         specifier: 3.7.5
         version: 3.7.5
@@ -741,6 +741,14 @@ packages:
 
   fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
+
+  fdir@6.2.0:
+    resolution: {integrity: sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -1800,6 +1808,8 @@ snapshots:
   fastq@1.15.0:
     dependencies:
       reusify: 1.0.4
+
+  fdir@6.2.0: {}
 
   fill-range@7.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,10 +132,7 @@ importers:
         version: 3.57.0
       svelte-preprocess:
         specifier: ^5.1.3
-        version: 5.1.3(svelte@3.57.0)(typescript@5.4.5)
-      typescript:
-        specifier: ^5.0.3
-        version: 5.4.5
+        version: 5.1.3(svelte@3.57.0)(typescript@5.5.2)
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^24.0.0
@@ -151,7 +148,7 @@ importers:
         version: 5.0.2(rollup@3.7.5)
       '@rollup/plugin-typescript':
         specifier: ^10.0.0
-        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.4.5)
+        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.5.2)
       '@types/sade':
         specifier: ^1.7.2
         version: 1.7.4
@@ -173,6 +170,9 @@ importers:
       svelte-language-server:
         specifier: workspace:*
         version: link:../language-server
+      typescript:
+        specifier: ^5.5.2
+        version: 5.5.2
       vscode-languageserver:
         specifier: 8.0.2
         version: 8.0.2
@@ -1295,11 +1295,6 @@ packages:
   typescript-auto-import-cache@0.3.3:
     resolution: {integrity: sha512-ojEC7+Ci1ij9eE6hp8Jl9VUNnsEKzztktP5gtYNRMrTmfXVwA1PITYYAkpxCvvupdSYa/Re51B6KMcv1CTZEUA==}
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.5.2:
     resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
     engines: {node: '>=14.17'}
@@ -1499,15 +1494,6 @@ snapshots:
       magic-string: 0.27.0
     optionalDependencies:
       rollup: 3.7.5
-
-  '@rollup/plugin-typescript@10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.4.5)':
-    dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.7.5)
-      resolve: 1.22.2
-      typescript: 5.4.5
-    optionalDependencies:
-      rollup: 3.7.5
-      tslib: 2.5.2
 
   '@rollup/plugin-typescript@10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.5.2)':
     dependencies:
@@ -2301,17 +2287,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-preprocess@5.1.3(svelte@3.57.0)(typescript@5.4.5):
-    dependencies:
-      '@types/pug': 2.0.6
-      detect-indent: 6.1.0
-      magic-string: 0.30.7
-      sorcery: 0.11.0
-      strip-indent: 3.0.0
-      svelte: 3.57.0
-    optionalDependencies:
-      typescript: 5.4.5
-
   svelte-preprocess@5.1.3(svelte@3.57.0)(typescript@5.5.2):
     dependencies:
       '@types/pug': 2.0.6
@@ -2359,8 +2334,6 @@ snapshots:
   typescript-auto-import-cache@0.3.3:
     dependencies:
       semver: 7.5.1
-
-  typescript@5.4.5: {}
 
   typescript@5.5.2: {}
 


### PR DESCRIPTION
- breaking: make TypeScript a peer dependency
- breaking: require node 18 or later
- breaking: require Svelte 4 or later (devDependencies pinned to Svelte 3 because other packages in this repo still use it. Theoretically we still support Svelte 3 with svelte-check v4 but this gives us the opportunity to adjust that later without a major)
- breaking: throw an error when `--ignore` is used without `--no-tsconfig` #1074
- feat: remove dependency on `svelte-preprocess` (also see #2452)

closes #2243

WIP, will finish after my vacation. 