### PR TITLE
feat: support typescript 5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "lint": "prettier --check ."
     },
     "dependencies": {
-        "typescript": "^5.5.2"
+        "typescript": "^5.6.3"
     },
     "devDependencies": {
         "cross-env": "^7.0.2",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -61,7 +61,7 @@
         "svelte": "^4.2.19",
         "svelte2tsx": "workspace:~",
         "typescript": "^5.5.2",
-        "typescript-auto-import-cache": "^0.3.3",
+        "typescript-auto-import-cache": "^0.3.4",
         "vscode-css-languageservice": "~6.3.0",
         "vscode-html-languageservice": "~5.3.0",
         "vscode-languageserver": "9.0.1",

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expected_svelte_4.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expected_svelte_4.json
@@ -69,7 +69,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Type 'Component' is not assignable to type 'OtherComponent'.",
+        "message": "Type 'Component' is not assignable to type 'OtherComponent'.\n  Type '{ prop: boolean; }' is not assignable to type '{ prop: string; }'.\n    Types of property 'prop' are incompatible.\n      Type 'boolean' is not assignable to type 'string'.",
         "code": 2322,
         "tags": []
     },

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expected_svelte_5.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/bind-this/expected_svelte_5.json
@@ -69,7 +69,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Type 'Component' is not assignable to type 'OtherComponent'.",
+        "message": "Type 'Component' is not assignable to type 'OtherComponent'.\n  Type '{ prop: boolean; }' is not assignable to type '{ prop: string; }'.\n    Types of property 'prop' are incompatible.\n      Type 'boolean' is not assignable to type 'string'.",
         "code": 2322,
         "tags": []
     },

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expected_svelte_5.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expected_svelte_5.json
@@ -28,7 +28,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent | Component<any, any, any> | null | undefined'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. ",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent | Component<any, any, any> | null | undefined'.\n  Type 'typeof DoesntWork' is not assignable to type 'ConstructorOfATypedSvelteComponent'.\n    Type 'DoesntWork' is missing the following properties from type 'ATypedSvelteComponent': $$prop_def, $$events_def, $$slot_def, $on\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. ",
         "code": 2345,
         "tags": []
     },
@@ -39,7 +39,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent | Component<any, any, any> | null | undefined'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. ",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent | Component<any, any, any> | null | undefined'.\n  Type 'typeof DoesntWork' is not assignable to type 'ConstructorOfATypedSvelteComponent'.\n    Type 'DoesntWork' is missing the following properties from type 'ATypedSvelteComponent': $$prop_def, $$events_def, $$slot_def, $on\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. ",
         "code": 2345,
         "tags": []
     },
@@ -50,7 +50,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent | Component<any, any, any> | null | undefined'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. ",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent | Component<any, any, any> | null | undefined'.\n  Type 'typeof DoesntWork' is not assignable to type 'ConstructorOfATypedSvelteComponent'.\n    Type 'DoesntWork' is missing the following properties from type 'ATypedSvelteComponent': $$prop_def, $$events_def, $$slot_def, $on\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. ",
         "code": 2345,
         "tags": []
     }

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-invalid/expectedv2.json
@@ -28,7 +28,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n  Type 'DoesntWork' is missing the following properties from type 'ATypedSvelteComponent': $$prop_def, $$events_def, $$slot_def, $on\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
         "code": 2345,
         "tags": []
     },
@@ -39,7 +39,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n  Type 'DoesntWork' is missing the following properties from type 'ATypedSvelteComponent': $$prop_def, $$events_def, $$slot_def, $on\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
         "code": 2345,
         "tags": []
     },
@@ -50,7 +50,7 @@
         },
         "severity": 1,
         "source": "ts",
-        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
+        "message": "Argument of type 'typeof DoesntWork' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.\n  Type 'DoesntWork' is missing the following properties from type 'ATypedSvelteComponent': $$prop_def, $$events_def, $$slot_def, $on\n\nPossible causes:\n- You use the instance type of a component where you should use the constructor type\n- Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition:\n  import type { SvelteComponentTyped } from \"svelte\";\n  class ComponentName extends SvelteComponentTyped<{propertyName: string;}> {}",
         "code": 2345,
         "tags": []
     }

--- a/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/component-handler/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/component-handler/expectedv2.json
@@ -12,8 +12,8 @@
                 "value": "MouseEvent",
                 "location": {
                     "range": {
-                        "start": { "line": 15860, "character": 10 },
-                        "end": { "line": 15860, "character": 20 }
+                        "start": { "line": 15340, "character": 10 },
+                        "end": { "line": 15340, "character": 20 }
                     },
                     "uri": "<node_modules>/typescript/lib/lib.dom.d.ts"
                 }

--- a/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/element-handler/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/element-handler/expectedv2.json
@@ -6,8 +6,8 @@
                 "value": "MouseEvent",
                 "location": {
                     "range": {
-                        "start": { "line": 15860, "character": 10 },
-                        "end": { "line": 15860, "character": 20 }
+                        "start": { "line": 15340, "character": 10 },
+                        "end": { "line": 15340, "character": 20 }
                     },
                     "uri": "<node_modules>/typescript/lib/lib.dom.d.ts"
                 }
@@ -21,8 +21,8 @@
                 "value": "EventTarget",
                 "location": {
                     "range": {
-                        "start": { "line": 8318, "character": 10 },
-                        "end": { "line": 8318, "character": 21 }
+                        "start": { "line": 8284, "character": 10 },
+                        "end": { "line": 8284, "character": 21 }
                     },
                     "uri": "<node_modules>/typescript/lib/lib.dom.d.ts"
                 }
@@ -32,8 +32,8 @@
                 "value": "HTMLButtonElement",
                 "location": {
                     "range": {
-                        "start": { "line": 9810, "character": 10 },
-                        "end": { "line": 9810, "character": 27 }
+                        "start": { "line": 9721, "character": 10 },
+                        "end": { "line": 9721, "character": 27 }
                     },
                     "uri": "<node_modules>/typescript/lib/lib.dom.d.ts"
                 }

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -54,7 +54,7 @@
         "rollup-plugin-copy": "^3.4.0",
         "svelte": "^4.2.19",
         "svelte-language-server": "workspace:*",
-        "typescript": "^5.5.2",
+        "typescript": "^5.6.3",
         "vscode-languageserver": "8.0.2",
         "vscode-languageserver-protocol": "3.17.2",
         "vscode-languageserver-types": "3.17.2",

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -726,7 +726,7 @@
         "@types/vscode": "^1.67",
         "js-yaml": "^3.14.0",
         "tslib": "^2.4.0",
-        "typescript": "^5.5.2",
+        "typescript": "^5.6.3",
         "vscode-tmgrammar-test": "^0.0.11"
     },
     "dependencies": {

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -40,7 +40,7 @@
         "svelte": "~4.2.19",
         "tiny-glob": "^0.2.6",
         "tslib": "^2.4.0",
-        "typescript": "^5.5.2"
+        "typescript": "^5.6.3"
     },
     "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -24,7 +24,7 @@
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^18.0.0",
-        "typescript": "^5.5.2",
+        "typescript": "^5.6.3",
         "svelte": "^4.2.19"
     },
     "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.2
+        specifier: ^5.6.3
+        version: 5.6.3
     devDependencies:
       cross-env:
         specifier: ^7.0.2
@@ -20,7 +20,7 @@ importers:
         version: 3.3.3
       ts-node:
         specifier: ^10.0.0
-        version: 10.9.1(@types/node@18.19.46)(typescript@5.5.2)
+        version: 10.9.1(@types/node@18.19.46)(typescript@5.6.3)
 
   packages/language-server:
     dependencies:
@@ -56,10 +56,10 @@ importers:
         version: link:../svelte2tsx
       typescript:
         specifier: ^5.5.2
-        version: 5.5.2
+        version: 5.6.3
       typescript-auto-import-cache:
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.3.4
+        version: 0.3.4
       vscode-css-languageservice:
         specifier: ~6.3.0
         version: 6.3.0
@@ -105,7 +105,7 @@ importers:
         version: 11.1.2
       ts-node:
         specifier: ^10.0.0
-        version: 10.9.1(@types/node@18.19.46)(typescript@5.5.2)
+        version: 10.9.1(@types/node@18.19.46)(typescript@5.6.3)
 
   packages/svelte-check:
     dependencies:
@@ -139,7 +139,7 @@ importers:
         version: 5.0.2(rollup@3.7.5)
       '@rollup/plugin-typescript':
         specifier: ^10.0.0
-        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.5.2)
+        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.6.3)
       '@types/sade':
         specifier: ^1.7.2
         version: 1.7.4
@@ -162,8 +162,8 @@ importers:
         specifier: workspace:*
         version: link:../language-server
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.2
+        specifier: ^5.6.3
+        version: 5.6.3
       vscode-languageserver:
         specifier: 8.0.2
         version: 8.0.2
@@ -211,8 +211,8 @@ importers:
         specifier: ^2.4.0
         version: 2.5.2
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.2
+        specifier: ^5.6.3
+        version: 5.6.3
       vscode-tmgrammar-test:
         specifier: ^0.0.11
         version: 0.0.11
@@ -243,7 +243,7 @@ importers:
         version: 15.0.2(rollup@3.7.5)
       '@rollup/plugin-typescript':
         specifier: ^10.0.0
-        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.5.2)
+        version: 10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.6.3)
       '@types/estree':
         specifier: ^0.0.42
         version: 0.0.42
@@ -293,8 +293,8 @@ importers:
         specifier: ^2.4.0
         version: 2.5.2
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.2
+        specifier: ^5.6.3
+        version: 5.6.3
 
   packages/typescript-plugin:
     dependencies:
@@ -312,8 +312,8 @@ importers:
         specifier: ^4.2.19
         version: 4.2.19
       typescript:
-        specifier: ^5.5.2
-        version: 5.5.2
+        specifier: ^5.6.3
+        version: 5.6.3
 
 packages:
 
@@ -1269,11 +1269,11 @@ packages:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
 
-  typescript-auto-import-cache@0.3.3:
-    resolution: {integrity: sha512-ojEC7+Ci1ij9eE6hp8Jl9VUNnsEKzztktP5gtYNRMrTmfXVwA1PITYYAkpxCvvupdSYa/Re51B6KMcv1CTZEUA==}
+  typescript-auto-import-cache@0.3.4:
+    resolution: {integrity: sha512-ztlGq1CB0TX9wKv3DJPRBiT5GJf0Gio1bRzcXElEZMjW1VlyZifiZqk6No3OS1XwNBx+n74dSbH2Bjy+5fN5Xw==}
 
-  typescript@5.5.2:
-    resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1487,11 +1487,11 @@ snapshots:
     optionalDependencies:
       rollup: 3.7.5
 
-  '@rollup/plugin-typescript@10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.5.2)':
+  '@rollup/plugin-typescript@10.0.1(rollup@3.7.5)(tslib@2.5.2)(typescript@5.6.3)':
     dependencies:
       '@rollup/pluginutils': 5.0.2(rollup@3.7.5)
       resolve: 1.22.2
-      typescript: 5.5.2
+      typescript: 5.6.3
     optionalDependencies:
       rollup: 3.7.5
       tslib: 2.5.2
@@ -2318,7 +2318,7 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-node@10.9.1(@types/node@18.19.46)(typescript@5.5.2):
+  ts-node@10.9.1(@types/node@18.19.46)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -2332,7 +2332,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.5.2
+      typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -2340,11 +2340,11 @@ snapshots:
 
   type-detect@4.0.8: {}
 
-  typescript-auto-import-cache@0.3.3:
+  typescript-auto-import-cache@0.3.4:
     dependencies:
       semver: 7.5.1
 
-  typescript@5.5.2: {}
+  typescript@5.6.3: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
I bumped typescript-auto-import-cache for #2541, but there is no test for it. I am not really sure what the exact condition triggering this is, but the problem is that the caching implementation of typescript-auto-import-cache is out of sync with TypeScript 5.6. TypeScript added another parameter for some functions. 

Mark as a draft for now, I'll add the support for [Exclude Patterns for Auto-Imports](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#exclude-patterns-for-auto-imports) and maybe [Granular Commit Characters](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#exclude-patterns-for-auto-imports) later.