### PR TITLE
chore: remove "Run tests with debugger" task.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,23 +31,6 @@
         },
         {
             "type": "node",
-            "request": "launch",
-            "name": "Run tests with debugger",
-            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": [
-                "-r",
-                "ts-node/register",
-                "--colors",
-                "${workspaceFolder}/packages/*/test/**/*.ts"
-            ],
-            "env": {
-                "TS_NODE_COMPILER_OPTIONS": "{\"esModuleInterop\":true}"
-            },
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen"
-        },
-        {
-            "type": "node",
             "request": "attach",
             "name": "Attach debugger to language server",
             "port": 6009,

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ This means it's easy to write tests for your changes:
 pnpm test
 ```
 
-For tricker issues, you can run the tests with a debugger in VSCode by setting a breakpoint (or adding `debugger` in the code) and launching the task: "Run tests with debugger".
+For trickier issues, you can run the tests with a debugger in VSCode by setting a breakpoint (or adding `debugger` in the code) and launching the test in the [JavaScript Debug Terminal](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_javascript-debug-terminal).
 
 ## Supporting Svelte
 


### PR DESCRIPTION
#1504 

It doesn't even have this compiler error anymore since we now use pnpm, and the path to Mocha has changed. 