### PR TITLE
fix: add Sveltekit snippet for Svelte 5

### DIFF
--- a/packages/svelte-vscode/src/sveltekit/generateFiles/index.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/index.ts
@@ -3,7 +3,7 @@ import { commands, ExtensionContext, ProgressLocation, Uri, window, workspace } 
 import { addResourceCommandMap } from './commands';
 import { generateResources } from './generate';
 import { resourcesMap } from './resources';
-import { FileType, ResourceType, GenerateConfig, CommandType } from './types';
+import { FileType, ResourceType, GenerateConfig, CommandType, ProjectType } from './types';
 import { checkProjectType } from '../utils';
 
 class GenerateError extends Error {}
@@ -126,12 +126,16 @@ async function getCommonConfig(uri: Uri | undefined) {
     }
 
     const type = await checkProjectType(rootPath);
-    const scriptExtension = type === 'js' ? 'js' : 'ts';
+    const scriptExtension = getScriptExtension(type);
     return {
         type,
         scriptExtension,
         rootPath
     } as const;
+}
+
+function getScriptExtension(type: ProjectType) {
+    return type === ProjectType.JS || type === ProjectType.JS_SV5 ? 'js' : 'ts';
 }
 
 function getRootPath(uri: Uri | undefined) {

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/error.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/error.ts
@@ -1,21 +1,31 @@
-import { GenerateConfig } from '../types';
+import { GenerateConfig, ProjectType, Resource } from '../types';
 
-export default async function (config: GenerateConfig) {
-    const ts = `
-<script lang="ts">
-    import { page } from '$app/stores';
-</script>
-
-<h1>{$page.status}: {$page.error?.message}</h1>
-    `.trim();
-
-    const js = `
+const defaultScriptTemplate = `
 <script>
     import { page } from '$app/stores';
 </script>
 
 <h1>{$page.status}: {$page.error.message}</h1>
-    `.trim();
+`;
 
-    return config.type === 'js' ? js : ts;
+
+const tsScriptTemplate = `
+<script lang="ts">
+    import { page } from '$app/stores';
+</script>
+
+<h1>{$page.status}: {$page.error?.message}</h1>
+`;
+
+const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
+    [ProjectType.TS_SV5, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsScriptTemplate],
+    [ProjectType.JS_SV5, defaultScriptTemplate],
+    [ProjectType.TS, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.JS, defaultScriptTemplate]
+])
+
+export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
+    return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/error.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/error.ts
@@ -8,7 +8,6 @@ const defaultScriptTemplate = `
 <h1>{$page.status}: {$page.error.message}</h1>
 `;
 
-
 const tsScriptTemplate = `
 <script lang="ts">
     import { page } from '$app/stores';
@@ -24,7 +23,7 @@ const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS, tsScriptTemplate],
     [ProjectType.TS_SATISFIES, tsScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
-])
+]);
 
 export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
     return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-load.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-load.ts
@@ -1,28 +1,38 @@
-import { GenerateConfig } from '../types';
+import { GenerateConfig, ProjectType, Resource } from '../types';
 
-export default async function (config: GenerateConfig) {
-    const ts = `
+const defaultScriptTemplate = `
+/** @type {import('./$types').LayoutLoad} */
+export async function load() {
+    return {};
+}
+`;
+
+
+const tsScriptTemplate = `
 import type { LayoutLoad } from './$types';
 
 export const load: LayoutLoad = async () => {
     return {};
 };
-    `.trim();
+`;
 
-    const tsSatisfies = `
+const tsSatisfiesScriptTemplate = `
 import type { LayoutLoad } from './$types';
 
 export const load = (async () => {
     return {};
 }) satisfies LayoutLoad;
-    `.trim();
+`;
 
-    const js = `
-/** @type {import('./$types').LayoutLoad} */
-export async function load() {
-    return {};
-}
-    `.trim();
+const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
+    [ProjectType.TS_SV5, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsSatisfiesScriptTemplate],
+    [ProjectType.JS_SV5, defaultScriptTemplate],
+    [ProjectType.TS, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsSatisfiesScriptTemplate],
+    [ProjectType.JS, defaultScriptTemplate]
+])
 
-    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
+export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
+    return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-load.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-load.ts
@@ -7,7 +7,6 @@ export async function load() {
 }
 `;
 
-
 const tsScriptTemplate = `
 import type { LayoutLoad } from './$types';
 
@@ -31,7 +30,7 @@ const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS, tsScriptTemplate],
     [ProjectType.TS_SATISFIES, tsSatisfiesScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
-])
+]);
 
 export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
     return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-server.ts
@@ -26,10 +26,10 @@ export const load = (async () => {
 
 const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS_SV5, tsScriptTemplate],
-    [ProjectType.TS_SATISFIES_SV5, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsSatisfiesScriptTemplate],
     [ProjectType.JS_SV5, defaultScriptTemplate],
     [ProjectType.TS, tsScriptTemplate],
-    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsSatisfiesScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
 ])
 

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-server.ts
@@ -7,7 +7,6 @@ export async function load() {
 }
 `;
 
-
 const tsScriptTemplate = `
 import type { LayoutServerLoad } from './$types';
 
@@ -31,7 +30,7 @@ const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS, tsScriptTemplate],
     [ProjectType.TS_SATISFIES, tsSatisfiesScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
-])
+]);
 
 export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
     return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout-server.ts
@@ -1,28 +1,38 @@
-import { GenerateConfig } from '../types';
+import { GenerateConfig, ProjectType, Resource } from '../types';
 
-export default async function (config: GenerateConfig) {
-    const ts = `
+const defaultScriptTemplate = `
+/** @type {import('./$types').LayoutServerLoad} */
+export async function load() {
+    return {};
+}
+`;
+
+
+const tsScriptTemplate = `
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async () => {
     return {};
 };
-    `.trim();
+`;
 
-    const tsSatisfies = `
+const tsSatisfiesScriptTemplate = `
 import type { LayoutServerLoad } from './$types';
 
 export const load = (async () => {
     return {};
 }) satisfies LayoutServerLoad;
-    `.trim();
+`;
 
-    const js = `
-/** @type {import('./$types').LayoutServerLoad} */
-export async function load() {
-    return {};
-}
-    `.trim();
+const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
+    [ProjectType.TS_SV5, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsScriptTemplate],
+    [ProjectType.JS_SV5, defaultScriptTemplate],
+    [ProjectType.TS, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.JS, defaultScriptTemplate]
+])
 
-    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
+export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
+    return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
@@ -37,7 +37,7 @@ const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS, tsScriptTemplate],
     [ProjectType.TS_SATISFIES, tsScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
-])
+]);
 
 export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
     return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
@@ -1,20 +1,44 @@
-import { GenerateConfig } from '../types';
+import { GenerateConfig, ProjectType, Resource } from '../types';
 
-export default async function (config: GenerateConfig) {
-    const ts = `
+const defaultScriptTemplate = `
+<script>
+    /** @type {import('./$types').LayoutData} */
+    export let data;
+</script>
+`;
+
+const tsSv5ScriptTemplate = `
+<script lang="ts">
+    import type { LayoutData } from './$types';
+    
+    let data: LayoutData = $props();
+</script>
+`;
+
+const tsScriptTemplate = `
 <script lang="ts">
     import type { LayoutData } from './$types';
     
     export let data: LayoutData;
 </script>
-    `.trim();
+`;
 
-    const js = `
+const jsSv5ScriptTemplate = `
 <script>
     /** @type {import('./$types').LayoutData} */
-    export let data;
+    let data = $props();
 </script>
-    `.trim();
+`;
 
-    return config.type === 'js' ? js : ts;
+const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
+    [ProjectType.TS_SV5, tsSv5ScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsSv5ScriptTemplate],
+    [ProjectType.JS_SV5, jsSv5ScriptTemplate],
+    [ProjectType.TS, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.JS, defaultScriptTemplate]
+])
+
+export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
+    return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
@@ -11,7 +11,7 @@ const tsSv5ScriptTemplate = `
 <script lang="ts">
     import type { LayoutData } from './$types';
     
-    let data: LayoutData = $props();
+    let { data }: LayoutData = $props();
 </script>
 `;
 
@@ -26,7 +26,7 @@ const tsScriptTemplate = `
 const jsSv5ScriptTemplate = `
 <script>
     /** @type {import('./$types').LayoutData} */
-    let data = $props();
+    let { data } = $props();
 </script>
 `;
 

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-load.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-load.ts
@@ -26,10 +26,10 @@ export const load = (async () => {
 
 const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS_SV5, tsScriptTemplate],
-    [ProjectType.TS_SATISFIES_SV5, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsSatisfiesScriptTemplate],
     [ProjectType.JS_SV5, defaultScriptTemplate],
     [ProjectType.TS, tsScriptTemplate],
-    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsSatisfiesScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
 ])
 

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-load.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-load.ts
@@ -7,7 +7,6 @@ export async function load() {
 };
 `;
 
-
 const tsScriptTemplate = `
 import type { PageLoad } from './$types';
 
@@ -31,7 +30,7 @@ const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS, tsScriptTemplate],
     [ProjectType.TS_SATISFIES, tsSatisfiesScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
-])
+]);
 
 export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
     return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-load.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-load.ts
@@ -1,28 +1,38 @@
-import { GenerateConfig } from '../types';
+import { GenerateConfig, ProjectType, Resource } from '../types';
 
-export default async function (config: GenerateConfig) {
-    const ts = `
+const defaultScriptTemplate = `
+/** @type {import('./$types').PageLoad} */
+export async function load() {
+    return {};
+};
+`;
+
+
+const tsScriptTemplate = `
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
     return {};
 };
-    `.trim();
+`;
 
-    const tsSatisfies = `
+const tsSatisfiesScriptTemplate = `
 import type { PageLoad } from './$types';
 
 export const load = (async () => {
     return {};
 }) satisfies PageLoad;
-    `.trim();
+`;
 
-    const js = `
-/** @type {import('./$types').PageLoad} */
-export async function load() {
-    return {};
-};
-    `.trim();
+const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
+    [ProjectType.TS_SV5, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsScriptTemplate],
+    [ProjectType.JS_SV5, defaultScriptTemplate],
+    [ProjectType.TS, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.JS, defaultScriptTemplate]
+])
 
-    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
+export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
+    return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-server.ts
@@ -7,7 +7,6 @@ export async function load() {
 };
 `;
 
-
 const tsScriptTemplate = `
 import type { PageServerLoad } from './$types';
 
@@ -31,7 +30,7 @@ const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS, tsScriptTemplate],
     [ProjectType.TS_SATISFIES, tsSatisfiesScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
-])
+]);
 
 export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
     return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-server.ts
@@ -26,10 +26,10 @@ export const load = (async () => {
 
 const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS_SV5, tsScriptTemplate],
-    [ProjectType.TS_SATISFIES_SV5, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsSatisfiesScriptTemplate],
     [ProjectType.JS_SV5, defaultScriptTemplate],
     [ProjectType.TS, tsScriptTemplate],
-    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsSatisfiesScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
 ])
 

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page-server.ts
@@ -1,28 +1,38 @@
-import { GenerateConfig } from '../types';
+import { GenerateConfig, ProjectType, Resource } from '../types';
 
-export default async function (config: GenerateConfig) {
-    const ts = `
+const defaultScriptTemplate = `
+/** @type {import('./$types').PageServerLoad} */
+export async function load() {
+    return {};
+};
+`;
+
+
+const tsScriptTemplate = `
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
     return {};
 };
-    `.trim();
+`;
 
-    const tsSatisfies = `
+const tsSatisfiesScriptTemplate = `
 import type { PageServerLoad } from './$types';
 
 export const load = (async () => {
     return {};
 }) satisfies PageServerLoad;
-    `.trim();
+`;
 
-    const js = `
-/** @type {import('./$types').PageServerLoad} */
-export async function load() {
-    return {};
-};
-    `.trim();
+const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
+    [ProjectType.TS_SV5, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsScriptTemplate],
+    [ProjectType.JS_SV5, defaultScriptTemplate],
+    [ProjectType.TS, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.JS, defaultScriptTemplate]
+])
 
-    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
+export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
+    return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
@@ -37,7 +37,7 @@ const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS, tsScriptTemplate],
     [ProjectType.TS_SATISFIES, tsScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
-])
+]);
 
 export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
     return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
@@ -11,7 +11,7 @@ const tsSv5ScriptTemplate = `
 <script lang="ts">
     import type { PageData } from './$types';
     
-    let data: PageData = $props();
+    let { data }: PageData = $props();
 </script>
 `;
 
@@ -26,7 +26,7 @@ const tsScriptTemplate = `
 const jsSv5ScriptTemplate = `
 <script>
     /** @type {import('./$types').PageData} */
-    let data = $props();
+    let { data } = $props();
 </script>
 `;
 

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
@@ -1,20 +1,44 @@
-import { GenerateConfig } from '../types';
+import { GenerateConfig, ProjectType, Resource } from '../types';
 
-export default async function (config: GenerateConfig) {
-    const ts = `
+const defaultScriptTemplate = `
+<script>
+    /** @type {import('./$types').PageData} */
+    export let data;
+</script>
+`;
+
+const tsSv5ScriptTemplate = `
+<script lang="ts">
+    import type { PageData } from './$types';
+    
+    let data: PageData = $props();
+</script>
+`;
+
+const tsScriptTemplate = `
 <script lang="ts">
     import type { PageData } from './$types';
     
     export let data: PageData;
 </script>
-    `.trim();
+`;
 
-    const js = `
+const jsSv5ScriptTemplate = `
 <script>
     /** @type {import('./$types').PageData} */
-    export let data;
+    let data = $props();
 </script>
-    `.trim();
+`;
 
-    return config.type === 'js' ? js : ts;
+const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
+    [ProjectType.TS_SV5, tsSv5ScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsSv5ScriptTemplate],
+    [ProjectType.JS_SV5, jsSv5ScriptTemplate],
+    [ProjectType.TS, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.JS, defaultScriptTemplate]
+])
+
+export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
+    return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/server.ts
@@ -7,7 +7,6 @@ export async function GET() {
 };
 `;
 
-
 const tsScriptTemplate = `
 import type { RequestHandler } from './$types';
 
@@ -23,7 +22,7 @@ const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
     [ProjectType.TS, tsScriptTemplate],
     [ProjectType.TS_SATISFIES, tsScriptTemplate],
     [ProjectType.JS, defaultScriptTemplate]
-])
+]);
 
 export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
     return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/server.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/server.ts
@@ -1,20 +1,30 @@
-import { GenerateConfig } from '../types';
+import { GenerateConfig, ProjectType, Resource } from '../types';
 
-export default async function generate(config: GenerateConfig) {
-    const ts = `
+const defaultScriptTemplate = `
+/** @type {import('./$types').RequestHandler} */
+export async function GET() {
+    return new Response();
+};
+`;
+
+
+const tsScriptTemplate = `
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async () => {
     return new Response();
 };
-    `.trim();
+`;
 
-    const js = `
-/** @type {import('./$types').RequestHandler} */
-export async function GET() {
-    return new Response();
-};
-    `.trim();
+const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([
+    [ProjectType.TS_SV5, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES_SV5, tsScriptTemplate],
+    [ProjectType.JS_SV5, defaultScriptTemplate],
+    [ProjectType.TS, tsScriptTemplate],
+    [ProjectType.TS_SATISFIES, tsScriptTemplate],
+    [ProjectType.JS, defaultScriptTemplate]
+])
 
-    return config.type === 'js' ? js : ts;
+export default async function (config: GenerateConfig): ReturnType<Resource['generate']> {
+    return (scriptTemplate.get(config.type) ?? defaultScriptTemplate).trim();
 }

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/types.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/types.ts
@@ -38,15 +38,15 @@ export enum ProjectType {
     TS_SATISFIES_SV5 = 'ts-satisfies-sv5',
     TS = 'ts',
     JS = 'js',
-    TS_SATISFIES = 'ts-satisfies',
+    TS_SATISFIES = 'ts-satisfies'
 }
 
-export type IsSvelte5Plus = boolean
+export type IsSvelte5Plus = boolean;
 
 export const IsSvelte5Plus: Record<string, IsSvelte5Plus> = {
     yes: true,
     no: false
-}
+};
 
 export interface GenerateConfig {
     path: string;

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/types.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/types.ts
@@ -32,9 +32,25 @@ export type Resource = {
     generate: (config: GenerateConfig) => Promise<string>;
 };
 
+export enum ProjectType {
+    TS_SV5 = 'ts-sv5',
+    JS_SV5 = 'js-sv5',
+    TS_SATISFIES_SV5 = 'ts-satisfies-sv5',
+    TS = 'ts',
+    JS = 'js',
+    TS_SATISFIES = 'ts-satisfies',
+}
+
+export type IsSvelte5Plus = boolean
+
+export const IsSvelte5Plus: Record<string, IsSvelte5Plus> = {
+    yes: true,
+    no: false
+}
+
 export interface GenerateConfig {
     path: string;
-    type: 'js' | 'ts' | 'ts-satisfies';
+    type: ProjectType;
     pageExtension: string;
     scriptExtension: string;
     resources: Resource[];

--- a/packages/svelte-vscode/src/sveltekit/utils.ts
+++ b/packages/svelte-vscode/src/sveltekit/utils.ts
@@ -1,7 +1,7 @@
 import { TextDecoder } from 'util';
 import * as path from 'path';
 import { Uri, workspace } from 'vscode';
-import { IsSvelte5Plus, ProjectType } from './generateFiles/types'
+import { IsSvelte5Plus, ProjectType } from './generateFiles/types';
 
 export async function fileExists(file: string) {
     try {

--- a/packages/svelte-vscode/src/sveltekit/utils.ts
+++ b/packages/svelte-vscode/src/sveltekit/utils.ts
@@ -1,3 +1,4 @@
+import { TextDecoder } from 'util';
 import * as path from 'path';
 import { Uri, workspace } from 'vscode';
 import { IsSvelte5Plus, ProjectType } from './generateFiles/types'
@@ -57,12 +58,11 @@ export function isSvelte5Plus(version: string | undefined): IsSvelte5Plus {
     return version.split('.')[0] >= '5';
 }
 
-export async function getSvelteVersionFromPackageJson(): Promise<string> {
+export async function getSvelteVersionFromPackageJson(): Promise<string | undefined> {
     const packageJsonList = await workspace.findFiles('**/package.json', '**/node_modules/**');
 
     if (packageJsonList.length === 0) {
-        // We assume that the user has not setup their project yet
-        throw new Error('No package.json found');
+        return undefined;
     }
 
     for (const fileUri of packageJsonList) {
@@ -79,5 +79,5 @@ export async function getSvelteVersionFromPackageJson(): Promise<string> {
         }
     }
 
-    throw new Error('No svelte version found');
+    return undefined;
 }


### PR DESCRIPTION
When using SvelteKit with Svelte 5, the SvelteKit snippets still generate snippets with Svelte 4 syntax.

I fixed this by detecting the current Svelte version and generating Svelte 4 or Svelte 5 snippets according to it.

It follows a discussion from `Ypsilon` on the Svelte discord:

> I know there is a massive list of things to do probably , but wouldn't it be nice to have a use svelte 5 syntax option in the vscode extension. So when you use snippets, or feature like create route that it creates the files with the new runes syntax. And not the old export let data syntax ?