### PR TITLE
fix: ensure imports without semicolon doesn't break intellisense

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CodeActionsProvider.test.ts
@@ -1755,20 +1755,9 @@ describe('CodeActionsProvider', function () {
                                             line: 1
                                         }
                                     }
-                                },
-                                {
-                                    newText: "import { } from './somepng.png';\n",
-                                    range: {
-                                        end: {
-                                            character: 0,
-                                            line: 4
-                                        },
-                                        start: {
-                                            character: 4,
-                                            line: 3
-                                        }
-                                    }
                                 }
+                                // Because the generated code adds a ; after the last import, the
+                                // second import is not appearing in the edits here
                             ],
                             textDocument: {
                                 uri: getUri('organize-imports-leading-comment.svelte'),

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/handleImportDeclaration.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/handleImportDeclaration.ts
@@ -25,9 +25,8 @@ export function handleFirstInstanceImport(
     hasModuleScript: boolean,
     str: MagicString
 ) {
-    const firstImport = tsAst.statements
-        .filter(ts.isImportDeclaration)
-        .sort((a, b) => a.end - b.end)[0];
+    const imports = tsAst.statements.filter(ts.isImportDeclaration).sort((a, b) => a.end - b.end);
+    const firstImport = imports[0];
     if (!firstImport) {
         return;
     }
@@ -42,4 +41,12 @@ export function handleFirstInstanceImport(
             : firstImport.getStart();
 
     str.appendRight(start + astOffset, '\n' + (hasModuleScript ? '\n' : ''));
+
+    // Add a semi-colon to the last import if it doesn't have one, to prevent auto completion
+    // and imports from being added at the wrong position
+    const lastImport = imports[imports.length - 1];
+    const end = lastImport.end + astOffset - 1;
+    if (str.original[end] !== ';') {
+        str.overwrite(end, lastImport.end + astOffset, str.original[end] + ';\n');
+    }
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/imports/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/imports/expectedv2.ts
@@ -2,7 +2,7 @@
 ;
 import { a as b } from "./test.svelte"
 
-import * as c from "b.ts"
+import * as c from "b.ts";
 function render() {
 
     

--- a/packages/svelte2tsx/test/svelte2tsx/samples/jsdoc-before-first-import/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/jsdoc-before-first-import/expectedv2.ts
@@ -2,7 +2,7 @@
 ;// non-leading comment
 /**@typedef {{ a: string }} Foo */
 
-import ''
+import '';
 function render() {
 
     

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-2.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-hoistable-props-2.v5/expectedv2.ts
@@ -5,7 +5,8 @@
     interface Dependency {
         a: number;
         b: typeof value;
-    };;type $$ComponentProps =  { a: Dependency, b: string };function render() {
+    };
+;type $$ComponentProps =  { a: Dependency, b: string };function render() {
 
 
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes.v5/expectedv2.ts
@@ -1,5 +1,6 @@
 ///<reference types="svelte" />
-;;type $$ComponentProps =  { a: number, b: string };function render() {
+;
+;type $$ComponentProps =  { a: number, b: string };function render() {
 
     let { a, b }:/*Ωignore_startΩ*/$$ComponentProps/*Ωignore_endΩ*/ = $props();
     let x = $state(0);

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune-unchanged.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-sveltekit-autotypes-$props-rune-unchanged.v5/expectedv2.ts
@@ -1,5 +1,6 @@
 ///<reference types="svelte" />
-;;type $$ComponentProps =  {form: boolean, data: true };function render() {
+;
+;type $$ComponentProps =  {form: boolean, data: true };function render() {
 
      const snapshot: any = {};
     let { form, data }:/*Ωignore_startΩ*/$$ComponentProps/*Ωignore_endΩ*/ = $props();


### PR DESCRIPTION
...by adding a generated semicolon at the end. That prevents TypeScript from going up until the next semicolon it finds, which may be from another generated code, messing up the generated->original end position

#2608
#2607