### PR TITLE
fix: make no Svelte files found a warning

### DIFF
--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -1,6 +1,7 @@
 import { dirname, join, resolve, basename } from 'path';
 import ts from 'typescript';
 import {
+    DiagnosticSeverity,
     PublishDiagnosticsParams,
     RelativePattern,
     TextDocumentContentChangeEvent
@@ -803,7 +804,7 @@ async function createLanguageService(
         const excludeText = JSON.stringify(exclude);
         const svelteConfigDiagnostics: ts.Diagnostic[] = [
             {
-                category: ts.DiagnosticCategory.Error,
+                category: ts.DiagnosticCategory.Warning,
                 code: TsconfigSvelteDiagnostics.NO_SVELTE_INPUT,
                 file: undefined,
                 start: undefined,
@@ -977,13 +978,14 @@ async function createLanguageService(
                 diagnostics: svelteConfigDiagnostics.map((d) => ({
                     message: d.messageText as string,
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-                    severity: ts.DiagnosticCategory.Error,
+                    severity: DiagnosticSeverity.Warning,
                     source: 'svelte'
                 }))
             });
-            projectConfig.errors = projectConfig.errors
+            const new_errors = projectConfig.errors
                 .filter((e) => !codes.includes(e.code))
                 .concat(svelteConfigDiagnostics);
+            projectConfig.errors.splice(0, projectConfig.errors.length, ...new_errors);
         }
 
         // https://github.com/microsoft/TypeScript/blob/23faef92703556567ddbcb9afb893f4ba638fc20/src/server/project.ts#L1624

--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -49,7 +49,13 @@ export function processInstanceScriptContent(
     const tsAst = ts.createSourceFile(
         'component.ts.svelte',
         scriptContent,
-        ts.ScriptTarget.Latest,
+        ts.JSDocParsingMode
+            ? {
+                  languageVersion: ts.ScriptTarget.Latest,
+                  // Exists since TS 5.3
+                  jsDocParsingMode: ts.JSDocParsingMode.ParseNone
+              }
+            : ts.ScriptTarget.Latest,
         true,
         ts.ScriptKind.TS
     );


### PR DESCRIPTION
There were reports that this was too overzealous as some people use this potentially not knowing whether or not this is a Svelte-projects, too. Therefore only issue a warning instead of an error.