### PR TITLE
chore: optimize svelte-check bundle size

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -7,7 +7,8 @@
     "exports": {
         "./package.json": "./package.json",
         ".": "./dist/src/index.js",
-        "./bin/server.js": "./bin/server.js"
+        "./bin/server.js": "./bin/server.js",
+        "./svelte-check": "./dist/src/svelte-check.js"
     },
     "scripts": {
         "test": "cross-env TS_NODE_TRANSPILE_ONLY=true mocha --require ts-node/register \"test/**/*.test.ts\"",

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -6,7 +6,7 @@ import { watch } from 'chokidar';
 import * as fs from 'fs';
 import { fdir } from 'fdir';
 import * as path from 'path';
-import { SvelteCheck, SvelteCheckOptions } from 'svelte-language-server';
+import { SvelteCheck, SvelteCheckOptions } from 'svelte-language-server/svelte-check';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { parseOptions, SvelteCheckCliOptions } from './options';

--- a/packages/svelte-check/src/writers.ts
+++ b/packages/svelte-check/src/writers.ts
@@ -2,7 +2,7 @@ import pc from 'picocolors';
 import { sep } from 'path';
 import { Writable } from 'stream';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-protocol';
-import { offsetAt } from 'svelte-language-server';
+import { offsetAt } from 'svelte-language-server/svelte-check';
 
 export interface Writer {
     start: (workspaceDir: string) => void;


### PR DESCRIPTION
Following Ben's effort to trim down the size. I was actually trying to add some glob library back because chokidar v4 removed the glob support entirely() so was trying to trim it to balance it out 😆. The difference seems relatively large. The bulk of it seems to be HTML custom data which took around 500KB.