### PR TITLE
breaking(svelte5): only generate function component shape in runes mode

### DIFF
--- a/packages/language-server/src/plugins/typescript/features/SemanticTokensProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/SemanticTokensProvider.ts
@@ -129,16 +129,17 @@ export class SemanticTokensProviderImpl implements SemanticTokensProvider {
         const startOffset = document.offsetAt(startPosition);
         const endOffset = document.offsetAt(endPosition);
 
-        // Ensure components are highlighted consistently as types
+        // Ensure components in the template get no semantic highlighting
         if (
-            (encodedClassification === /* const variant 1 */ 2056 ||
-                encodedClassification === /* const variant 2 */ 2088 ||
-                encodedClassification === /* function */ 2848) &&
+            (classificationType === 0 ||
+                classificationType === 5 ||
+                classificationType === 7 ||
+                classificationType === 10) &&
             snapshot.svelteNodeAt(startOffset)?.type === 'InlineComponent' &&
             (document.getText().charCodeAt(startOffset - 1) === /* < */ 60 ||
                 document.getText().charCodeAt(startOffset - 1) === /* / */ 47)
         ) {
-            classificationType = 5;
+            return;
         }
 
         return [

--- a/packages/language-server/test/plugins/typescript/features/SemanticTokensProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/SemanticTokensProvider.test.ts
@@ -193,13 +193,6 @@ describe('SemanticTokensProvider', function () {
             },
             {
                 line: 12,
-                character: 5,
-                length: 'Imported'.length,
-                type: isSvelte5Plus ? TokenType.type : TokenType.class,
-                modifiers: isSvelte5Plus ? [TokenModifier.readonly] : []
-            },
-            {
-                line: 12,
                 character: 23,
                 length: 'blurHandler'.length,
                 type: TokenType.function,

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/RunesGeneric.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/RunesGeneric.svelte
@@ -1,0 +1,7 @@
+<script lang="ts" generics="T">
+    let { readonly, can_bind = $bindable() }: { readonly?: T; can_bind?: T } = $props();
+
+    export function only_bind() {
+        return true;
+    }
+</script>

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/expected_svelte_5.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/expected_svelte_5.json
@@ -5,11 +5,11 @@
         "range": {
             "end": {
                 "character": 20,
-                "line": 25
+                "line": 26
             },
             "start": {
                 "character": 7,
-                "line": 25
+                "line": 26
             }
         },
         "severity": 1,
@@ -22,11 +22,11 @@
         "range": {
             "end": {
                 "character": 21,
-                "line": 26
+                "line": 27
             },
             "start": {
                 "character": 12,
-                "line": 26
+                "line": 27
             }
         },
         "severity": 1,
@@ -39,11 +39,11 @@
         "range": {
             "end": {
                 "character": 21,
-                "line": 26
+                "line": 27
             },
             "start": {
                 "character": 7,
-                "line": 26
+                "line": 27
             }
         },
         "severity": 1,
@@ -56,11 +56,11 @@
         "range": {
             "end": {
                 "character": 17,
-                "line": 27
+                "line": 28
             },
             "start": {
                 "character": 8,
-                "line": 27
+                "line": 28
             }
         },
         "severity": 1,
@@ -73,11 +73,11 @@
         "range": {
             "end": {
                 "character": 27,
-                "line": 29
+                "line": 30
             },
             "start": {
                 "character": 14,
-                "line": 29
+                "line": 30
             }
         },
         "severity": 1,
@@ -90,11 +90,11 @@
         "range": {
             "end": {
                 "character": 28,
-                "line": 30
+                "line": 31
             },
             "start": {
                 "character": 19,
-                "line": 30
+                "line": 31
             }
         },
         "severity": 1,
@@ -107,11 +107,11 @@
         "range": {
             "end": {
                 "character": 28,
-                "line": 30
+                "line": 31
             },
             "start": {
                 "character": 14,
-                "line": 30
+                "line": 31
             }
         },
         "severity": 1,
@@ -124,11 +124,11 @@
         "range": {
             "end": {
                 "character": 24,
-                "line": 31
+                "line": 32
             },
             "start": {
                 "character": 15,
-                "line": 31
+                "line": 32
             }
         },
         "severity": 1,

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/expected_svelte_5.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/expected_svelte_5.json
@@ -66,5 +66,73 @@
         "severity": 1,
         "source": "ts",
         "tags": []
+    },
+    {
+        "code": 2322,
+        "message": "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\nTo mark a property as bindable: 'let { readonly = $bindable() } = $props()'",
+        "range": {
+            "end": {
+                "character": 27,
+                "line": 29
+            },
+            "start": {
+                "character": 14,
+                "line": 29
+            }
+        },
+        "severity": 1,
+        "source": "ts",
+        "tags": []
+    },
+    {
+        "code": 2353,
+        "message": "Object literal may only specify known properties, and 'only_bind' does not exist in type '$$ComponentProps'.",
+        "range": {
+            "end": {
+                "character": 28,
+                "line": 30
+            },
+            "start": {
+                "character": 19,
+                "line": 30
+            }
+        },
+        "severity": 1,
+        "source": "ts",
+        "tags": []
+    },
+    {
+        "code": 2322,
+        "message": "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component.\nTo mark a property as bindable: 'let { only_bind = $bindable() } = $props()'",
+        "range": {
+            "end": {
+                "character": 28,
+                "line": 30
+            },
+            "start": {
+                "character": 14,
+                "line": 30
+            }
+        },
+        "severity": 1,
+        "source": "ts",
+        "tags": []
+    },
+    {
+        "code": 2353,
+        "message": "Object literal may only specify known properties, and 'only_bind' does not exist in type '$$ComponentProps'.",
+        "range": {
+            "end": {
+                "character": 24,
+                "line": 31
+            },
+            "start": {
+                "character": 15,
+                "line": 31
+            }
+        },
+        "severity": 1,
+        "source": "ts",
+        "tags": []
     }
 ]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/expectedv2.json
@@ -1,15 +1,32 @@
 [
     {
+        "code": 2344,
+        "message": "Type 'typeof Runes__SvelteComponent_' does not satisfy the constraint '(...args: any) => any'.\n  Type 'typeof Runes__SvelteComponent_' provides no match for the signature '(...args: any): any'.",
+        "range": {
+            "end": {
+                "character": 41,
+                "line": 12
+            },
+            "start": {
+                "character": 29,
+                "line": 12
+            }
+        },
+        "severity": 1,
+        "source": "ts",
+        "tags": []
+    },
+    {
         "code": 2353,
         "message": "Object literal may only specify known properties, and 'can_bind' does not exist in type '{ only_bind?: (() => boolean) | undefined; }'.",
         "range": {
             "end": {
                 "character": 20,
-                "line": 20
+                "line": 21
             },
             "start": {
                 "character": 12,
-                "line": 20
+                "line": 21
             }
         },
         "severity": 1,
@@ -19,23 +36,6 @@
     {
         "code": 2353,
         "message": "Object literal may only specify known properties, and 'can_bind' does not exist in type '{ only_bind?: (() => boolean) | undefined; }'.",
-        "range": {
-            "end": {
-                "character": 16,
-                "line": 21
-            },
-            "start": {
-                "character": 8,
-                "line": 21
-            }
-        },
-        "severity": 1,
-        "source": "ts",
-        "tags": []
-    },
-    {
-        "code": 2353,
-        "message": "Object literal may only specify known properties, and 'readonly' does not exist in type '{ only_bind?: (() => boolean) | undefined; }'.",
         "range": {
             "end": {
                 "character": 16,
@@ -55,12 +55,46 @@
         "message": "Object literal may only specify known properties, and 'readonly' does not exist in type '{ only_bind?: (() => boolean) | undefined; }'.",
         "range": {
             "end": {
+                "character": 16,
+                "line": 23
+            },
+            "start": {
+                "character": 8,
+                "line": 23
+            }
+        },
+        "severity": 1,
+        "source": "ts",
+        "tags": []
+    },
+    {
+        "code": 2353,
+        "message": "Object literal may only specify known properties, and 'readonly' does not exist in type '{ only_bind?: (() => boolean) | undefined; }'.",
+        "range": {
+            "end": {
                 "character": 20,
-                "line": 25
+                "line": 26
             },
             "start": {
                 "character": 12,
-                "line": 25
+                "line": 26
+            }
+        },
+        "severity": 1,
+        "source": "ts",
+        "tags": []
+    },
+    {
+        "code": 2353,
+        "message": "Object literal may only specify known properties, and 'readonly' does not exist in type '{ only_bind?: (() => boolean) | undefined; }'.",
+        "range": {
+            "end": {
+                "character": 27,
+                "line": 30
+            },
+            "start": {
+                "character": 19,
+                "line": 30
             }
         },
         "severity": 1,

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/input.svelte
@@ -9,7 +9,7 @@
     let can_bind = '';
     let readonly = ''
 
-    let instance: Runes;
+    let instance: ReturnType<typeof Runes>;
     instance!.only_bind() === true;
 </script>
 
@@ -26,3 +26,7 @@
 <Runes bind:readonly />
 <Runes bind:only_bind />
 <Runes {only_bind} />
+
+<RunesGeneric bind:readonly />
+<RunesGeneric bind:only_bind />
+<RunesGeneric {only_bind} />

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bindings/input.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import Legacy from './Legacy.svelte';
     import Runes from './Runes.svelte';
+    import RunesGeneric from './RunesGeneric.svelte';
 
     let bind_and_prop: () => boolean;
     let value = '';

--- a/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
@@ -5,15 +5,16 @@ import { ExportedNames } from './nodes/ExportedNames';
 import { ComponentDocumentation } from './nodes/ComponentDocumentation';
 import { Generics } from './nodes/Generics';
 import { surroundWithIgnoreComments } from '../utils/ignore';
+import { ComponentEvents } from './nodes/ComponentEvents';
 
 export interface AddComponentExportPara {
     str: MagicString;
     canHaveAnyProp: boolean;
     /**
-     * If true, not fallback to `any`
+     * If strictEvents true, not fallback to `any`
      * -> all unknown events will throw a type error
      * */
-    strictEvents: boolean;
+    events: ComponentEvents;
     isTsFile: boolean;
     usesAccessors: boolean;
     exportedNames: ExportedNames;
@@ -41,7 +42,7 @@ export function addComponentExport(params: AddComponentExportPara) {
 }
 
 function addGenericsComponentExport({
-    strictEvents,
+    events,
     canHaveAnyProp,
     exportedNames,
     componentDocumentation,
@@ -70,7 +71,7 @@ class __sveltets_Render${genericsDef} {
         return ${props(true, canHaveAnyProp, exportedNames, `render${genericsRef}()`)}.props;
     }
     events() {
-        return ${events(strictEvents, `render${genericsRef}()`)}.events;
+        return ${_events(events.hasStrictEvents() || exportedNames.usesRunes(), `render${genericsRef}()`)}.events;
     }
     slots() {
         return render${genericsRef}().slots;
@@ -94,21 +95,42 @@ ${
     if (isSvelte5) {
         // Don't add props/events/slots type exports in dts mode for now, maybe someone asks for it to be back,
         // but it's safer to not do it for now to have more flexibility in the future.
+        let eventsSlotsType = [];
+        if (events.hasEvents() || !exportedNames.usesRunes()) {
+            eventsSlotsType.push(`$$events?: ${returnType('events')}`);
+        }
+        if (usesSlots) {
+            eventsSlotsType.push(`$$slots?: ${returnType('slots')}`);
+            eventsSlotsType.push(`children?: any`);
+        }
         const propsType =
             !canHaveAnyProp && exportedNames.hasNoProps()
-                ? `{$$events?: ${returnType('events')}${usesSlots ? `, $$slots?: ${returnType('slots')}, children?: any` : ''}}`
-                : `${returnType('props')} & {$$events?: ${returnType('events')}${usesSlots ? `, $$slots?: ${returnType('slots')}, children?: any` : ''}}`;
-        statement +=
-            `\ninterface $$IsomorphicComponent {\n` +
-            `    new ${genericsDef}(options: import('svelte').ComponentConstructorOptions<${returnType('props') + (usesSlots ? '& {children?: any}' : '')}>): import('svelte').SvelteComponent<${returnType('props')}, ${returnType('events')}, ${returnType('slots')}> & { $$bindings?: ${returnType('bindings')} } & ${returnType('exports')};\n` +
-            `    ${genericsDef}(internal: unknown, props: ${propsType}): ${returnType('exports')};\n` +
-            `    z_$$bindings?: ReturnType<__sveltets_Render${generics.toReferencesAnyString()}['bindings']>;\n` +
-            `}\n` +
-            `${doc}const ${className || '$$Component'}: $$IsomorphicComponent = null as any;\n` +
-            surroundWithIgnoreComments(
-                `type ${className || '$$Component'}${genericsDef} = InstanceType<typeof ${className || '$$Component'}${genericsRef}>;\n`
-            ) +
-            `export default ${className || '$$Component'};`;
+                ? `{${eventsSlotsType.join(', ')}}`
+                : `${returnType('props')} & {${eventsSlotsType.join(', ')}}`;
+        const bindingsType = `ReturnType<__sveltets_Render${generics.toReferencesAnyString()}['bindings']>`;
+
+        if (exportedNames.usesRunes() && !events.hasEvents() && !usesSlots) {
+            statement +=
+                `\ntype $$$Component${genericsDef} = import('svelte').Component<${propsType}, ${returnType('exports')}, ${bindingsType}> \n` +
+                `${doc}declare function ${className || '$$Component'}${genericsDef}(...args: Parameters<$$$Component${generics.toReferencesString()}>): ReturnType<$$$Component${generics.toReferencesString()}>;\n` +
+                // The only way to preserve the generic type when transforming this function type to a class via __sveltets_2_ensureComponent later is a function,
+                // and so we need to manually add the properties on the function itself this way.
+                `${className || '$$Component'}.z_$$bindings = null as any as ${bindingsType};\n` +
+                `${className || '$$Component'}.element = null as any;\n` +
+                `export default ${className || '$$Component'};`;
+        } else {
+            statement +=
+                `\ninterface $$IsomorphicComponent {\n` +
+                `    new ${genericsDef}(options: import('svelte').ComponentConstructorOptions<${returnType('props') + (usesSlots ? '& {children?: any}' : '')}>): import('svelte').SvelteComponent<${returnType('props')}, ${returnType('events')}, ${returnType('slots')}> & { $$bindings?: ${returnType('bindings')} } & ${returnType('exports')};\n` +
+                `    ${genericsDef}(internal: unknown, props: ${propsType}): ${returnType('exports')};\n` +
+                `    z_$$bindings?: ${bindingsType};\n` +
+                `}\n` +
+                `${doc}const ${className || '$$Component'}: $$IsomorphicComponent = null as any;\n` +
+                surroundWithIgnoreComments(
+                    `type ${className || '$$Component'}${genericsDef} = InstanceType<typeof ${className || '$$Component'}${genericsRef}>;\n`
+                ) +
+                `export default ${className || '$$Component'};`;
+        }
     } else if (mode === 'dts') {
         statement +=
             `export type ${PropsName}${genericsDef} = ${returnType('props')};\n` +
@@ -137,7 +159,7 @@ ${
 }
 
 function addSimpleComponentExport({
-    strictEvents,
+    events,
     isTsFile,
     canHaveAnyProp,
     exportedNames,
@@ -154,7 +176,7 @@ function addSimpleComponentExport({
         isTsFile,
         canHaveAnyProp,
         exportedNames,
-        events(strictEvents, 'render()')
+        _events(events.hasStrictEvents(), 'render()')
     );
 
     const doc = componentDocumentation.getFormatted();
@@ -162,7 +184,11 @@ function addSimpleComponentExport({
 
     let statement: string;
     if (mode === 'dts') {
-        if (isSvelte5) {
+        if (isSvelte5 && exportedNames.usesRunes() && !usesSlots && !events.hasEvents()) {
+            statement =
+                `\n${doc}const ${className || '$$Component'} = __sveltets_2_fn_component(render());\n` +
+                `export default ${className || '$$Component'};`;
+        } else if (isSvelte5) {
             // Inline definitions from Svelte shims; else dts files will reference the globals which will be unresolved
             statement =
                 `\ninterface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
@@ -223,12 +249,18 @@ declare function $$__sveltets_2_isomorphic_component<
         }
     } else {
         if (isSvelte5) {
-            statement =
-                `\n${doc}const ${className || '$$Component'} = __sveltets_2_isomorphic_component${usesSlots ? '_slots' : ''}(${propDef});\n` +
-                surroundWithIgnoreComments(
-                    `type ${className || '$$Component'} = InstanceType<typeof ${className || '$$Component'}>;\n`
-                ) +
-                `export default ${className || '$$Component'};`;
+            if (exportedNames.usesRunes() && !usesSlots && !events.hasEvents()) {
+                statement =
+                    `\n${doc}const ${className || '$$Component'} = __sveltets_2_fn_component(render());\n` +
+                    `export default ${className || '$$Component'};`;
+            } else {
+                statement =
+                    `\n${doc}const ${className || '$$Component'} = __sveltets_2_isomorphic_component${usesSlots ? '_slots' : ''}(${propDef});\n` +
+                    surroundWithIgnoreComments(
+                        `type ${className || '$$Component'} = InstanceType<typeof ${className || '$$Component'}>;\n`
+                    ) +
+                    `export default ${className || '$$Component'};`;
+            }
         } else {
             statement =
                 `\n\n${doc}export default class${
@@ -281,7 +313,7 @@ function addTypeExport(
     }
 }
 
-function events(strictEvents: boolean, renderStr: string) {
+function _events(strictEvents: boolean, renderStr: string) {
     return strictEvents ? renderStr : `__sveltets_2_with_any_event(${renderStr})`;
 }
 

--- a/packages/svelte2tsx/src/svelte2tsx/index.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/index.ts
@@ -435,7 +435,7 @@ export function svelte2tsx(
     addComponentExport({
         str,
         canHaveAnyProp: !exportedNames.uses$$Props && (uses$$props || uses$$restProps),
-        strictEvents: events.hasStrictEvents(), // TODO in Svelte 6 we should also apply strictEvents in runes mode
+        events,
         isTsFile: options?.isTsFile,
         exportedNames,
         usesAccessors,

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ComponentEvents.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ComponentEvents.ts
@@ -77,6 +77,10 @@ export class ComponentEvents {
         this.componentEventsInterface.setComponentEventsInterface(node, this.str, astOffset);
     }
 
+    hasEvents(): boolean {
+        return this.eventsClass.events.size > 0;
+    }
+
     hasStrictEvents(): boolean {
         return this.componentEventsInterface.isPresent() || this.strictEvents;
     }

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -793,7 +793,7 @@ export class ExportedNames {
     }
 
     hasPropsRune() {
-        return this.isSvelte5Plus && (this.$props.type || this.$props.comment);
+        return this.isSvelte5Plus && !!(this.$props.type || this.$props.comment);
     }
 
     checkGlobalsForRunes(globals: string[]) {

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -220,11 +220,36 @@ declare type ATypedSvelteComponent = {
  * ```
  */
 declare type ConstructorOfATypedSvelteComponent = new (args: {target: any, props?: any}) => ATypedSvelteComponent
+// Usage note: Cannot properly transform generic function components to class components due to TypeScript limitations
 declare function __sveltets_2_ensureComponent<
-    // @ts-ignore svelte.Component doesn't exist in Svelte 4
-    T extends ConstructorOfATypedSvelteComponent | (typeof import('svelte') extends { mount: any } ? import('svelte').Component<any, any, any> : never) | null | undefined
-    // @ts-ignore svelte.Component doesn't exist in Svelte 4
->(type: T): NonNullable<T extends ConstructorOfATypedSvelteComponent ? T : typeof import('svelte') extends { mount: any } ? T extends import('svelte').Component<infer Props extends Record<string, any>> ? typeof import('svelte').SvelteComponent<Props, Props['$$events'], Props['$$slots']> : T : T>;
+    T extends
+        | ConstructorOfATypedSvelteComponent
+        | (typeof import('svelte') extends { mount: any }
+              ? // @ts-ignore svelte.Component doesn't exist in Svelte 4
+                import('svelte').Component<any, any, any>
+              : never)
+        | null
+        | undefined
+>(
+    type: T
+): NonNullable<
+    T extends ConstructorOfATypedSvelteComponent
+        ? T
+        : typeof import('svelte') extends { mount: any }
+          ? // @ts-ignore svelte.Component doesn't exist in Svelte 4
+            T extends import('svelte').Component<
+                infer Props extends Record<string, any>,
+                infer Exports extends Record<string, any>,
+                infer Bindings extends string
+            >
+              ? new (
+                    options: import('svelte').ComponentConstructorOptions<Props>
+                ) => import('svelte').SvelteComponent<Props, Props['$$events'], Props['$$slots']> &
+                    Exports & { $$bindings: Bindings }
+              : never
+          : never
+>;
+
 declare function __sveltets_2_ensureArray<T extends ArrayLike<unknown> | Iterable<unknown>>(array: T): T extends ArrayLike<infer U> ? U[] : T extends Iterable<infer U> ? Iterable<U> : any[];
 
 type __sveltets_2_PropsWithChildren<Props, Slots> = Props &

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -240,6 +240,11 @@ declare function __sveltets_2_runes_constructor<Props extends {}>(render: {props
 
 declare function __sveltets_$$bindings<Bindings extends string[]>(...bindings: Bindings): Bindings[number];
 
+declare function __sveltets_2_fn_component<
+    Props extends Record<string, any>, Exports extends Record<string, any>, Bindings extends string
+    // @ts-ignore Svelte 5 only
+>(klass: {props: Props, exports?: Exports, bindings?: Bindings }): import('svelte').Component<Props, Exports, Bindings>;
+
 interface __sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
     new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & { $$bindings?: Bindings } & Exports;
     (internal: unknown, props: Props extends Record<string, never> ? {$$events?: Events, $$slots?: Slots} : Props & {$$events?: Events, $$slots?: Slots}): Exports & { $set?: any, $on?: any };

--- a/packages/svelte2tsx/test/emitDts/samples/javascript-runes.v5/expected/TestRunes.svelte.d.ts
+++ b/packages/svelte2tsx/test/emitDts/samples/javascript-runes.v5/expected/TestRunes.svelte.d.ts
@@ -1,23 +1,7 @@
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-    new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
-        $$bindings?: Bindings;
-    } & Exports;
-    (internal: unknown, props: Props & {
-        $$events?: Events;
-        $$slots?: Slots;
-    }): Exports & {
-        $set?: any;
-        $on?: any;
-    };
-    z_$$bindings?: Bindings;
-}
-declare const TestRunes: $$__sveltets_2_IsomorphicComponent<{
+declare const TestRunes: import("svelte").Component<{
     foo: string;
     bar?: number;
 }, {
-    [evt: string]: CustomEvent<any>;
-}, {}, {
     baz: () => void;
 }, "bar">;
-type TestRunes = InstanceType<typeof TestRunes>;
 export default TestRunes;

--- a/packages/svelte2tsx/test/emitDts/samples/typescript-runes-generics.v5/expected/TestRunes.svelte.d.ts
+++ b/packages/svelte2tsx/test/emitDts/samples/typescript-runes-generics.v5/expected/TestRunes.svelte.d.ts
@@ -10,10 +10,13 @@ declare class __sveltets_Render<T extends Record<string, any>, K extends keyof T
         baz: () => T;
     };
 }
-type $$$Component<T extends Record<string, any>, K extends keyof T> = import('svelte').Component<ReturnType<__sveltets_Render<T, K>['props']> & {}, ReturnType<__sveltets_Render<T, K>['exports']>, ReturnType<__sveltets_Render<any, any>['bindings']>>;
-declare function TestRunes<T extends Record<string, any>, K extends keyof T>(...args: Parameters<$$$Component<T, K>>): ReturnType<$$$Component<T, K>>;
-declare namespace TestRunes {
-    var z_$$bindings: "bar";
-    var element: any;
+interface $$IsomorphicComponent {
+    new <T extends Record<string, any>, K extends keyof T>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<T, K>['props']>>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<T, K>['props']>, ReturnType<__sveltets_Render<T, K>['events']>, ReturnType<__sveltets_Render<T, K>['slots']>> & {
+        $$bindings?: ReturnType<__sveltets_Render<T, K>['bindings']>;
+    } & ReturnType<__sveltets_Render<T, K>['exports']>;
+    <T extends Record<string, any>, K extends keyof T>(internal: unknown, props: ReturnType<__sveltets_Render<T, K>['props']> & {}): ReturnType<__sveltets_Render<T, K>['exports']>;
+    z_$$bindings?: ReturnType<__sveltets_Render<any, any>['bindings']>;
 }
+declare const TestRunes: $$IsomorphicComponent;
+type TestRunes<T extends Record<string, any>, K extends keyof T> = InstanceType<typeof TestRunes<T, K>>;
 export default TestRunes;

--- a/packages/svelte2tsx/test/emitDts/samples/typescript-runes-generics.v5/expected/TestRunes.svelte.d.ts
+++ b/packages/svelte2tsx/test/emitDts/samples/typescript-runes-generics.v5/expected/TestRunes.svelte.d.ts
@@ -3,24 +3,17 @@ declare class __sveltets_Render<T extends Record<string, any>, K extends keyof T
         foo: T;
         bar?: K;
     };
-    events(): {} & {
-        [evt: string]: CustomEvent<any>;
-    };
+    events(): {};
     slots(): {};
     bindings(): "bar";
     exports(): {
         baz: () => T;
     };
 }
-interface $$IsomorphicComponent {
-    new <T extends Record<string, any>, K extends keyof T>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<T, K>['props']>>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<T, K>['props']>, ReturnType<__sveltets_Render<T, K>['events']>, ReturnType<__sveltets_Render<T, K>['slots']>> & {
-        $$bindings?: ReturnType<__sveltets_Render<T, K>['bindings']>;
-    } & ReturnType<__sveltets_Render<T, K>['exports']>;
-    <T extends Record<string, any>, K extends keyof T>(internal: unknown, props: ReturnType<__sveltets_Render<T, K>['props']> & {
-        $$events?: ReturnType<__sveltets_Render<T, K>['events']>;
-    }): ReturnType<__sveltets_Render<T, K>['exports']>;
-    z_$$bindings?: ReturnType<__sveltets_Render<any, any>['bindings']>;
+type $$$Component<T extends Record<string, any>, K extends keyof T> = import('svelte').Component<ReturnType<__sveltets_Render<T, K>['props']> & {}, ReturnType<__sveltets_Render<T, K>['exports']>, ReturnType<__sveltets_Render<any, any>['bindings']>>;
+declare function TestRunes<T extends Record<string, any>, K extends keyof T>(...args: Parameters<$$$Component<T, K>>): ReturnType<$$$Component<T, K>>;
+declare namespace TestRunes {
+    var z_$$bindings: "bar";
+    var element: any;
 }
-declare const TestRunes: $$IsomorphicComponent;
-type TestRunes<T extends Record<string, any>, K extends keyof T> = InstanceType<typeof TestRunes<T, K>>;
 export default TestRunes;

--- a/packages/svelte2tsx/test/emitDts/samples/typescript-runes.v5/expected/TestRunes.svelte.d.ts
+++ b/packages/svelte2tsx/test/emitDts/samples/typescript-runes.v5/expected/TestRunes.svelte.d.ts
@@ -1,23 +1,7 @@
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-    new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
-        $$bindings?: Bindings;
-    } & Exports;
-    (internal: unknown, props: Props & {
-        $$events?: Events;
-        $$slots?: Slots;
-    }): Exports & {
-        $set?: any;
-        $on?: any;
-    };
-    z_$$bindings?: Bindings;
-}
-declare const TestRunes: $$__sveltets_2_IsomorphicComponent<{
+declare const TestRunes: import("svelte").Component<{
     foo: string;
     bar?: number;
 }, {
-    [evt: string]: CustomEvent<any>;
-}, {}, {
     baz: () => void;
 }, "bar">;
-type TestRunes = InstanceType<typeof TestRunes>;
 export default TestRunes;

--- a/packages/svelte2tsx/test/helpers.ts
+++ b/packages/svelte2tsx/test/helpers.ts
@@ -230,7 +230,10 @@ export function test_samples(dir: string, transform: TransformSampleFn, js: 'js'
         if (sample.name.endsWith('.v5') && !isSvelte5Plus) continue;
 
         const svelteFile = sample.find_file('*.svelte');
-        const expectedFile = isSvelte5Plus ? `expected-svelte5.${js}` : `expectedv2.${js}`;
+        const expectedFile =
+            isSvelte5Plus && !sample.name.endsWith('.v5')
+                ? `expected-svelte5.${js}`
+                : `expectedv2.${js}`;
         const config = {
             filename: svelteFile,
             sampleName: sample.name,

--- a/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script3.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/module-script-and-script3.v5/expectedv2.ts
@@ -9,7 +9,7 @@
 async () => {
 
  { svelteHTML.createElement("h1", {}); world; }};
-return { props: {world: world}, slots: {}, events: {} }}
-
-export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(['world'], __sveltets_2_with_any_event(render()))) {
-}
+return { props: {world: world}, exports: {}, bindings: "", slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['world'], __sveltets_2_with_any_event(render())));
+/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-best-effort-types.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-best-effort-types.v5/expectedv2.ts
@@ -5,6 +5,5 @@
 ;
 async () => {};
 return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Input__SvelteComponent_;
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-bindable.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-bindable.v5/expectedv2.ts
@@ -5,6 +5,5 @@
 ;
 async () => {};
 return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings('b'), slots: {}, events: {} }}
-const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Input__SvelteComponent_;
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-looking-like-stores.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-looking-like-stores.v5/expectedv2.ts
@@ -9,6 +9,5 @@ async () => {
 
 state; derived;};
 return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Input__SvelteComponent_;
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-only-export.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-only-export.v5/expectedv2.ts
@@ -8,6 +8,5 @@ async () => {
 
 x;};
 return { props: /** @type {Record<string, never>} */ ({}), exports: /** @type {{foo: typeof foo}} */ ({}), bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Input__SvelteComponent_;
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes.v5/expectedv2.ts
@@ -8,6 +8,5 @@
 ;
 async () => {};
 return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Input__SvelteComponent_;
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune-no-changes.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune-no-changes.v5/expectedv2.ts
@@ -8,6 +8,5 @@
 ;
 async () => {};
 return { props: /** @type {$$ComponentProps} */({}), exports: /** @type {{snapshot: typeof snapshot}} */ ({}), bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Page__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Page__SvelteComponent_ = InstanceType<typeof Page__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Page__SvelteComponent_;
+const Page__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Page__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/sveltekit-autotypes-$props-rune.v5/expectedv2.ts
@@ -6,6 +6,5 @@
 ;
 async () => {};
 return { props: /** @type {$$ComponentProps} */({}), exports: /** @type {{snapshot: typeof snapshot}} */ ({}), bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Page__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Page__SvelteComponent_ = InstanceType<typeof Page__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Page__SvelteComponent_;
+const Page__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Page__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-best-effort-types.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-best-effort-types.v5/expectedv2.ts
@@ -5,6 +5,5 @@
 ;
 async () => {};
 return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Input__SvelteComponent_;
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable.v5/expectedv2.ts
@@ -5,6 +5,5 @@
 ;
 async () => {};
 return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings('b', 'c'), slots: {}, events: {} }}
-const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Input__SvelteComponent_;
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-generics.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-generics.v5/expectedv2.ts
@@ -12,7 +12,7 @@ class __sveltets_Render<T> {
         return render<T>().props;
     }
     events() {
-        return __sveltets_2_with_any_event(render<T>()).events;
+        return render<T>().events;
     }
     slots() {
         return render<T>().slots;
@@ -21,11 +21,8 @@ class __sveltets_Render<T> {
     exports() { return {}; }
 }
 
-interface $$IsomorphicComponent {
-    new <T>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<T>['props']>>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<T>['props']>, ReturnType<__sveltets_Render<T>['events']>, ReturnType<__sveltets_Render<T>['slots']>> & { $$bindings?: ReturnType<__sveltets_Render<T>['bindings']> } & ReturnType<__sveltets_Render<T>['exports']>;
-    <T>(internal: unknown, props: ReturnType<__sveltets_Render<T>['props']> & {$$events?: ReturnType<__sveltets_Render<T>['events']>}): ReturnType<__sveltets_Render<T>['exports']>;
-    z_$$bindings?: ReturnType<__sveltets_Render<any>['bindings']>;
-}
-const Input__SvelteComponent_: $$IsomorphicComponent = null as any;
-/*Ωignore_startΩ*/type Input__SvelteComponent_<T> = InstanceType<typeof Input__SvelteComponent_<T>>;
-/*Ωignore_endΩ*/export default Input__SvelteComponent_;
+type $$$Component<T> = import('svelte').Component<ReturnType<__sveltets_Render<T>['props']> & {}, ReturnType<__sveltets_Render<T>['exports']>, ReturnType<__sveltets_Render<any>['bindings']>> 
+declare function Input__SvelteComponent_<T>(...args: Parameters<$$$Component<T>>): ReturnType<$$$Component<T>>;
+Input__SvelteComponent_.z_$$bindings = null as any as ReturnType<__sveltets_Render<any>['bindings']>;
+Input__SvelteComponent_.element = null as any;
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-generics.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-generics.v5/expectedv2.ts
@@ -21,8 +21,11 @@ class __sveltets_Render<T> {
     exports() { return {}; }
 }
 
-type $$$Component<T> = import('svelte').Component<ReturnType<__sveltets_Render<T>['props']> & {}, ReturnType<__sveltets_Render<T>['exports']>, ReturnType<__sveltets_Render<any>['bindings']>> 
-declare function Input__SvelteComponent_<T>(...args: Parameters<$$$Component<T>>): ReturnType<$$$Component<T>>;
-Input__SvelteComponent_.z_$$bindings = null as any as ReturnType<__sveltets_Render<any>['bindings']>;
-Input__SvelteComponent_.element = null as any;
-export default Input__SvelteComponent_;
+interface $$IsomorphicComponent {
+    new <T>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<T>['props']>>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<T>['props']>, ReturnType<__sveltets_Render<T>['events']>, ReturnType<__sveltets_Render<T>['slots']>> & { $$bindings?: ReturnType<__sveltets_Render<T>['bindings']> } & ReturnType<__sveltets_Render<T>['exports']>;
+    <T>(internal: unknown, props: ReturnType<__sveltets_Render<T>['props']> & {}): ReturnType<__sveltets_Render<T>['exports']>;
+    z_$$bindings?: ReturnType<__sveltets_Render<any>['bindings']>;
+}
+const Input__SvelteComponent_: $$IsomorphicComponent = null as any;
+/*Ωignore_startΩ*/type Input__SvelteComponent_<T> = InstanceType<typeof Input__SvelteComponent_<T>>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-with-slot.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-with-slot.v5/expectedv2.ts
@@ -16,7 +16,7 @@ class __sveltets_Render<T> {
         return render<T>().props;
     }
     events() {
-        return __sveltets_2_with_any_event(render<T>()).events;
+        return render<T>().events;
     }
     slots() {
         return render<T>().slots;
@@ -27,7 +27,7 @@ class __sveltets_Render<T> {
 
 interface $$IsomorphicComponent {
     new <T>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<T>['props']>& {children?: any}>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<T>['props']>, ReturnType<__sveltets_Render<T>['events']>, ReturnType<__sveltets_Render<T>['slots']>> & { $$bindings?: ReturnType<__sveltets_Render<T>['bindings']> } & ReturnType<__sveltets_Render<T>['exports']>;
-    <T>(internal: unknown, props: ReturnType<__sveltets_Render<T>['props']> & {$$events?: ReturnType<__sveltets_Render<T>['events']>, $$slots?: ReturnType<__sveltets_Render<T>['slots']>, children?: any}): ReturnType<__sveltets_Render<T>['exports']>;
+    <T>(internal: unknown, props: ReturnType<__sveltets_Render<T>['props']> & {$$slots?: ReturnType<__sveltets_Render<T>['slots']>, children?: any}): ReturnType<__sveltets_Render<T>['exports']>;
     z_$$bindings?: ReturnType<__sveltets_Render<any>['bindings']>;
 }
 const Input__SvelteComponent_: $$IsomorphicComponent = null as any;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes.v5/expectedv2.ts
@@ -7,6 +7,5 @@
 ;
 async () => {};
 return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Input__SvelteComponent_;
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune-unchanged.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune-unchanged.v5/expectedv2.ts
@@ -6,6 +6,5 @@
 ;
 async () => {};
 return { props: {} as any as $$ComponentProps, exports: {} as any as { snapshot: any }, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Page__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Page__SvelteComponent_ = InstanceType<typeof Page__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Page__SvelteComponent_;
+const Page__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Page__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune.v5/expectedv2.ts
@@ -6,6 +6,5 @@
 ;
 async () => {};
 return { props: {} as any as $$ComponentProps, exports: {} as any as { snapshot: typeof snapshot }, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
-const Page__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event(render()));
-/*Ωignore_startΩ*/type Page__SvelteComponent_ = InstanceType<typeof Page__SvelteComponent_>;
-/*Ωignore_endΩ*/export default Page__SvelteComponent_;
+const Page__SvelteComponent_ = __sveltets_2_fn_component(render());
+export default Page__SvelteComponent_;


### PR DESCRIPTION
When a component is in runes mode and not using slots or events, adjust the output to only create the function type that mimics the underlying real shape of components in Svelte 5. This is a breaking change because previously the type was enhanced such that it also had the legacy class shape. As a result, users now may need to switch to `typeof Component` when using the component inside types.

Sadly, due to a combination of requirements and TypeScript limitations, we need to always create both a legacy class component and function component type.
 - Constraints: Need to support Svelte 4 class component types, therefore we need to use __sveltets_2_ensureComponent to transform function components to classes
- Limitations: TypeScript is not able to preserve generics during said transformation (i.e. there's no way to express keeping the generic etc)

> TODO Svelte 6/7: Switch this around and not use new Component in svelte2tsx anymore, which means we can remove the legacy class component. We need something like _ensureFnComponent then.

