### PR TITLE
feat: add runes mode indicator

### DIFF
--- a/packages/language-server/src/plugins/svelte/SvelteDocument.ts
+++ b/packages/language-server/src/plugins/svelte/SvelteDocument.ts
@@ -48,6 +48,9 @@ export class SvelteDocument {
     public get config() {
         return this.parent.configPromise;
     }
+    public get isSvelte5() {
+        return this.getSvelteVersion()[0] > 4;
+    }
 
     constructor(private parent: Document) {
         this.script = this.parent.scriptInfo;
@@ -70,11 +73,7 @@ export class SvelteDocument {
 
     async getTranspiled(): Promise<ITranspiledSvelteDocument> {
         if (!this.transpiledDoc) {
-            if (!this.svelteVersion) {
-                const { major, minor } = getPackageInfo('svelte', this.getFilePath()).version;
-                this.svelteVersion = [major, minor];
-            }
-            const [major, minor] = this.svelteVersion;
+            const [major, minor] = this.getSvelteVersion();
 
             if (major > 3 || (major === 3 && minor >= 32)) {
                 this.transpiledDoc = await TranspiledSvelteDocument.create(
@@ -102,6 +101,14 @@ export class SvelteDocument {
     async getCompiledWith(options: CompileOptions = {}): Promise<SvelteCompileResult> {
         const svelte = importSvelte(this.getFilePath());
         return svelte.compile((await this.getTranspiled()).getText(), options);
+    }
+
+    private getSvelteVersion() {
+        if (!this.svelteVersion) {
+            const { major, minor } = getPackageInfo('svelte', this.getFilePath()).version;
+            this.svelteVersion = [major, minor];
+        }
+        return this.svelteVersion;
     }
 }
 

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -261,6 +261,8 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
 
     addMigrateToSvelte5Command(getLS, context);
 
+    addOpenLinkCommand(context);
+
     languages.setLanguageConfiguration('svelte', {
         indentationRules: {
             // Matches a valid opening tag that is:
@@ -509,6 +511,14 @@ function addMigrateToSvelte5Command(getLS: () => LanguageClient, context: Extens
                 command: 'migrate_to_svelte_5',
                 arguments: [uri]
             });
+        })
+    );
+}
+
+function addOpenLinkCommand(context: ExtensionContext) {
+    context.subscriptions.push(
+        commands.registerCommand('svelte.openLink', (url: string) => {
+            commands.executeCommand('vscode.open', Uri.parse(url));
         })
     );
 }


### PR DESCRIPTION
adds a runes mode indicator atop of the file via a code lens. Will show "runes mode" if the components is in that mode, "legacy mode" if not, and nothing if it's not Svelte 5

#2418