### PR TITLE
fix: don't create new output channel after restart

### DIFF
--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -40,13 +40,24 @@ namespace TagCloseRequest {
     );
 }
 
-let lsApi: { getLS(): LanguageClient } | undefined;
+let lsApi:
+    | {
+          getLS(): LanguageClient;
+          restartLS(showNotification: boolean): Promise<void>;
+      }
+    | undefined;
 
 export function activate(context: ExtensionContext) {
     // The extension is activated on TS/JS/Svelte files because else it might be too late to configure the TS plugin:
     // If we only activate on Svelte file and the user opens a TS file first, the configuration command is issued too late.
     // We wait until there's a Svelte file open and only then start the actual language client.
     const tsPlugin = new TsPlugin(context);
+
+    context.subscriptions.push(
+        commands.registerCommand('svelte.restartLanguageServer', async () => {
+            await lsApi?.restartLS(true);
+        })
+    );
 
     if (workspace.textDocuments.some((doc) => doc.languageId === 'svelte')) {
         lsApi = activateSvelteLanguageServer(context);
@@ -150,7 +161,10 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
         console.log('setting server runtime to', serverRuntime);
     }
 
+    // Manually create the output channel so that it'll be reused and won't lose focus during restarts
+    const outputChannel = window.createOutputChannel('Svelte', 'svelte');
     const clientOptions: LanguageClientOptions = {
+        outputChannel,
         documentSelector: [{ scheme: 'file', language: 'svelte' }],
         revealOutputChannelOn: RevealOutputChannelOn.Never,
         synchronize: {
@@ -187,7 +201,7 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
         }
     };
 
-    let ls = createLanguageServer(serverOptions, clientOptions);
+    const ls = createLanguageServer(serverOptions, clientOptions);
     ls.start().then(() => {
         const tagRequestor = (document: TextDocument, position: Position) => {
             const param = ls.code2ProtocolConverter.asTextDocumentPositionParams(
@@ -222,12 +236,6 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
         }
     });
 
-    context.subscriptions.push(
-        commands.registerCommand('svelte.restartLanguageServer', async () => {
-            await restartLS(true);
-        })
-    );
-
     let restartingLs = false;
     async function restartLS(showNotification: boolean) {
         if (restartingLs) {
@@ -235,9 +243,8 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
         }
 
         restartingLs = true;
-        await ls.stop();
-        ls = createLanguageServer(serverOptions, clientOptions);
-        await ls.start();
+        outputChannel.clear();
+        await ls.restart();
         if (showNotification) {
             window.showInformationMessage('Svelte language server restarted.');
         }
@@ -325,7 +332,8 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
     });
 
     return {
-        getLS
+        getLS,
+        restartLS
     };
 }
 


### PR DESCRIPTION
#2721 

Drive by preventing the "command not found error" when using the restart command when the language hasn't started yet. Manually create the output channel so that it'll be reused and won't lose focus during restarts. It'll also allow the output to be kept after restart if it's needed in the future. 