### PR TITLE
fix: don't move appended content from previous node while hoisting interface

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/nodes/HoistableInterfaces.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/HoistableInterfaces.ts
@@ -333,8 +333,21 @@ export class HoistableInterfaces {
 
         const hoistable = this.determineHoistableInterfaces();
         if (hoistable.has(this.props_interface.name)) {
-            for (const [, node] of hoistable) {
-                str.move(node.pos + astOffset, node.end + astOffset, scriptStart);
+            for (const [name, node] of hoistable) {
+                let pos = node.pos + astOffset;
+
+                // node.pos includes preceeding whitespace, which could mean we accidentally also move stuff appended to a previous node
+                if (name !== '$$ComponentProps') {
+                    if (str.original[pos] === '\r') {
+                        pos++;
+                    }
+                    if (/\s/.test(str.original[pos])) {
+                        pos++;
+                        str.prependRight(pos, '\n');
+                    }
+                }
+
+                str.move(pos, node.end + astOffset, scriptStart);
             }
         }
     }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-1.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-1.v5/expectedv2.ts
@@ -16,6 +16,9 @@
     };function render() {
 
 
+
+
+
     let { a, b }: Props<boolean> = $props();
 ;
 async () => {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-2.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-2.v5/expectedv2.ts
@@ -8,6 +8,7 @@
     };type $$ComponentProps =  { a: Dependency, b: string };;function render() {
 
 
+
     let { a, b }:/*Ωignore_startΩ*/$$ComponentProps/*Ωignore_endΩ*/ = $props();
 ;
 async () => {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-4.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-4.v5/expectedv2.ts
@@ -9,6 +9,8 @@
     };function render() {
 
 
+
+
     let { foo }: Props = $props();
 ;
 async () => {};


### PR DESCRIPTION
#2592