### PR TITLE
fix: data from $props does not need type

### DIFF
--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
@@ -10,22 +10,22 @@ const defaultScriptTemplate = `
 const tsSv5ScriptTemplate = `
 <script lang="ts">
     import type { LayoutData } from './$types';
-    
-    let { data }: LayoutData = $props();
+
+    let { data }: { data: LayoutData } = $props();
 </script>
 `;
 
 const tsScriptTemplate = `
 <script lang="ts">
     import type { LayoutData } from './$types';
-    
+
     export let data: LayoutData;
 </script>
 `;
 
 const jsSv5ScriptTemplate = `
 <script>
-    /** @type {import('./$types').LayoutData} */
+    /** @type {{ data: import('./$types').LayoutData }} */
     let { data } = $props();
 </script>
 `;

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/layout.ts
@@ -5,14 +5,19 @@ const defaultScriptTemplate = `
     /** @type {import('./$types').LayoutData} */
     export let data;
 </script>
+
+<slot />
 `;
 
 const tsSv5ScriptTemplate = `
 <script lang="ts">
+    import type { Snippet } from 'svelte';
     import type { LayoutData } from './$types';
 
-    let { data }: { data: LayoutData } = $props();
+    let { data, children }: { data: LayoutData, children: Snippet } = $props();
 </script>
+
+{@render children()}
 `;
 
 const tsScriptTemplate = `
@@ -21,13 +26,17 @@ const tsScriptTemplate = `
 
     export let data: LayoutData;
 </script>
+
+<slot />
 `;
 
 const jsSv5ScriptTemplate = `
 <script>
-    /** @type {{ data: import('./$types').LayoutData }} */
-    let { data } = $props();
+    /** @type {{ data: import('./$types').LayoutData, children: import('svelte').Snippet }} */
+    let { data, children } = $props();
 </script>
+
+{@render children()}
 `;
 
 const scriptTemplate: ReadonlyMap<ProjectType, string> = new Map([

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
@@ -9,16 +9,14 @@ const defaultScriptTemplate = `
 
 const tsSv5ScriptTemplate = `
 <script lang="ts">
-    import type { PageData } from './$types';
-    
-    let { data }: PageData = $props();
+    let { data } = $props();
 </script>
 `;
 
 const tsScriptTemplate = `
 <script lang="ts">
     import type { PageData } from './$types';
-    
+
     export let data: PageData;
 </script>
 `;

--- a/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
+++ b/packages/svelte-vscode/src/sveltekit/generateFiles/templates/page.ts
@@ -9,7 +9,9 @@ const defaultScriptTemplate = `
 
 const tsSv5ScriptTemplate = `
 <script lang="ts">
-    let { data } = $props();
+    import type { PageData } from './$types';
+
+    let { data }: { data: PageData } = $props();
 </script>
 `;
 
@@ -23,7 +25,7 @@ const tsScriptTemplate = `
 
 const jsSv5ScriptTemplate = `
 <script>
-    /** @type {import('./$types').PageData} */
+    /** @type {{ data: import('./$types').PageData }} */
     let { data } = $props();
 </script>
 `;


### PR DESCRIPTION
The data type is not need because $props() is type with a data attribute. And like it was now was even wrong because props is not of type data its an attribute.