### PR TITLE
fix: allow autoImportFileExcludePatterns to ignore files outside the root

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/preferences.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/preferences.test.ts
@@ -64,7 +64,14 @@ describe('ts user preferences', function () {
             typescript: { ...getPreferences(), ...preferences },
             javascript: { ...getPreferences(), ...preferences }
         });
-        return new LSAndTSDocResolver(docManager, [pathToUrl(testFilesDir)], configManager);
+        return {
+            lsAndTsDocResolver: new LSAndTSDocResolver(
+                docManager,
+                [pathToUrl(testFilesDir)],
+                configManager
+            ),
+            configManager
+        };
     }
 
     function getDefaultPreferences(): TsUserPreferencesConfig {
@@ -79,11 +86,8 @@ describe('ts user preferences', function () {
 
     it('provides auto import completion according to preferences', async () => {
         const { docManager, document } = setup('code-action.svelte');
-        const lsAndTsDocResolver = createLSAndTSDocResolver(docManager);
-        const completionProvider = new CompletionsProviderImpl(
-            lsAndTsDocResolver,
-            new LSConfigManager()
-        );
+        const { lsAndTsDocResolver, configManager } = createLSAndTSDocResolver(docManager);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, configManager);
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -102,15 +106,13 @@ describe('ts user preferences', function () {
         context: CodeActionContext
     ) {
         const { docManager, document } = setup(filename);
-        const lsAndTsDocResolver = createLSAndTSDocResolver(docManager);
-        const completionProvider = new CompletionsProviderImpl(
-            lsAndTsDocResolver,
-            new LSConfigManager()
-        );
+        const { lsAndTsDocResolver, configManager } = createLSAndTSDocResolver(docManager);
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, configManager);
+
         const codeActionProvider = new CodeActionsProviderImpl(
             lsAndTsDocResolver,
             completionProvider,
-            new LSConfigManager()
+            configManager
         );
 
         const codeAction = await codeActionProvider.getCodeActions(document, range, context);
@@ -137,7 +139,7 @@ describe('ts user preferences', function () {
 
     it('provides auto import suggestions according to preferences', async () => {
         const { docManager, document } = setup('code-action.svelte');
-        const lsAndTsDocResolver = createLSAndTSDocResolver(docManager, {
+        const { lsAndTsDocResolver, configManager } = createLSAndTSDocResolver(docManager, {
             suggest: {
                 autoImports: false,
                 includeAutomaticOptionalChainCompletions: undefined,
@@ -147,10 +149,7 @@ describe('ts user preferences', function () {
                 includeCompletionsWithSnippetText: undefined
             }
         });
-        const completionProvider = new CompletionsProviderImpl(
-            lsAndTsDocResolver,
-            new LSConfigManager()
-        );
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, configManager);
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -165,14 +164,14 @@ describe('ts user preferences', function () {
 
     function setupImportModuleSpecifierEndingJs() {
         const { docManager, document } = setup('module-specifier-js.svelte');
-        const lsAndTsDocResolver = createLSAndTSDocResolver(docManager, {
+        const { lsAndTsDocResolver, configManager } = createLSAndTSDocResolver(docManager, {
             preferences: {
                 ...getDefaultPreferences(),
                 importModuleSpecifierEnding: 'js'
             }
         });
 
-        return { document, lsAndTsDocResolver };
+        return { document, lsAndTsDocResolver, configManager };
     }
 
     it('provides auto import for svelte component when importModuleSpecifierEnding is js', async () => {
@@ -248,16 +247,13 @@ describe('ts user preferences', function () {
 
     async function testExcludeDefinitionDir(pattern: string) {
         const { docManager, document } = setup('code-action.svelte');
-        const lsAndTsDocResolver = createLSAndTSDocResolver(docManager, {
+        const { lsAndTsDocResolver, configManager } = createLSAndTSDocResolver(docManager, {
             preferences: {
                 ...getDefaultPreferences(),
                 autoImportFileExcludePatterns: [pattern]
             }
         });
-        const completionProvider = new CompletionsProviderImpl(
-            lsAndTsDocResolver,
-            new LSConfigManager()
-        );
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, configManager);
 
         const completions = await completionProvider.getCompletions(
             document,
@@ -279,5 +275,25 @@ describe('ts user preferences', function () {
 
     it('exclude auto import (**/ pattern)', async () => {
         await testExcludeDefinitionDir('**/definition');
+    });
+
+    it('exclude auto import outside of the root', async () => {
+        const { docManager, document } = setup('code-action-outside-root.svelte');
+        const { lsAndTsDocResolver, configManager } = createLSAndTSDocResolver(docManager, {
+            preferences: {
+                ...getDefaultPreferences(),
+                autoImportFileExcludePatterns: ['definitions.ts']
+            }
+        });
+        const completionProvider = new CompletionsProviderImpl(lsAndTsDocResolver, configManager);
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            Position.create(4, 7)
+        );
+
+        const item = completions?.items.find((item) => item.label === 'blubb');
+
+        assert.equal(item, undefined);
     });
 });

--- a/packages/language-server/test/plugins/typescript/testfiles/preferences/code-action-outside-root.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/preferences/code-action-outside-root.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+    import {} from '../definitions'
+    blu
+</script>


### PR DESCRIPTION
The first part of #2479. I will probably open a separate PR to deprioritise the component auto-import later. I did try it before and it should be possible to detect if there is a barrel import in the same list. 