### PR TITLE
style(svelte-check): make human output more concise and readable

### DIFF
--- a/packages/svelte-check/src/writers.ts
+++ b/packages/svelte-check/src/writers.ts
@@ -114,6 +114,9 @@ export class HumanFriendlyWriter implements Writer {
         warningCount: number,
         fileCountWithProblems: number
     ) {
+        if (fileCountWithProblems) {
+            this.stream.write('====================================\n');
+        }
         const message = [
             'svelte-check found ',
             `${errorCount} ${errorCount === 1 ? 'error' : 'errors'} and `,

--- a/packages/svelte-check/src/writers.ts
+++ b/packages/svelte-check/src/writers.ts
@@ -38,10 +38,7 @@ export class HumanFriendlyWriter implements Writer {
         }
 
         if (this.isVerbose) {
-            this.stream.write('\n');
-            this.stream.write('====================================\n');
-            this.stream.write(`Loading svelte-check in workspace: ${workspaceDir}`);
-            this.stream.write('\n');
+            this.stream.write(`Loading svelte-check in workspace: ${workspaceDir}\n`);
             this.stream.write('Getting Svelte diagnostics...\n');
             this.stream.write('\n');
         }
@@ -60,7 +57,7 @@ export class HumanFriendlyWriter implements Writer {
             let msg;
             if (this.isVerbose) {
                 const code = this.formatRelatedCode(diagnostic, text);
-                msg = `${diagnostic.message} ${source}\n${pc.cyan(code)}`;
+                msg = `${diagnostic.message} ${source}\n${pc.cyan(code.trimEnd())}`;
             } else {
                 msg = `${diagnostic.message} ${source}`;
             }
@@ -117,7 +114,6 @@ export class HumanFriendlyWriter implements Writer {
         warningCount: number,
         fileCountWithProblems: number
     ) {
-        this.stream.write('====================================\n');
         const message = [
             'svelte-check found ',
             `${errorCount} ${errorCount === 1 ? 'error' : 'errors'} and `,


### PR DESCRIPTION
This PR makes the human output of `svelte-check` more concise and readable.

TLDR:
- Remove `====================================` separator from the output
- Remove unnecessary leading newlines at the start of the output
- Trimmed trailing newlines at the end of code blocks when using the `--output=human-verbose` flag

# --output=human

## No Errors or Warnings

### Before
```sh
====================================
svelte-check found 0 errors and 0 warnings
```
### After
```sh
svelte-check found 0 errors and 0 warnings
```

## Single Error/Warning
### Before
```sh
/Users/yiming/workspace/somekit/src/routes/+layout.svelte:10:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)

====================================
svelte-check found 0 errors and 1 warning in 1 file
```
### After
```sh
/Users/yiming/workspace/somekit/src/routes/+layout.svelte:10:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)

svelte-check found 0 errors and 1 warning in 1 file
```

## Multiple Errors/Warnings
### Before
```sh
/Users/yiming/workspace/somekit/src/routes/+layout.svelte:10:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)

/Users/yiming/workspace/somekit/src/routes/+page.svelte:4:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)

====================================
svelte-check found 0 errors and 2 warnings in 2 files
```
### After
```sh
/Users/yiming/workspace/somekit/src/routes/+layout.svelte:10:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)

/Users/yiming/workspace/somekit/src/routes/+page.svelte:4:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)

svelte-check found 0 errors and 2 warnings in 2 files
```

# --output=human-verbose

## No Errors or Warnings

### Before
```sh
 
====================================
Loading svelte-check in workspace: /Users/yiming/workspace/somekit
Getting Svelte diagnostics...

====================================
svelte-check found 0 errors and 0 warnings
```
### After
```sh
Loading svelte-check in workspace: /Users/yiming/workspace/somekit
Getting Svelte diagnostics...

svelte-check found 0 errors and 0 warnings
```

## Single Error/Warning
### Before
```sh
 
====================================
Loading svelte-check in workspace: /Users/yiming/workspace/somekit
Getting Svelte diagnostics...

/Users/yiming/workspace/somekit/src/routes/+layout.svelte:10:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)
<style>
  .container {
    background-color: red;


====================================
svelte-check found 0 errors and 1 warning in 1 file
```
### After
```sh
Loading svelte-check in workspace: /Users/yiming/workspace/somekit
Getting Svelte diagnostics...

/Users/yiming/workspace/somekit/src/routes/+layout.svelte:10:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)
<style>
  .container {
    background-color: red;

svelte-check found 0 errors and 1 warning in 1 file
```

## Multiple Errors/Warnings
### Before
```sh
 
====================================
Loading svelte-check in workspace: /Users/yiming/workspace/somekit
Getting Svelte diagnostics...

/Users/yiming/workspace/somekit/src/routes/+layout.svelte:10:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)
<style>
  .container {
    background-color: red;


/Users/yiming/workspace/somekit/src/routes/+page.svelte:4:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)
<style>
  .container {
    background-color: red;


====================================
svelte-check found 0 errors and 2 warnings in 2 files
```
### After
```sh
Loading svelte-check in workspace: /Users/yiming/workspace/somekit
Getting Svelte diagnostics...

/Users/yiming/workspace/somekit/src/routes/+layout.svelte:10:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)
<style>
  .container {
    background-color: red;

/Users/yiming/workspace/somekit/src/routes/+page.svelte:4:3
Warn: Unused CSS selector ".container"
https://svelte.dev/e/css_unused_selector (svelte)
<style>
  .container {
    background-color: red;

svelte-check found 0 errors and 2 warnings in 2 files
```