### PR TITLE
fix: don't show html tag completion with namespace component

### DIFF
--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -312,12 +312,14 @@ export function updateRelativeImport(oldPath: string, newPath: string, relativeI
  */
 export function getNodeIfIsInComponentStartTag(
     html: HTMLDocument,
+    document: Document,
     offset: number
 ): Node | undefined {
     const node = html.findNodeAt(offset);
     if (
         !!node.tag &&
-        node.tag[0] === node.tag[0].toUpperCase() &&
+        (node.tag[0] === node.tag[0].toUpperCase() ||
+            (document.isSvelte5 && node.tag.includes('.'))) &&
         (!node.startTagEnd || offset < node.startTagEnd)
     ) {
         return node;

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -217,7 +217,7 @@ export class HTMLPlugin
     }
 
     private isInComponentTag(html: HTMLDocument, document: Document, position: Position) {
-        return !!getNodeIfIsInComponentStartTag(html, document.offsetAt(position));
+        return !!getNodeIfIsInComponentStartTag(html, document, document.offsetAt(position));
     }
 
     private getLangCompletions(completions: CompletionItem[]): CompletionItem[] {

--- a/packages/language-server/src/plugins/typescript/features/utils.ts
+++ b/packages/language-server/src/plugins/typescript/features/utils.ts
@@ -41,7 +41,7 @@ export function getComponentAtPosition(
         return null;
     }
 
-    const node = getNodeIfIsInComponentStartTag(doc.html, doc.offsetAt(originalPosition));
+    const node = getNodeIfIsInComponentStartTag(doc.html, doc, doc.offsetAt(originalPosition));
     if (!node) {
         return null;
     }
@@ -80,7 +80,7 @@ export function isComponentAtPosition(
         return false;
     }
 
-    return !!getNodeIfIsInComponentStartTag(doc.html, doc.offsetAt(originalPosition));
+    return !!getNodeIfIsInComponentStartTag(doc.html, doc, doc.offsetAt(originalPosition));
 }
 
 export const IGNORE_START_COMMENT = '/*Ωignore_startΩ*/';


### PR DESCRIPTION
#2684 The problem is that the HTML tag completion takes priority over the ts completion and the TextEdit from HTML tag completion includes the whole dot notation. VSCode doesn't like it spans over the word span and filters it out.