### PR TITLE
fix: support workspace symbol excludeLibrarySymbols config in ts-plugin

### DIFF
--- a/packages/typescript-plugin/src/language-service/navigate-to-items.ts
+++ b/packages/typescript-plugin/src/language-service/navigate-to-items.ts
@@ -7,18 +7,8 @@ export function decorateNavigateToItems(
     snapshotManager: SvelteSnapshotManager
 ): void {
     const getNavigateToItems = ls.getNavigateToItems;
-    ls.getNavigateToItems = (
-        searchValue: string,
-        maxResultCount?: number,
-        fileName?: string,
-        excludeDtsFiles?: boolean
-    ) => {
-        const navigationToItems = getNavigateToItems(
-            searchValue,
-            maxResultCount,
-            fileName,
-            excludeDtsFiles
-        );
+    ls.getNavigateToItems = (...args) => {
+        const navigationToItems = getNavigateToItems(...args);
 
         return navigationToItems
             .map((item) => {


### PR DESCRIPTION
#2672 

The config is added in TypeScript 5.3. A month after we added the workspace symbol patch 😅.