### PR TITLE
(deps) Replace `pascal-case` with `change-case` (Maintained & Lighter)

### DIFF
--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -66,6 +66,6 @@
     ],
     "dependencies": {
         "dedent-js": "^1.0.1",
-        "pascal-case": "^3.1.1"
+        "change-case": "^5.4.4"
     }
 }

--- a/packages/svelte2tsx/rollup.config.mjs
+++ b/packages/svelte2tsx/rollup.config.mjs
@@ -107,7 +107,7 @@ export default [
             'svelte',
             'svelte/compiler',
             'dedent-js',
-            'pascal-case'
+            'change-case'
         ]
     }
 ];

--- a/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
@@ -1,4 +1,4 @@
-import { pascalCase } from 'pascal-case';
+import { pascalCase } from 'change-case';
 import path from 'path';
 import MagicString from 'magic-string';
 import { ExportedNames } from './nodes/ExportedNames';
@@ -356,7 +356,7 @@ function classNameFromFilename(filename: string, appendSuffix: boolean): string 
         const withoutExtensions = path.parse(filename).name?.split('.')[0];
         const withoutInvalidCharacters = withoutExtensions
             .split('')
-            // Although "-" is invalid, we leave it in, pascal-case-handling will throw it out later
+            // Although "-" is invalid, we leave it in, change-case-handling (pascalCase) will throw it out later
             .filter((char) => /[A-Za-z$_\d-]/.test(char))
             .join('');
         const firstValidCharIdx = withoutInvalidCharacters

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,12 +225,12 @@ importers:
 
   packages/svelte2tsx:
     dependencies:
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
       dedent-js:
         specifier: ^1.0.1
         version: 1.0.1
-      pascal-case:
-        specifier: ^3.1.1
-        version: 3.1.2
     devDependencies:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.5.0
@@ -625,6 +625,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -971,9 +974,6 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
-  lower-case@2.0.2:
-    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
-
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -1036,9 +1036,6 @@ packages:
   nise@5.1.4:
     resolution: {integrity: sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==}
 
-  no-case@3.0.4:
-    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -1057,9 +1054,6 @@ packages:
   p-map@3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
     engines: {node: '>=8'}
-
-  pascal-case@3.1.2:
-    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1691,6 +1685,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  change-case@5.4.4: {}
+
   chokidar@3.5.3:
     dependencies:
       anymatch: 3.1.3
@@ -2023,10 +2019,6 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
-  lower-case@2.0.2:
-    dependencies:
-      tslib: 2.5.2
-
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -2109,11 +2101,6 @@ snapshots:
       just-extend: 4.2.1
       path-to-regexp: 1.8.0
 
-  no-case@3.0.4:
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.5.2
-
   normalize-path@3.0.0: {}
 
   once@1.4.0:
@@ -2131,11 +2118,6 @@ snapshots:
   p-map@3.0.0:
     dependencies:
       aggregate-error: 3.1.0
-
-  pascal-case@3.1.2:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.5.2
 
   path-exists@4.0.0: {}
 


### PR DESCRIPTION
This PR replaces the unmaintained `pascal-case` package with its recommended successor, `change-case`.

#### **Why?**
- `pascal-case@3.1.1` is outdated, and `4.0.0` is deprecated.
- The author suggests migrating to `change-case`.
- `change-case` has **0 dependencies** and a smaller total footprint.

#### **Comparison:**
| Package       | Size  | Dependencies | Total Size |
|--------------|-------|-------------|------------|
| pascal-case  | 14KB  | 2 (`no-case` 25KB, `lower-case` 17KB) | **56KB** |
| change-case  | 35KB  | 0 | **35KB** |

---

✅ **Net win**: Fewer dependencies, lower size, and a more future-proof solution.
