### PR TITLE
fix: properly transform `$props.id` when `$props` is assigned to `props`

### DIFF
--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -93,6 +93,7 @@ export function processInstanceScriptContent(
     let scope = new Scope();
     const rootScope = scope;
 
+    //track is the variable declared as `props` comes from `$props()`
     let isPropsDeclarationRune = false;
 
     const pushScope = () => (scope = new Scope(scope));
@@ -130,6 +131,7 @@ export function processInstanceScriptContent(
             return;
         }
 
+        //if we are in a variable declaration and the identifier is `props` we check the initializer
         if (
             ident.text === 'props' &&
             variableDeclarationNode &&
@@ -327,6 +329,7 @@ export function processInstanceScriptContent(
 
     //resolve stores
     if (isPropsDeclarationRune) {
+        //we filter out every pendingStore resolution that `isPropsId` if the variable names `props` comes from `$props()`
         pendingStoreResolutions = pendingStoreResolutions.filter(({ isPropsId }) => !isPropsId);
     }
     pendingStoreResolutions.map(resolveStore);

--- a/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-destructured.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-destructured.v5/expectedv2.ts
@@ -1,0 +1,13 @@
+///<reference types="svelte" />
+;function $$render() {
+
+	let/** @typedef {{ props: any }} $$ComponentProps *//** @type {$$ComponentProps} */ { props } = $props();
+	let id = $props.id();
+;
+async () => {
+
+id; props;};
+return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_fn_component($$render());
+type Input__SvelteComponent_ = ReturnType<typeof Input__SvelteComponent_>;
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-destructured.v5/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-destructured.v5/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { props } = $props();
+	let id = $props.id();
+</script>
+
+{id} {props}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-not-$props-init.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-not-$props-init.v5/expectedv2.ts
@@ -1,0 +1,13 @@
+///<reference types="svelte" />
+;function $$render() {
+
+	let props = {}/*Ωignore_startΩ*/;let $props = __sveltets_2_store_get(props);/*Ωignore_endΩ*/;
+	let id = $props.id();
+;
+async () => {
+
+id; props;};
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event($$render())));
+/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-not-$props-init.v5/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-not-$props-init.v5/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	let props = {};
+	let id = $props.id();
+</script>
+
+{id} {props}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-spread.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-spread.v5/expectedv2.ts
@@ -1,0 +1,13 @@
+///<reference types="svelte" />
+;function $$render() {
+
+	let/** @typedef {Record<string, any>} $$ComponentProps *//** @type {$$ComponentProps} */ {...props} = $props();
+	let id = $props.id();
+;
+async () => {
+
+id; props;};
+return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_fn_component($$render());
+type Input__SvelteComponent_ = ReturnType<typeof Input__SvelteComponent_>;
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-spread.v5/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id-spread.v5/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	let {...props} = $props();
+	let id = $props.id();
+</script>
+
+{id} {props}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id.v5/expectedv2.ts
@@ -1,0 +1,13 @@
+///<reference types="svelte" />
+;function $$render() {
+
+	let props = $props();
+	let id = $props.id();
+;
+async () => {
+
+id; props;};
+return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings(''), slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_fn_component($$render());
+type Input__SvelteComponent_ = ReturnType<typeof Input__SvelteComponent_>;
+export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id.v5/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/props-variable-and-$props.id.v5/input.svelte
@@ -1,0 +1,6 @@
+<script>
+	let props = $props();
+	let id = $props.id();
+</script>
+
+{id} {props}


### PR DESCRIPTION
This is a bit of weird one and I'm not sure there's a better way to handle this. The problem is that when you are doing this

```svelte
<script>
    let props = $props();
    let id = $props.id();
</script>
```

the second `$props` identifier was not considered a rune because it's not an immediate function call. There's a catch tho: even if we check that the parent is a call expression and the text is `$props.id` we can't rule that out immediately because it depends if the `props` variable comes from the assignment of `$props()` or not. But the scope we have here is far less powerful than the one in the svelte compiler. So i had to do this weird dance where i still add the possible store in the array but i also save the fact that comes from `$props.id`...then while walking if i encounter an identifier `props` which is in a variable declaration i check if the variable declaration initializer is `$props()`.

It should cover all the edge cases but it's a bit convoluted. Also i would've loved to add some comments here and there but everytime i open that file my vscode crashes 😳