### PR TITLE
feat: Allow embedded languages to utilise Svelte Intellisense in VSCode

### DIFF
--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -266,7 +266,7 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
 export class SvelteDocumentSnapshot implements DocumentSnapshot {
     private mapper?: DocumentMapper;
     private lineOffsets?: number[];
-    private url = pathToUrl(this.filePath);
+    private url = this.fileUrl;
 
     version = this.parent.version;
     isSvelte5Plus = Number(this.svelteVersion?.split('.')[0]) >= 5;
@@ -281,7 +281,11 @@ export class SvelteDocumentSnapshot implements DocumentSnapshot {
         private readonly exportedNames: IExportedNames,
         private readonly tsxMap?: EncodedSourceMap,
         private readonly htmlAst?: TemplateNode
-    ) {}
+    ) { }
+
+    get fileUrl() {
+        return this.parent.getURL() || '';
+    }
 
     get filePath() {
         return this.parent.getFilePath() || '';

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -28,13 +28,16 @@ export function clamp(num: number, min: number, max: number): number {
 
 export function urlToPath(stringUrl: string): string | null {
     const url = URI.parse(stringUrl);
-    if (url.scheme !== 'file') {
+    if (url.scheme === 'http' || url.scheme === 'https') {
         return null;
     }
     return url.fsPath.replace(/\\/g, '/');
 }
 
-export function pathToUrl(path: string) {
+export function pathToUrl(path: string, scheme?: string) {
+    const baseUri = URI.file(path);
+    if (scheme)
+        return baseUri.with({ scheme: scheme }).toString();
     return URI.file(path).toString();
 }
 

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -151,7 +151,7 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
     }
 
     const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'svelte' }],
+        documentSelector: [{ scheme: '*', language: 'svelte' }],
         revealOutputChannelOn: RevealOutputChannelOn.Never,
         synchronize: {
             // TODO deprecated, rework upon next VS Code minimum version bump


### PR DESCRIPTION
Hello! This PR modifies the behaviour of the Svelte VSCode extension so that it activates for URIs that don't use the `file://` scheme.
During standard extension usage, this makes no difference, as all Svelte files on disk will use the `file://` scheme in their URI. However, enabling this support allows other extensions to use Svelte as an embedded language and still take full advantage of all of the Svelte extension's Intellisense.

This is handled in VSCode by a mechanism called [Request Forwarding](https://code.visualstudio.com/api/language-extensions/embedded-languages#request-forwarding). In summary, VSCode will preprocess the custom language and create a virtual document that contains just the "Svelte" portion of the document. It can then invoke the Svelte extension on that virtual document.
The problem is that these virtual documents must use a unique URI scheme. As Svelte currently only activates on `file://` scheme URIs, these requests will be dropped.

### Example Use-Cases
- MDsveX syntax support: I've got a [draft extension](https://github.com/BOJIT/vscode-MDsveX) that adds MDsveX syntax support to VSCode.
- Custom languages built around Svelte. I know that [Evidence BI](https://github.com/evidence-dev/evidence/tree/next/packages/extension) maintain an extension that would benefit from Svelte intellisense/language features.

### Potential Problems
Various parts of the extension (document snapshots, Typescript plugin) track the `path` of the file, not the URI. The conversion from path to URI in `language-server/utils.ts` will assume the `file://` URI scheme when mapping between paths and URIs.

I am not familiar enough with the Svelte Language Server inner workings to fully know what the impact of supporting all URI schemes is. I've tested these modifications locally and the extension _seems_ to behave identically to the original extension, but I would appreciate some advice from the maintainers on the impact of this change!

I'm also not sure if there are any URI schemes that should be explicitly disallowed by the extension. For example, `http`/`https` URIs ending in `.svelte` should probably not be recorded in document snapshots, as these might appear in webviews?

### Next Steps
- My suggestion would be to only ever pass references to URIs in the language server, and only convert them into paths where speific APIs require it.
- Some of the Svelte-Kit specific Intellisense still doesn't work in virtual documents. Not sure where this gets tracked in the extension.

I'm hoping that this small change does not break any existing behaviour, as merging it will make any downstream embedded svelte extension's experience much better!