### PR TITLE
add missing imports source action and tests

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -45,7 +45,7 @@ import { debounceThrottle, isNotNullOrUndefined, normalizeUri, urlToPath } from 
 import { FallbackWatcher } from './lib/FallbackWatcher';
 import { configLoader } from './lib/documents/configLoader';
 import { setIsTrusted } from './importPackage';
-import { SORT_IMPORT_CODE_ACTION_KIND } from './plugins/typescript/features/CodeActionsProvider';
+import { SORT_IMPORT_CODE_ACTION_KIND,ADD_MISSING_IMPORTS_CODE_ACTION_KIND } from './plugins/typescript/features/CodeActionsProvider';
 import { createLanguageServices } from './plugins/css/service';
 import { FileSystemProvider } from './plugins/css/FileSystemProvider';
 
@@ -270,6 +270,7 @@ export function startServer(options?: LSOptions) {
                               CodeActionKind.QuickFix,
                               CodeActionKind.SourceOrganizeImports,
                               SORT_IMPORT_CODE_ACTION_KIND,
+                              ADD_MISSING_IMPORTS_CODE_ACTION_KIND,
                               ...(clientSupportApplyEditCommand ? [CodeActionKind.Refactor] : [])
                           ].filter(
                               clientSupportedCodeActionKinds &&

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -45,7 +45,10 @@ import { debounceThrottle, isNotNullOrUndefined, normalizeUri, urlToPath } from 
 import { FallbackWatcher } from './lib/FallbackWatcher';
 import { configLoader } from './lib/documents/configLoader';
 import { setIsTrusted } from './importPackage';
-import { SORT_IMPORT_CODE_ACTION_KIND,ADD_MISSING_IMPORTS_CODE_ACTION_KIND } from './plugins/typescript/features/CodeActionsProvider';
+import {
+    SORT_IMPORT_CODE_ACTION_KIND,
+    ADD_MISSING_IMPORTS_CODE_ACTION_KIND
+} from './plugins/typescript/features/CodeActionsProvider';
 import { createLanguageServices } from './plugins/css/service';
 import { FileSystemProvider } from './plugins/css/FileSystemProvider';
 

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-custom-fix-all-component5.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-custom-fix-all-component5.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+
+</script>
+
+<FixAllImported />
+<FixAllImported2 />
+

--- a/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-custom-fix-all-component6.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/code-actions/codeaction-custom-fix-all-component6.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import FixAllImported from './importing/FixAllImported.svelte';
+    import FixAllImported2 from './importing/FixAllImported2.svelte';
+
+
+</script>
+
+<FixAllImported />
+<FixAllImported2 />
+


### PR DESCRIPTION
Fixes https://github.com/sveltejs/language-tools/issues/2616

Adds the source action to addMissingImports, reusing the same quick fix action as "import all missing"

Added two tests to show it working with missing imports and without.

works with the
```json
  "editor.codeActionsOnSave": {
    "source.addMissingImports": "always",
  },
```

to add the imports on save, producing similar functionality to the typescript version.