### PR TITLE
fix: disambiguate `render` in module script

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
@@ -25,6 +25,7 @@ export interface AddComponentExportPara {
     usesSlots: boolean;
     isSvelte5: boolean;
     noSvelteComponentTyped?: boolean;
+    renderName: string;
 }
 
 /**
@@ -54,7 +55,8 @@ function addGenericsComponentExport({
     generics,
     usesSlots,
     isSvelte5,
-    noSvelteComponentTyped
+    noSvelteComponentTyped,
+    renderName
 }: AddComponentExportPara) {
     const genericsDef = generics.toDefinitionString();
     const genericsRef = generics.toReferencesString();
@@ -71,13 +73,13 @@ function addGenericsComponentExport({
     let statement = `
 class __sveltets_Render${genericsDef} {
     props() {
-        return ${props(true, canHaveAnyProp, exportedNames, `render${genericsRef}()`)}.props;
+        return ${props(true, canHaveAnyProp, exportedNames, `${renderName}${genericsRef}()`)}.props;
     }
     events() {
-        return ${_events(events.hasStrictEvents() || exportedNames.usesRunes(), `render${genericsRef}()`)}.events;
+        return ${_events(events.hasStrictEvents() || exportedNames.usesRunes(), `${renderName}${genericsRef}()`)}.events;
     }
     slots() {
-        return render${genericsRef}().slots;
+        return ${renderName}${genericsRef}().slots;
     }
 `;
 
@@ -85,15 +87,15 @@ class __sveltets_Render${genericsDef} {
     if (isSvelte5 && !isTsFile && exportedNames.usesRunes()) {
         statement = `
 class __sveltets_Render${genericsDef} {
-    props(): ReturnType<typeof render${genericsRef}>['props'] { return null as any; }
-    events(): ReturnType<typeof render${genericsRef}>['events'] { return null as any; }
-    slots(): ReturnType<typeof render${genericsRef}>['slots'] { return null as any; }
+    props(): ReturnType<typeof ${renderName}${genericsRef}>['props'] { return null as any; }
+    events(): ReturnType<typeof ${renderName}${genericsRef}>['events'] { return null as any; }
+    slots(): ReturnType<typeof ${renderName}${genericsRef}>['slots'] { return null as any; }
 `;
     }
 
     statement += isSvelte5
         ? `    bindings() { return ${exportedNames.createBindingsStr()}; }
-    exports() { return ${exportedNames.hasExports() ? `render${genericsRef}().exports` : '{}'}; }
+    exports() { return ${exportedNames.hasExports() ? `${renderName}${genericsRef}().exports` : '{}'}; }
 }\n`
         : '}\n';
 
@@ -175,13 +177,14 @@ function addSimpleComponentExport({
     str,
     usesSlots,
     noSvelteComponentTyped,
-    isSvelte5
+    isSvelte5,
+    renderName
 }: AddComponentExportPara) {
     const propDef = props(
         isTsFile,
         canHaveAnyProp,
         exportedNames,
-        _events(events.hasStrictEvents(), 'render()')
+        _events(events.hasStrictEvents(), `${renderName}()`)
     );
 
     const doc = componentDocumentation.getFormatted();
@@ -192,7 +195,7 @@ function addSimpleComponentExport({
     if (mode === 'dts') {
         if (isSvelte5 && exportedNames.usesRunes() && !usesSlots && !events.hasEvents()) {
             statement =
-                `\n${doc}const ${componentName} = __sveltets_2_fn_component(render());\n` +
+                `\n${doc}const ${componentName} = __sveltets_2_fn_component(${renderName}());\n` +
                 `type ${componentName} = ReturnType<typeof ${componentName}>;\n` +
                 `export default ${componentName};`;
         } else if (isSvelte5) {
@@ -258,7 +261,7 @@ declare function $$__sveltets_2_isomorphic_component<
         if (isSvelte5) {
             if (exportedNames.usesRunes() && !usesSlots && !events.hasEvents()) {
                 statement =
-                    `\n${doc}const ${componentName} = __sveltets_2_fn_component(render());\n` +
+                    `\n${doc}const ${componentName} = __sveltets_2_fn_component(${renderName}());\n` +
                     `type ${componentName} = ReturnType<typeof ${componentName}>;\n` +
                     `export default ${componentName};`;
             } else {

--- a/packages/svelte2tsx/src/svelte2tsx/createRenderFunction.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/createRenderFunction.ts
@@ -18,6 +18,7 @@ export interface CreateRenderFunctionPara extends InstanceScriptProcessResult {
     svelte5Plus: boolean;
     isTsFile: boolean;
     mode?: 'ts' | 'dts';
+    renderName: string;
 }
 
 export function createRenderFunction({
@@ -33,7 +34,8 @@ export function createRenderFunction({
     uses$$SlotsInterface,
     generics,
     isTsFile,
-    mode
+    mode,
+    renderName
 }: CreateRenderFunctionPara) {
     const htmlx = str.original;
     let propsDecl = '';
@@ -75,7 +77,8 @@ export function createRenderFunction({
                 start++;
                 end--;
             }
-            str.overwrite(scriptTag.start + 1, start - 1, `function render`);
+
+            str.overwrite(scriptTag.start + 1, start - 1, `function ${renderName}`);
             str.overwrite(start - 1, start, isTsFile ? '<' : `<${IGNORE_START_COMMENT}`); // if the generics are unused, only this char is colored opaque
             str.overwrite(
                 end,
@@ -86,7 +89,7 @@ export function createRenderFunction({
             str.overwrite(
                 scriptTag.start + 1,
                 scriptTagEnd,
-                `function render${generics.toDefinitionString(true)}() {${propsDecl}\n`
+                `function ${renderName}${generics.toDefinitionString(true)}() {${propsDecl}\n`
             );
         }
 
@@ -98,7 +101,7 @@ export function createRenderFunction({
     } else {
         str.prependRight(
             scriptDestination,
-            `;function render() {` + `${propsDecl}${slotsDeclaration}\nasync () => {`
+            `;function ${renderName}() {` + `${propsDecl}${slotsDeclaration}\nasync () => {`
         );
     }
 

--- a/packages/svelte2tsx/src/svelte2tsx/index.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/index.ts
@@ -96,7 +96,15 @@ export function svelte2tsx(
         : instanceScriptTarget;
     const implicitStoreValues = new ImplicitStoreValues(resolvedStores, renderFunctionStart);
     //move the instance script and process the content
-    let exportedNames = new ExportedNames(str, 0, basename, isTsFile, svelte5Plus, isRunes);
+    let exportedNames = new ExportedNames(
+        str,
+        0,
+        basename,
+        isTsFile,
+        svelte5Plus,
+        isRunes,
+        moduleAst.renderName
+    );
     let generics = new Generics(str, 0, { attributes: [] } as any);
     let uses$$SlotsInterface = false;
     if (scriptTag) {
@@ -114,7 +122,8 @@ export function svelte2tsx(
             isTsFile,
             basename,
             svelte5Plus,
-            isRunes
+            isRunes,
+            moduleAst.renderName
         );
         uses$$props = uses$$props || res.uses$$props;
         uses$$restProps = uses$$restProps || res.uses$$restProps;
@@ -143,7 +152,8 @@ export function svelte2tsx(
         generics,
         svelte5Plus,
         isTsFile,
-        mode: options.mode
+        mode: options.mode,
+        renderName: moduleAst.renderName
     });
 
     // we need to process the module script after the instance script has moved otherwise we get warnings about moving edited items
@@ -201,7 +211,8 @@ export function svelte2tsx(
         mode: options.mode,
         generics,
         isSvelte5: svelte5Plus,
-        noSvelteComponentTyped: options.noSvelteComponentTyped
+        noSvelteComponentTyped: options.noSvelteComponentTyped,
+        renderName: moduleAst.renderName
     });
 
     if (options.mode === 'dts') {

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -60,7 +60,8 @@ export class ExportedNames {
         private basename: string,
         private isTsFile: boolean,
         private isSvelte5Plus: boolean,
-        private isRunes: boolean
+        private isRunes: boolean,
+        private renderName: string
     ) {}
 
     handleVariableStatement(node: ts.VariableStatement, parent: ts.Node): void {
@@ -506,7 +507,10 @@ export class ExportedNames {
         if (this.usesRunes()) {
             // In runes mode, exports are no longer part of props
             return Array.from(this.getters)
-                .map((name) => `\n    get ${name}() { return render${generics}().exports.${name} }`)
+                .map(
+                    (name) =>
+                        `\n    get ${name}() { return ${this.renderName}${generics}().exports.${name} }`
+                )
                 .join('');
         } else {
             return Array.from(this.getters)

--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -44,7 +44,8 @@ export function processInstanceScriptContent(
     isTSFile: boolean,
     basename: string,
     isSvelte5Plus: boolean,
-    isRunes: boolean
+    isRunes: boolean,
+    renderName: string
 ): InstanceScriptProcessResult {
     const htmlx = str.original;
     const scriptContent = htmlx.substring(script.content.start, script.content.end);
@@ -62,7 +63,8 @@ export function processInstanceScriptContent(
         basename,
         isTSFile,
         isSvelte5Plus,
-        isRunes
+        isRunes,
+        renderName
     );
     const generics = new Generics(str, astOffset, script);
     const interfacesAndTypes = new InterfacesAndTypes();

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-function-module/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-function-module/expected-svelte5.ts
@@ -1,0 +1,9 @@
+///<reference types="svelte" />
+;
+	function render(){}
+;;function render_0() {
+async () => {};
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event(render_0())));
+/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-function-module/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-function-module/input.svelte
@@ -1,0 +1,3 @@
+<script module lang="ts">
+	function render(){}
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module-exports/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module-exports/expected-svelte5.ts
@@ -1,0 +1,14 @@
+///<reference types="svelte" />
+;
+	import { render } from "render";
+;;function render_0() {
+
+	
+;
+async () => {
+
+};
+return { props: {render: render}, exports: /** @type {{render: typeof render}} */ ({}), bindings: "", slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['render'], __sveltets_2_with_any_event(render_0())));
+/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module-exports/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module-exports/input.svelte
@@ -1,0 +1,7 @@
+<script module lang="ts">
+	import { render } from "render";
+</script>
+
+<script lang="ts">
+	export { render }
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module-generics/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module-generics/expected-svelte5.ts
@@ -1,0 +1,32 @@
+///<reference types="svelte" />
+;
+	import { render } from "render";
+;;function render_0</*Ωignore_startΩ*/T>/*Ωignore_endΩ*/() {
+
+;
+async () => {
+
+};
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
+class __sveltets_Render<T> {
+    props() {
+        return render_0<T>().props;
+    }
+    events() {
+        return __sveltets_2_with_any_event(render_0<T>()).events;
+    }
+    slots() {
+        return render_0<T>().slots;
+    }
+    bindings() { return ""; }
+    exports() { return {}; }
+}
+
+interface $$IsomorphicComponent {
+    new <T>(options: import('svelte').ComponentConstructorOptions<ReturnType<__sveltets_Render<T>['props']>>): import('svelte').SvelteComponent<ReturnType<__sveltets_Render<T>['props']>, ReturnType<__sveltets_Render<T>['events']>, ReturnType<__sveltets_Render<T>['slots']>> & { $$bindings?: ReturnType<__sveltets_Render<T>['bindings']> } & ReturnType<__sveltets_Render<T>['exports']>;
+    <T>(internal: unknown, props: {$$events?: ReturnType<__sveltets_Render<T>['events']>}): ReturnType<__sveltets_Render<T>['exports']>;
+    z_$$bindings?: ReturnType<__sveltets_Render<any>['bindings']>;
+}
+const Input__SvelteComponent_: $$IsomorphicComponent = null as any;
+/*Ωignore_startΩ*/type Input__SvelteComponent_<T> = InstanceType<typeof Input__SvelteComponent_<T>>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module-generics/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module-generics/input.svelte
@@ -1,0 +1,6 @@
+<script module lang="ts">
+	import { render } from "render";
+</script>
+
+<script lang="ts" generics="T">
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module/expectedv2.ts
@@ -1,0 +1,9 @@
+///<reference types="svelte" />
+;
+	import { render } from "render";
+;;function render_0() {
+async () => {};
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event(render_0()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-import-module/input.svelte
@@ -1,0 +1,3 @@
+<script module lang="ts">
+	import { render } from "render";
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-named-import-module/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-named-import-module/expected-svelte5.ts
@@ -1,0 +1,9 @@
+///<reference types="svelte" />
+;
+	import render from "render";
+;;function render_0() {
+async () => {};
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event(render_0())));
+/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-named-import-module/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-named-import-module/input.svelte
@@ -1,0 +1,3 @@
+<script module lang="ts">
+	import render from "render";
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-variable-module/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-variable-module/expected-svelte5.ts
@@ -1,0 +1,9 @@
+///<reference types="svelte" />
+;
+	const render = 42;
+;;function render_0() {
+async () => {};
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event(render_0())));
+/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/render-variable-module/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/render-variable-module/input.svelte
@@ -1,0 +1,3 @@
+<script module lang="ts">
+	const render = 42;
+</script>


### PR DESCRIPTION
One day i'll learn how to properly generate the tests...sorry if i fumbled.

This fixes a problem that you get when you import or create a variable/function named `render` in the module...since we create a `render` function ourselves it conflicts with it giving a confusing error to the user.

It also just occured to me that maybe we can even `rename` the function to something less usual so that it has less chance of conflicting with the user (now that we have a global variable with the name could even be a random identifier so that even if by any change it conflicts with the user it should go away the next restart of language server).

I think this should work fine but I hope the name (or the length of the name) was not referenced somewhere else so please have an extra eye for this things.