### PR TITLE
fix: don't patch solution project in ts plugin

### DIFF
--- a/packages/typescript-plugin/src/utils.ts
+++ b/packages/typescript-plugin/src/utils.ts
@@ -255,6 +255,14 @@ export function hasNodeModule(startPath: string, module: string) {
 }
 
 export function isSvelteProject(project: ts.server.Project) {
+    // internal api, the way to check requires checking the files config in tsconfig.json
+    // so we can't reimplement it without reading the tsconfig.json again
+    // The solution project is mostly just a container we don't need to patch it
+    // and having any files in this project cause TSServer to send config error while it originally won't
+    if ((project as any).isSolution?.()) {
+        return false;
+    }
+
     const projectDirectory = getProjectDirectory(project);
     if (projectDirectory) {
         return hasNodeModule(projectDirectory, 'svelte');


### PR DESCRIPTION
For the referenced project error part of #2612. The error is only sent out if there is any file triggering update in the project. It doesn't really make it valid but just doesn't interfere with the default behaviour. And the solution project is mostly just a container anyway we don't need to patch it. 

