### PR TITLE
fix: properly highlight svelte 5 <component.dot.notation />

### DIFF
--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
@@ -224,7 +224,7 @@ repository:
          { match: if|else\s+if|else, name: keyword.control.conditional.svelte },
          { match: each|key,          name: keyword.control.svelte             },
          { match: await|then|catch,  name: keyword.control.flow.svelte        },
-         { match: snippet,           name: keyword.control.svelte        },
+         { match: snippet,           name: keyword.control.svelte             },
          { match: html,              name: keyword.other.svelte               },
          { match: render,            name: keyword.other.svelte               },
          { match: debug,             name: keyword.other.debugger.svelte      },
@@ -518,11 +518,13 @@ repository:
     # Slot.
     - { match: 'slot', name: keyword.control.svelte }
     # Components (either Namespaced.Component, namespaced.component or PascalCase).
-    - match: '([A-Z][\w]+)|(?<=\.)([\w]+)(?<!\.)|(?!\.)([\w]+)(?=\.)'
+    - match: '([\w]+(?:\.[\w]+)+)|([A-Z][\w]+)'
       captures:
-        1: { name: support.class.component.svelte }
+        1: { patterns: [
+           { match: '\w+', name: support.class.component.svelte },
+           { match: '\.', name: punctuation.definition.keyword.svelte },
+         ]}
         2: { name: support.class.component.svelte }
-        3: { name: support.class.component.svelte }
     # Custom elements. (has a dash, but otherwise is a valid HTML element)
     - { match: '[a-z][\w0-9:]*-[\w0-9:-]*', name: meta.tag.custom.svelte entity.name.tag.svelte }
     # HTML elements.

--- a/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+++ b/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
@@ -509,16 +509,20 @@ repository:
   # Scopes the `name` part in `<name>`.
   tags-name:
     patterns:
-    # Svelte (`svelte:<type>`) elements.
-    - match: '(svelte)(:)([a-z][\w0-9:-]*)'
+    # Svelte built-in elements (e.g., svelte:self, svelte:component).
+    - match: '(svelte)(:)([a-z][\w:-]*)'
       captures:
         1: { name: keyword.control.svelte }
         2: { name: punctuation.definition.keyword.svelte }
         3: { name: entity.name.tag.svelte }
     # Slot.
     - { match: 'slot', name: keyword.control.svelte }
-    # Components.
-    - { match: '[A-Z][a-zA-Z0-9_]*', name: support.class.component.svelte }
+    # Components (either Namespaced.Component, namespaced.component or PascalCase).
+    - match: '([A-Z][\w]+)|(?<=\.)([\w]+)(?<!\.)|(?!\.)([\w]+)(?=\.)'
+      captures:
+        1: { name: support.class.component.svelte }
+        2: { name: support.class.component.svelte }
+        3: { name: support.class.component.svelte }
     # Custom elements. (has a dash, but otherwise is a valid HTML element)
     - { match: '[a-z][\w0-9:]*-[\w0-9:-]*', name: meta.tag.custom.svelte entity.name.tag.svelte }
     # HTML elements.

--- a/packages/svelte-vscode/test/grammar/samples/namespaced-component/input.svelte
+++ b/packages/svelte-vscode/test/grammar/samples/namespaced-component/input.svelte
@@ -1,1 +1,6 @@
 <Hi.Input></Hi.Input>
+<Hello.World.Input></Hello.World.Input>
+<Hello._World123.Input></Hello._World123.Input>
+<hi.input></hi.input>
+<hello.world.input></hello.world.input>
+<hello._world123.input></hello._world123.input>

--- a/packages/svelte-vscode/test/grammar/samples/namespaced-component/input.svelte.snap
+++ b/packages/svelte-vscode/test/grammar/samples/namespaced-component/input.svelte.snap
@@ -9,3 +9,74 @@
 #              ^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.end.svelte
 #               ^^^^^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.end.svelte support.class.component.svelte
 #                    ^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
+><Hello.World.Input></Hello.World.Input>
+#^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
+# ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte support.class.component.svelte
+#      ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte
+#       ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte support.class.component.svelte
+#            ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte
+#             ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte support.class.component.svelte
+#                  ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
+#                   ^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
+#                     ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte support.class.component.svelte
+#                          ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte
+#                           ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte support.class.component.svelte
+#                                ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte
+#                                 ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte support.class.component.svelte
+#                                      ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
+><Hello._World123.Input></Hello._World123.Input>
+#^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
+# ^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte support.class.component.svelte
+#      ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte
+#       ^^^^^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte support.class.component.svelte
+#                ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte
+#                 ^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte support.class.component.svelte
+#                      ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
+#                       ^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
+#                         ^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte support.class.component.svelte
+#                              ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte
+#                               ^^^^^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte support.class.component.svelte
+#                                        ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte
+#                                         ^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte support.class.component.svelte
+#                                              ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
+><hi.input></hi.input>
+#^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
+# ^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte support.class.component.svelte
+#   ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte
+#    ^^^^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte support.class.component.svelte
+#         ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
+#          ^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
+#            ^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte support.class.component.svelte
+#              ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte
+#               ^^^^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte support.class.component.svelte
+#                    ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
+><hello.world.input></hello.world.input>
+#^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
+# ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte support.class.component.svelte
+#      ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte
+#       ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte support.class.component.svelte
+#            ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte
+#             ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte support.class.component.svelte
+#                  ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
+#                   ^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
+#                     ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte support.class.component.svelte
+#                          ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte
+#                           ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte support.class.component.svelte
+#                                ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte
+#                                 ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte support.class.component.svelte
+#                                      ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
+><hello._world123.input></hello._world123.input>
+#^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
+# ^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte support.class.component.svelte
+#      ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte
+#       ^^^^^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte support.class.component.svelte
+#                ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte
+#                 ^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte support.class.component.svelte
+#                      ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
+#                       ^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
+#                         ^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte support.class.component.svelte
+#                              ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte
+#                               ^^^^^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte support.class.component.svelte
+#                                        ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte
+#                                         ^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte support.class.component.svelte
+#                                              ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte

--- a/packages/svelte-vscode/test/grammar/samples/namespaced-component/input.svelte.snap
+++ b/packages/svelte-vscode/test/grammar/samples/namespaced-component/input.svelte.snap
@@ -1,82 +1,82 @@
 ><Hi.Input></Hi.Input>
 #^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
 # ^^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.start.svelte support.class.component.svelte
-#   ^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.start.svelte
+#   ^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #    ^^^^^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.start.svelte support.class.component.svelte
 #         ^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
 #          ^^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
 #            ^^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.end.svelte support.class.component.svelte
-#              ^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.end.svelte
+#              ^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #               ^^^^^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.end.svelte support.class.component.svelte
 #                    ^ source.svelte meta.scope.tag.Hi.Input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
 ><Hello.World.Input></Hello.World.Input>
 #^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
 # ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte support.class.component.svelte
-#      ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte
+#      ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #       ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte support.class.component.svelte
-#            ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte
+#            ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #             ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte support.class.component.svelte
 #                  ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
 #                   ^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
 #                     ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte support.class.component.svelte
-#                          ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte
+#                          ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #                           ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte support.class.component.svelte
-#                                ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte
+#                                ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #                                 ^^^^^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte support.class.component.svelte
 #                                      ^ source.svelte meta.scope.tag.Hello.World.Input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
 ><Hello._World123.Input></Hello._World123.Input>
 #^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
 # ^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte support.class.component.svelte
-#      ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte
+#      ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #       ^^^^^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte support.class.component.svelte
-#                ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte
+#                ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #                 ^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte support.class.component.svelte
 #                      ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
 #                       ^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
 #                         ^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte support.class.component.svelte
-#                              ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte
+#                              ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #                               ^^^^^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte support.class.component.svelte
-#                                        ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte
+#                                        ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #                                         ^^^^^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte support.class.component.svelte
 #                                              ^ source.svelte meta.scope.tag.Hello._World123.Input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
 ><hi.input></hi.input>
 #^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
 # ^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte support.class.component.svelte
-#   ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte
+#   ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #    ^^^^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte support.class.component.svelte
 #         ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
 #          ^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
 #            ^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte support.class.component.svelte
-#              ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte
+#              ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #               ^^^^^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte support.class.component.svelte
 #                    ^ source.svelte meta.scope.tag.hi.input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
 ><hello.world.input></hello.world.input>
 #^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
 # ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte support.class.component.svelte
-#      ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte
+#      ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #       ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte support.class.component.svelte
-#            ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte
+#            ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #             ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte support.class.component.svelte
 #                  ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
 #                   ^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
 #                     ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte support.class.component.svelte
-#                          ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte
+#                          ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #                           ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte support.class.component.svelte
-#                                ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte
+#                                ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #                                 ^^^^^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte support.class.component.svelte
 #                                      ^ source.svelte meta.scope.tag.hello.world.input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte
 ><hello._world123.input></hello._world123.input>
 #^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte punctuation.definition.tag.begin.svelte
 # ^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte support.class.component.svelte
-#      ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte
+#      ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #       ^^^^^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte support.class.component.svelte
-#                ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte
+#                ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte punctuation.definition.keyword.svelte
 #                 ^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte support.class.component.svelte
 #                      ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.start.svelte punctuation.definition.tag.end.svelte
 #                       ^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte punctuation.definition.tag.begin.svelte
 #                         ^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte support.class.component.svelte
-#                              ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte
+#                              ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #                               ^^^^^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte support.class.component.svelte
-#                                        ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte
+#                                        ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte punctuation.definition.keyword.svelte
 #                                         ^^^^^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte support.class.component.svelte
 #                                              ^ source.svelte meta.scope.tag.hello._world123.input.svelte meta.tag.end.svelte punctuation.definition.tag.end.svelte


### PR DESCRIPTION
Hi, there,

Regarding this [issue](https://github.com/sveltejs/language-tools/issues/2525), I made this Pull Request to correct the lack of support for component names with dots notation in VSCode Svelte syntax.

(as the [Svelte 5 doc](https://svelte.dev/docs/svelte/basic-markup#Tags) says, `A capitalized tag or a tag that uses dot notation, such as <Widget> or <my.stuff>, indicates a component.`).

Any ideas to make the [regex](https://regex101.com/r/ofiCit/1) simpler are welcome.

before:

<img width="474" alt="Capture d’écran 2024-10-31 à 07 22 30" src="https://github.com/user-attachments/assets/4d3a4e98-0942-4a31-b3f3-e790994c9e67">

after:

<img width="418" alt="Capture d’écran 2024-10-31 à 17 47 08" src="https://github.com/user-attachments/assets/4c698c9c-26f7-4b72-befd-cc69c84d7b48">


