### PR TITLE
chore: standardize author field

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -29,7 +29,7 @@
         "editor",
         "language-server"
     ],
-    "author": "James Birtles <jameshbirtles@gmail.com> and the Svelte Language Tools contributors",
+    "author": "The Svelte Community",
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/sveltejs/language-tools/issues"

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -19,7 +19,7 @@
         "svelte",
         "vscode"
     ],
-    "author": "James Birtles <jameshbirtles@gmail.com> & the Svelte Core Team",
+    "author": "The Svelte Community",
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/sveltejs/language-tools/issues"

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -2,7 +2,7 @@
     "name": "svelte2tsx",
     "version": "0.7.35",
     "description": "Convert Svelte components to TSX for type checking",
-    "author": "David Pershouse",
+    "author": "The Svelte Community",
     "license": "MIT",
     "keywords": [
         "svelte",


### PR DESCRIPTION
The other two packages in this repo have "The Svelte Community" listed. It might make sense to do that everywhere to reflect the current authors rather than original author