### PR TITLE
fix: invalidate module resolution cache when higher priority file is added

### DIFF
--- a/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/DiagnosticsProvider.test.ts
@@ -84,7 +84,7 @@ describe('DiagnosticsProvider', function () {
 
         try {
             const diagnostics3 = await plugin.getDiagnostics(document);
-            assert.deepStrictEqual(diagnostics3.length, 1);
+            assert.deepStrictEqual(diagnostics3.length, 0);
             await lsAndTsDocResolver.deleteSnapshot(newTsFilePath);
         } finally {
             unlinkSync(newTsFilePath);


### PR DESCRIPTION
While debugging #2738, I found that the memory usage of svelte-language-server is much higher than that of TSServer when there are many files. It turns out that the way we store the mapping of "failed lookup path" to "containing file" uses a lot of memory. I guess path normalisation might have prevented V8 from optimising the string memory usage, so the same path has multiple instances in the `failedPathToContainingFile` map.

In an empty SvelteKit project that imports `googleapis`, which has 800+ `.d.ts` files and takes around 80 MB, the memory usage went down from around 1.4GB to 1 GB. It's still higher than TServer, but it's a lot closer. 

![圖片](https://github.com/user-attachments/assets/295d2569-1988-461e-be01-f384d712f235)
![圖片](https://github.com/user-attachments/assets/18a18866-a774-4727-a3a4-f844d4e40e12)

Also, a bit embarrassing that the old way I wrote also doesn't completely invalidate the cache, and the test is wrong 😅.
