### PR TITLE
chore: publish package provenance info

### DIFF
--- a/.github/workflows/DeploySvelte2tsxProd.yml
+++ b/.github/workflows/DeploySvelte2tsxProd.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      id-token: write # OpenID Connect token needed for provenance
+
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +35,7 @@ jobs:
       - run: |
           cd packages/svelte2tsx
           pnpm install
-          pnpm publish --no-git-checks
+          pnpm publish --provenance --no-git-checks
 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/DeploySvelteCheckProd.yml
+++ b/.github/workflows/DeploySvelteCheckProd.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      id-token: write # OpenID Connect token needed for provenance
+
     runs-on: ubuntu-latest
 
     steps:
@@ -33,7 +36,7 @@ jobs:
       - run: |
           cd packages/svelte-check
           pnpm install
-          pnpm publish --no-git-checks
+          pnpm publish --provenance --no-git-checks
 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/DeploySvelteLanguageServerProd.yml
+++ b/.github/workflows/DeploySvelteLanguageServerProd.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      id-token: write # OpenID Connect token needed for provenance
+
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +35,7 @@ jobs:
       - run: |
           cd packages/language-server
           pnpm install
-          pnpm publish --no-git-checks
+          pnpm publish --provenance --no-git-checks
 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/DeployTypescriptPluginProd.yaml
+++ b/.github/workflows/DeployTypescriptPluginProd.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      id-token: write # OpenID Connect token needed for provenance
+
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +35,7 @@ jobs:
       - run: |
           cd packages/typescript-plugin
           pnpm install
-          pnpm publish --no-git-checks
+          pnpm publish --provenance --no-git-checks
 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
According to https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow

closes #2461