### PR TITLE
chore: tweak completions

### DIFF
--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -159,6 +159,7 @@ export class HTMLPlugin
                 : null;
 
         const svelteStrictMode = prettierConfig?.svelteStrictMode;
+
         items.forEach((item) => {
             const startQuote = svelteStrictMode ? '"{' : '{';
             const endQuote = svelteStrictMode ? '}"' : '}';
@@ -171,6 +172,10 @@ export class HTMLPlugin
                     ...item.textEdit,
                     newText: item.textEdit.newText.replace('="$1"', `$2=${startQuote}$1${endQuote}`)
                 };
+                // In Svelte 5, people should use `onclick` instead of `on:click`
+                if (document.isSvelte5) {
+                    item.sortText = 'z' + (item.sortText ?? item.label);
+                }
             }
 
             if (item.label.startsWith('bind:')) {
@@ -182,11 +187,7 @@ export class HTMLPlugin
         });
 
         return CompletionList.create(
-            [
-                ...this.toCompletionItems(items),
-                ...this.getLangCompletions(items),
-                ...emmetResults.items
-            ],
+            [...items, ...this.getLangCompletions(items), ...emmetResults.items],
             // Emmet completions change on every keystroke, so they are never complete
             emmetResults.items.length > 0
         );

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -16,7 +16,7 @@ import {
     WorkspaceEdit
 } from 'vscode-languageserver';
 import { Plugin } from 'prettier';
-import { getPackageInfo, importPrettier, importSvelte } from '../../importPackage';
+import { getPackageInfo, importPrettier } from '../../importPackage';
 import { Document } from '../../lib/documents';
 import { Logger } from '../../logger';
 import { LSConfigManager, LSSvelteConfig } from '../../ls-config';
@@ -52,9 +52,9 @@ export class SveltePlugin
 
     async getCodeLens(document: Document): Promise<CodeLens[] | null> {
         if (!this.featureEnabled('runesLegacyModeCodeLens')) return null;
+        if (!document.isSvelte5) return null;
 
         const doc = await this.getSvelteDoc(document);
-        if (!doc.isSvelte5) return null;
 
         try {
             const result = await doc.getCompiled();
@@ -355,7 +355,7 @@ export class SveltePlugin
 
     private migrate(document: Document): WorkspaceEdit | string {
         try {
-            const compiler = importSvelte(document.getFilePath() ?? '') as any;
+            const compiler = document.compiler as any;
             if (!compiler.migrate) {
                 return 'Your installed Svelte version does not support migration';
             }

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -1,4 +1,4 @@
-import { dirname, join, resolve, basename } from 'path';
+import { dirname, basename } from 'path';
 import ts from 'typescript';
 import {
     DiagnosticSeverity,


### PR DESCRIPTION
- In Svelte 5, prefer `onclick` over `on:click` suggestions
- Ignore completions in more Text positions
- Only prefer runes/components in the script tag and in opening tags; should give more accurate completions in the template