### PR TITLE
chore: support function for compilerOptions

### DIFF
--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -23,7 +23,9 @@ export type InternalPreprocessorGroup = PreprocessorGroup & {
 };
 
 export interface SvelteConfig {
-    compilerOptions?: CompileOptions;
+    compilerOptions?:
+        | CompileOptions
+        | ((input: { filename: string; code: string }) => CompileOptions);
     preprocess?: InternalPreprocessorGroup | InternalPreprocessorGroup[];
     loadConfigError?: any;
     isFallbackConfig?: boolean;

--- a/packages/language-server/src/plugins/svelte/SvelteDocument.ts
+++ b/packages/language-server/src/plugins/svelte/SvelteDocument.ts
@@ -98,9 +98,15 @@ export class SvelteDocument {
         return this.compileResult;
     }
 
-    async getCompiledWith(options: CompileOptions = {}): Promise<SvelteCompileResult> {
+    async getCompiledWith(options: SvelteConfig['compilerOptions']): Promise<SvelteCompileResult> {
         const svelte = importSvelte(this.getFilePath());
-        return svelte.compile((await this.getTranspiled()).getText(), options);
+        const code = (await this.getTranspiled()).getText();
+        return svelte.compile(
+            code,
+            typeof options === 'function'
+                ? options({ filename: this.getFilePath(), code })
+                : (options ?? {})
+        );
     }
 
     private getSvelteVersion() {


### PR DESCRIPTION
For svelte2tsx we gotta make a compromise - since everything has to be sync, we can only pass the unpreprocessed file. Should be fine in practise because a preprocessor influencing the code in such a way that it in turn influences the compiler options is probably vanishingly rare.

https://github.com/sveltejs/svelte/issues/12415