### PR TITLE
fix: relax component constructor type

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/generics-runes.v5/ValueComponent.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/generics-runes.v5/ValueComponent.svelte
@@ -1,0 +1,6 @@
+<script lang="ts" generics="T">
+    let { value, defaultValue }: { value: T; defaultValue?: T } = $props();
+</script>
+
+{value}
+{defaultValue}

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/generics-runes.v5/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/generics-runes.v5/expectedv2.json
@@ -1,0 +1,19 @@
+[
+    {
+        "code": 2322,
+        "message": "Type 'number' is not assignable to type 'string'.",
+        "range": {
+            "end": {
+                "character": 36,
+                "line": 10
+            },
+            "start": {
+                "character": 24,
+                "line": 10
+            }
+        },
+        "severity": 1,
+        "source": "ts",
+        "tags": []
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/generics-runes.v5/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/generics-runes.v5/input.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    import ValueComponent from './ValueComponent.svelte';
+
+    let value = $state("test");
+</script>
+
+<!-- ok -->
+<ValueComponent {value} defaultValue={"foo"} />
+
+<!-- error -->
+<ValueComponent {value} defaultValue={1} />

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -207,7 +207,7 @@ declare type ATypedSvelteComponent = {
      */
     $$slot_def: any;
 
-    $on(event: string, handler: ((e: any) => any) | null | undefined): () => void;
+    $on(event: string, handler: any): () => void;
 }
 /**
  * Ambient type only used for intellisense, DO NOT USE IN YOUR PROJECT.


### PR DESCRIPTION
Since #2517 we're no longer adding the `[evt: string]: CustomEvent<any>` index signature to components in runes mode not using `createEventDispatcher`. This revealed a type bug in our `ATypedSvelteComponent` type. It was to restricting, because TypeScript will resolve the empty event object to a handler with callback type `never`, which then means the `__sveltets_2_ensureComponent` generic no longer picks the right type, resulting in generics not being resolved properly. Fix this by relaxing the constraints.

Fixes #2523