### PR TITLE
fix: detect `<script module>` tag

### DIFF
--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -143,8 +143,12 @@ export function extractScriptTags(
         return null;
     }
 
-    const script = scripts.find((s) => s.attributes['context'] !== 'module');
-    const moduleScript = scripts.find((s) => s.attributes['context'] === 'module');
+    const script = scripts.find(
+        (s) => s.attributes['context'] !== 'module' && !('module' in s.attributes)
+    );
+    const moduleScript = scripts.find(
+        (s) => s.attributes['context'] === 'module' || 'module' in s.attributes
+    );
     return { script, moduleScript };
 }
 


### PR DESCRIPTION
This was missing in #2473

Possibly related to https://github.com/sveltejs/svelte/issues/13039