### PR TITLE
fix(vscode): let `linkedEditing` work when tag name contains `.`

### DIFF
--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -333,7 +333,12 @@ export class HTMLPlugin
             return null;
         }
 
-        return { ranges };
+        // Note that `.` is excluded from the word pattern. This is intentional to support property access in Svelte component tags.
+        return {
+            ranges,
+            wordPattern:
+                '(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\\'\\"\\,\\<\\>\\/\\s]+)'
+        };
     }
 
     getFoldingRanges(document: Document): FoldingRange[] {

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -256,7 +256,9 @@ describe('HTML Plugin', () => {
             ranges: [
                 { start: { line: 0, character: 1 }, end: { line: 0, character: 4 } },
                 { start: { line: 0, character: 7 }, end: { line: 0, character: 10 } }
-            ]
+            ],
+            wordPattern:
+                '(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\\'\\"\\,\\<\\>\\/\\s]+)'
         });
     });
 


### PR DESCRIPTION
fixes #2569

Tested it manually on my machine and it works.