### PR TITLE
fix: source of the TypeScript plugin modal is now visible

### DIFF
--- a/packages/svelte-vscode/src/tsplugin.ts
+++ b/packages/svelte-vscode/src/tsplugin.ts
@@ -46,7 +46,7 @@ export class TsPlugin {
             return;
         }
 
-        const answers = ['Ask again later', "Don't show this message again", 'Enable Plugin'];
+        const answers = ['Enable', 'Later', 'Do not show again'];
         const response = await window.showInformationMessage(
             'The Svelte for VS Code extension now contains a TypeScript plugin. ' +
                 'Enabling it will provide intellisense for Svelte files from TS/JS files. ' +
@@ -55,9 +55,9 @@ export class TsPlugin {
             ...answers
         );
 
-        if (response === answers[2]) {
+        if (response === answers[0]) {
             workspace.getConfiguration('svelte').update('enable-ts-plugin', true, true);
-        } else if (response === answers[1]) {
+        } else if (response === answers[2]) {
             workspace.getConfiguration('svelte').update('ask-to-enable-ts-plugin', false, true);
         }
     }


### PR DESCRIPTION
Fixes #2646

- Source is completely visible
- "Enable" button is now the first and highlighted (Happy path)
- "Do not show again" according to "✔️ Do" in [VSCode UX Guidelines](https://code.visualstudio.com/api/ux-guidelines/notifications#notification-examples)

<img width="473" alt="2" src="https://github.com/user-attachments/assets/87c47704-c70a-46b7-801c-034ff25fa047" />