### PR TITLE
fix: prevent unused variable error for bindable

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$bindable-reassign.v5/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$bindable-reassign.v5/expectedv2.json
@@ -1,0 +1,10 @@
+[
+    {
+        "range": { "start": { "line": 3, "character": 8 }, "end": { "line": 3, "character": 12 } },
+        "severity": 4,
+        "source": "ts",
+        "message": "'foo2' is declared but its value is never read.",
+        "code": 6133,
+        "tags": [1]
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$bindable-reassign.v5/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/$bindable-reassign.v5/input.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    let { 
+        foo = $bindable(),
+        foo2
+    } = $props();
+
+    function onClick() {
+        foo = 42;
+    }
+</script>
+
+<button onclick={onClick}>Click me</button>

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -177,6 +177,15 @@ export class ExportedNames {
             }
         }
 
+        if (this.$props.bindings.length > 0) {
+            this.str.appendLeft(
+                node.end + this.astOffset,
+                surroundWithIgnoreComments(
+                    ';' + this.$props.bindings.map((prop) => prop + ';').join('')
+                )
+            );
+        }
+
         // Easy mode: User uses TypeScript and typed the $props() rune
         if (node.initializer.typeArguments?.length > 0 || node.type) {
             this.hoistableInterfaces.analyze$propsRune(node);

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-best-effort-types.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-best-effort-types.v5/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function $$render() {
 
-    let/** @typedef {{ a: any, b?: boolean, c?: number, d?: string, e?: any, f?: Record<string, any>, g?: typeof foo, h?: any[], i?: any, j?: any, k?: number, l?: Function }} $$ComponentProps *//** @type {$$ComponentProps} */ { a, b = true, c = 1, d = '', e = null, f = {}, g = foo, h = [], i = undefined, j = $bindable(), k = $bindable(1), l = () => {} } = $props(); 
+    let/** @typedef {{ a: any, b?: boolean, c?: number, d?: string, e?: any, f?: Record<string, any>, g?: typeof foo, h?: any[], i?: any, j?: any, k?: number, l?: Function }} $$ComponentProps *//** @type {$$ComponentProps} */ { a, b = true, c = 1, d = '', e = null, f = {}, g = foo, h = [], i = undefined, j = $bindable(), k = $bindable(1), l = () => {} } = $props()/*Ωignore_startΩ*/;j;k;/*Ωignore_endΩ*/; 
 ;
 async () => {};
 return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings('j', 'k'), slots: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/runes-bindable.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/runes-bindable.v5/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function $$render() {
 
-    let/** @typedef {{ a: any, b?: any }} $$ComponentProps *//** @type {$$ComponentProps} */ { a, b = $bindable() } = $props();
+    let/** @typedef {{ a: any, b?: any }} $$ComponentProps *//** @type {$$ComponentProps} */ { a, b = $bindable() } = $props()/*Ωignore_startΩ*/;b;/*Ωignore_endΩ*/;
 ;
 async () => {};
 return { props: /** @type {$$ComponentProps} */({}), exports: {}, bindings: __sveltets_$$bindings('b'), slots: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-best-effort-types.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-best-effort-types.v5/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function $$render() {
 /*Ωignore_startΩ*/;type $$ComponentProps = { a: any, b?: boolean, c?: number, d?: string, e?: any, f?: Record<string, any>, g?: typeof foo, h?: Bar, i?: Baz, j?: any[], k?: any, l?: any, m?: number, n?: Function };/*Ωignore_endΩ*/
-    let { a, b = true, c = 1, d = '', e = null, f = {}, g = foo, h = null as Bar, i = null as any as Baz, j = [], k = undefined, l = $bindable(), m = $bindable(1), n = () => {} }: $$ComponentProps = $props(); 
+    let { a, b = true, c = 1, d = '', e = null, f = {}, g = foo, h = null as Bar, i = null as any as Baz, j = [], k = undefined, l = $bindable(), m = $bindable(1), n = () => {} }: $$ComponentProps = $props()/*Ωignore_startΩ*/;l;m;/*Ωignore_endΩ*/; 
 ;
 async () => {};
 return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings('l', 'm'), slots: {}, events: {} }}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-runes-bindable.v5/expectedv2.ts
@@ -1,7 +1,7 @@
 ///<reference types="svelte" />
 ;function $$render() {
 /*Ωignore_startΩ*/;type $$ComponentProps = { a: any, b?: any, c?: number };/*Ωignore_endΩ*/
-    let { a, b = $bindable(), c = $bindable(0) as number }: $$ComponentProps = $props();
+    let { a, b = $bindable(), c = $bindable(0) as number }: $$ComponentProps = $props()/*Ωignore_startΩ*/;b;c;/*Ωignore_endΩ*/;
 ;
 async () => {};
 return { props: {} as any as $$ComponentProps, exports: {}, bindings: __sveltets_$$bindings('b', 'c'), slots: {}, events: {} }}


### PR DESCRIPTION
 #2268
 
 I was originally thinking about filtering it out in the language server so that it's easier to only filter out the props that are being reassigned. However, TypeScript combines the diagnostics into one when destructured variables are unused, this route won't work.
 
As for why the error isn't reliable in the editor, I tried debugging and found that if the symbol is already analysed prior to the diagnostics, the error/hint won't show. So it's a race condition. Our diagnostics are delayed later than TSServer, so it's easier to trigger. (Edit. found a reproduction in ts file and filed a upstream issue)