### PR TITLE
fix: detect shadowed variables/types during type hoisting

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/nodes/Generics.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/Generics.ts
@@ -5,8 +5,10 @@ import { surroundWithIgnoreComments } from '../../utils/ignore';
 import { throwError } from '../utils/error';
 
 export class Generics {
+    /** The whole `T extends boolean` */
     private definitions: string[] = [];
     private typeReferences: string[] = [];
+    /** The `T` in `T extends boolean` */
     private references: string[] = [];
     genericsAttr: Node | undefined;
 
@@ -91,6 +93,10 @@ export class Generics {
 
     getTypeReferences() {
         return this.typeReferences;
+    }
+
+    getReferences() {
+        return this.references;
     }
 
     toDefinitionString(addIgnore = false) {

--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -318,7 +318,12 @@ export function processInstanceScriptContent(
         transformInterfacesToTypes(tsAst, str, astOffset, nodesToMove);
     }
 
-    exportedNames.hoistableInterfaces.moveHoistableInterfaces(str, astOffset, script.start);
+    exportedNames.hoistableInterfaces.moveHoistableInterfaces(
+        str,
+        astOffset,
+        script.start,
+        generics.getReferences()
+    );
 
     return {
         exportedNames,

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-3.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-3.v5/expectedv2.ts
@@ -1,0 +1,34 @@
+///<reference types="svelte" />
+;
+    type SomeType<T extends boolean> = T;
+    type T = unknown;
+;;function render<T extends boolean>() {
+;type $$ComponentProps =  { someProp: SomeType<T>; };
+    let { someProp }:/*Ωignore_startΩ*/$$ComponentProps/*Ωignore_endΩ*/ = $props();
+;
+async () => {
+
+};
+return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+class __sveltets_Render<T extends boolean> {
+    props() {
+        return render<T>().props;
+    }
+    events() {
+        return render<T>().events;
+    }
+    slots() {
+        return render<T>().slots;
+    }
+    bindings() { return __sveltets_$$bindings(''); }
+    exports() { return {}; }
+}
+
+interface $$IsomorphicComponent {
+    new <T extends boolean>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<T>['props']>>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<T>['props']>, ReturnType<__sveltets_Render<T>['events']>, ReturnType<__sveltets_Render<T>['slots']>> & { $$bindings?: ReturnType<__sveltets_Render<T>['bindings']> } & ReturnType<__sveltets_Render<T>['exports']>;
+    <T extends boolean>(internal: unknown, props: ReturnType<__sveltets_Render<T>['props']> & {}): ReturnType<__sveltets_Render<T>['exports']>;
+    z_$$bindings?: ReturnType<__sveltets_Render<any>['bindings']>;
+}
+const Input__SvelteComponent_: $$IsomorphicComponent = null as any;
+/*Ωignore_startΩ*/type Input__SvelteComponent_<T extends boolean> = InstanceType<typeof Input__SvelteComponent_<T>>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-3.v5/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-3.v5/input.svelte
@@ -1,0 +1,8 @@
+<script lang="ts" module>
+    type SomeType<T extends boolean> = T;
+    type T = unknown;
+</script>
+
+<script lang="ts" generics="T extends boolean">
+    let { someProp }: { someProp: SomeType<T>; } = $props();
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-4.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-4.v5/expectedv2.ts
@@ -1,0 +1,15 @@
+///<reference types="svelte" />
+;
+    let a = '';
+;;function render() {
+
+    let a = true;;type $$ComponentProps =  { someProp: typeof a };
+    let { someProp }:/*Ωignore_startΩ*/$$ComponentProps/*Ωignore_endΩ*/ = $props();
+;
+async () => {
+
+};
+return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+type Input__SvelteComponent_ = ReturnType<typeof Input__SvelteComponent_>;
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-4.v5/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-4.v5/input.svelte
@@ -1,0 +1,8 @@
+<script lang="ts" module>
+    let a = '';
+</script>
+
+<script lang="ts">
+    let a = true;
+    let { someProp }: { someProp: typeof a } = $props();
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-5.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-5.v5/expectedv2.ts
@@ -1,0 +1,15 @@
+///<reference types="svelte" />
+;
+    type Shadowed = string;
+;;function render() {
+
+    type Shadowed = boolean;;type $$ComponentProps =  { someProp: Shadowed };
+    let { someProp }:/*Ωignore_startΩ*/$$ComponentProps/*Ωignore_endΩ*/ = $props();
+;
+async () => {
+
+};
+return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_fn_component(render());
+type Input__SvelteComponent_ = ReturnType<typeof Input__SvelteComponent_>;
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-5.v5/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-false-5.v5/input.svelte
@@ -1,0 +1,8 @@
+<script lang="ts" module>
+    type Shadowed = string;
+</script>
+
+<script lang="ts">
+    type Shadowed = boolean;
+    let { someProp }: { someProp: Shadowed } = $props();
+</script>


### PR DESCRIPTION
#2589