### PR TITLE
fix: handle booleanish popover

### DIFF
--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
@@ -160,7 +160,7 @@ export function handleAttribute(
     const attributeValue: TransformationArray = [];
 
     if (attr.value === true) {
-        attributeValue.push('true');
+        attributeValue.push(attr.name === 'popover' ? '""' : 'true');
         addAttribute(attributeName, attributeValue);
         return;
     }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-bare/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-bare/expectedv2.js
@@ -1,1 +1,5 @@
   { const $$_tnenopmoCemoS0C = __sveltets_2_ensureComponent(SomeComponent); new $$_tnenopmoCemoS0C({ target: __sveltets_2_any(), props: {"relaxed":true,}});}
+ { svelteHTML.createElement("input", {"disabled":true,});}
+
+
+ { svelteHTML.createElement("div", {"popover":"",}); }

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-bare/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-bare/input.svelte
@@ -1,1 +1,5 @@
 <SomeComponent relaxed />
+<input disabled>
+
+<!-- special: this actually means popover="" -->
+<div popover></div>


### PR DESCRIPTION
`<div popover></div>` actually means `<div popover=""></div>`

#2688

There may be other such special cases lurking in the spec, we can add them on a case-by-case basis when they pop up
