### PR TITLE
typo fix in DisagnosticsProvider

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/DiagnosticsProvider.ts
@@ -211,11 +211,11 @@ function moveBindingErrorMessage(
                     );
                     diagnostic.message =
                         "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\n" +
-                        `To mark a property as bindable: 'let { ${propName} = $bindable() = $props()'`;
+                        `To mark a property as bindable: 'let { ${propName} = $bindable() } = $props()'`;
                 } else {
                     diagnostic.message =
                         "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\n" +
-                        `To mark a property as bindable: 'let { prop = $bindable() = $props()'\n\n` +
+                        `To mark a property as bindable: 'let { prop = $bindable() } = $props()'\n\n` +
                         diagnostic.message;
                 }
                 diagnostic.range = {

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/expected_svelte_5.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/expected_svelte_5.json
@@ -1,7 +1,7 @@
 [
     {
         "code": 2322,
-        "message": "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\nTo mark a property as bindable: 'let { readonly = $bindable() = $props()'",
+        "message": "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\nTo mark a property as bindable: 'let { readonly = $bindable() } = $props()'",
         "range": {
             "end": {
                 "character": 20,
@@ -35,7 +35,7 @@
     },
     {
         "code": 2322,
-        "message": "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\nTo mark a property as bindable: 'let { only_bind = $bindable() = $props()'",
+        "message": "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\nTo mark a property as bindable: 'let { only_bind = $bindable() } = $props()'",
         "range": {
             "end": {
                 "character": 21,


### PR DESCRIPTION
A typo was fixed in DiagnosticsProvider.ts where a closing curly brace was missing after `$bindable()`.

Old:
```
 "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\n" +
`To mark a property as bindable: 'let { ${propName} = $bindable() = $props()'`;
```

New:
```
 "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\n" +
`To mark a property as bindable: 'let { ${propName} = $bindable() } = $props()'`;
```