### PR TITLE
warn svelte input only when program has no svelte files at all

### DIFF
--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -109,7 +109,7 @@ export namespace DocumentSnapshot {
         tsSystem: ts.System
     ) {
         if (isSvelteFilePath(filePath)) {
-            return DocumentSnapshot.fromSvelteFilePath(filePath, createDocument, options);
+            return DocumentSnapshot.fromSvelteFilePath(filePath, createDocument, options, tsSystem);
         } else {
             return DocumentSnapshot.fromNonSvelteFilePath(filePath, tsSystem);
         }
@@ -173,9 +173,10 @@ export namespace DocumentSnapshot {
     export function fromSvelteFilePath(
         filePath: string,
         createDocument: (filePath: string, text: string) => Document,
-        options: SvelteSnapshotOptions
+        options: SvelteSnapshotOptions,
+        tsSystem: ts.System
     ) {
-        const originalText = ts.sys.readFile(filePath) ?? '';
+        const originalText = tsSystem.readFile(filePath) ?? '';
         return fromDocument(createDocument(filePath, originalText), options);
     }
 }

--- a/packages/language-server/src/svelte-check.ts
+++ b/packages/language-server/src/svelte-check.ts
@@ -209,19 +209,14 @@ export class SvelteCheck {
         };
 
         if (lsContainer.configErrors.length > 0) {
-            const grouped = groupBy(
-                lsContainer.configErrors,
-                (error) => error.file?.fileName ?? tsconfigPath
-            );
-
-            return Object.entries(grouped).map(([filePath, errors]) => ({
-                filePath,
-                text: '',
-                diagnostics: errors.map((diagnostic) => map(diagnostic))
-            }));
+            return reportConfigError();
         }
 
         const lang = lsContainer.getService();
+        if (lsContainer.configErrors.length > 0) {
+            return reportConfigError();
+        }
+
         const files = lang.getProgram()?.getSourceFiles() || [];
         const options = lang.getProgram()?.getCompilerOptions() || {};
 
@@ -318,6 +313,19 @@ export class SvelteCheck {
                 }
             })
         );
+
+        function reportConfigError() {
+            const grouped = groupBy(
+                lsContainer.configErrors,
+                (error) => error.file?.fileName ?? tsconfigPath
+            );
+
+            return Object.entries(grouped).map(([filePath, errors]) => ({
+                filePath,
+                text: '',
+                diagnostics: errors.map((diagnostic) => map(diagnostic))
+            }));
+        }
     }
 
     private async getDiagnosticsForFile(uri: string) {


### PR DESCRIPTION
While implementing the delayed check. I found out that tsserver actually assigns files that aren't project files into the service that loads the files through import. And this has all sorts of inconsistent states 😅. So still need to compare the behavior to tsserver. 