### PR TITLE
fix: update SvelteKit trailingSlash types

### DIFF
--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -232,13 +232,13 @@ export const kitExports: Record<
                 kind: 'punctuation'
             },
             {
-                text: "'auto' | 'always' | 'never'",
+                text: "'never' | 'always' | 'ignore'",
                 kind: 'stringLiteral'
             }
         ],
         documentation: [
             {
-                text: 'Control how SvelteKit should handle (missing) trailing slashes in the URL. More info: https://kit.svelte.dev/docs/page-options#trailingslash',
+                text: 'Control how SvelteKit should handle trailing slashes in the URL. More info: https://kit.svelte.dev/docs/page-options#trailingslash',
                 kind: 'text'
             }
         ]


### PR DESCRIPTION
I noticed the types is incorrect for `trailingSlash`

<img width="789" alt="image" src="https://github.com/user-attachments/assets/b5a5446d-e3e7-4130-85c3-a4bc577027dd">

This aligns with SvelteKit's types at https://github.com/sveltejs/kit/blob/108cb127eb0a4c3655aeff1f749bcbd98b70324e/packages/kit/types/index.d.ts#L1578

I also removed the `(missing)` from the doc text since I don't think it's specific to missing trailing slashes only? SvelteKit could also handle requests differently if it gets a URL with trailing slash but with the `never` config (which it 308 redirects to the non-trailing slash path)