### PR TITLE
feat: workspace symbols support

### DIFF
--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -135,6 +135,10 @@ Enable signature help (parameter hints) for JS/TS. _Default_: `true`
 
 Enable semantic tokens (semantic highlight) for TypeScript. _Default_: `true`
 
+#### `svelte.plugin.typescript.workspaceSymbols.enable`
+
+Enable workspace symbols for TypeScript. You can disable this if the language server client you're using doesn't deduplicate results from the TSServer. _Default_: `true`.
+
 ##### `svelte.plugin.css.enable`
 
 Enable the CSS plugin. _Default_: `true`

--- a/packages/language-server/src/ls-config.ts
+++ b/packages/language-server/src/ls-config.ts
@@ -21,7 +21,8 @@ const defaultLSConfig: LSConfig = {
         codeActions: { enable: true },
         selectionRange: { enable: true },
         signatureHelp: { enable: true },
-        semanticTokens: { enable: true }
+        semanticTokens: { enable: true },
+        workspaceSymbols: { enable: true }
     },
     css: {
         enable: true,
@@ -103,6 +104,9 @@ export interface LSTypescriptConfig {
         enable: boolean;
     };
     semanticTokens: {
+        enable: boolean;
+    };
+    workspaceSymbols: {
         enable: boolean;
     };
 }
@@ -205,6 +209,7 @@ export interface TSUserConfig {
     inlayHints?: TsInlayHintsConfig;
     referencesCodeLens?: TsReferenceCodeLensConfig;
     implementationsCodeLens?: TsImplementationCodeLensConfig;
+    workspaceSymbols?: TsWorkspaceSymbolsConfig;
 }
 
 /**
@@ -278,6 +283,10 @@ export interface TsReferenceCodeLensConfig {
 export interface TsImplementationCodeLensConfig {
     enabled: boolean;
     showOnInterfaceMethods?: boolean | undefined;
+}
+
+export interface TsWorkspaceSymbolsConfig {
+    excludeLibrarySymbols?: boolean;
 }
 
 export type TsUserConfigLang = 'typescript' | 'javascript';
@@ -509,7 +518,9 @@ export class LSConfigManager {
             organizeImportsTypeOrder: this.withDefaultAsUndefined(
                 config.preferences?.organizeImports?.typeOrder,
                 'auto'
-            )
+            ),
+
+            excludeLibrarySymbolsInNavTo: config.workspaceSymbols?.excludeLibrarySymbols ?? true
         };
     }
 

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -34,7 +34,8 @@ import {
     TextDocumentIdentifier,
     TextEdit,
     WorkspaceEdit,
-    InlayHint
+    InlayHint,
+    WorkspaceSymbol
 } from 'vscode-languageserver';
 import { DocumentManager, getNodeIfIsInHTMLStartTag } from '../lib/documents';
 import { Logger } from '../logger';
@@ -694,6 +695,18 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
                 ExecuteMode.FirstNonNull,
                 'high'
             ) ?? [] // fall back to empty array to prevent fallback to word-based highlighting
+        );
+    }
+
+    async getWorkspaceSymbols(
+        query: string,
+        token: CancellationToken
+    ): Promise<WorkspaceSymbol[] | null> {
+        return await this.execute<WorkspaceSymbol[]>(
+            'getWorkspaceSymbols',
+            [query, token],
+            ExecuteMode.FirstNonNull,
+            'high'
         );
     }
 

--- a/packages/language-server/src/plugins/interfaces.ts
+++ b/packages/language-server/src/plugins/interfaces.ts
@@ -35,7 +35,8 @@ import {
     SymbolInformation,
     TextDocumentIdentifier,
     TextEdit,
-    WorkspaceEdit
+    WorkspaceEdit,
+    WorkspaceSymbol
 } from 'vscode-languageserver-types';
 import { Document } from '../lib/documents';
 
@@ -251,6 +252,13 @@ export interface DocumentHighlightProvider {
     ): Resolvable<DocumentHighlight[] | null>;
 }
 
+export interface WorkspaceSymbolsProvider {
+    getWorkspaceSymbols(
+        query: string,
+        cancellationToken?: CancellationToken
+    ): Resolvable<WorkspaceSymbol[] | null>;
+}
+
 export interface OnWatchFileChanges {
     onWatchFileChanges(onWatchFileChangesParas: OnWatchFileChangesPara[]): void;
 }
@@ -282,7 +290,8 @@ type ProviderBase = DiagnosticsProvider &
     CallHierarchyProvider &
     FoldingRangeProvider &
     CodeLensProvider &
-    DocumentHighlightProvider;
+    DocumentHighlightProvider &
+    WorkspaceSymbolsProvider;
 
 export type LSProvider = ProviderBase & BackwardsCompatibleDefinitionsProvider;
 

--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -290,6 +290,16 @@ export class SnapshotManager {
         }
     }
 
+    allFilesAreJsOrDts() {
+        for (const doc of this.documents.values()) {
+            if (doc.scriptKind === ts.ScriptKind.TS || doc.scriptKind === ts.ScriptKind.TSX) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     dispose() {
         this.globalSnapshotsManager.removeChangeListener(this.onSnapshotChange);
     }

--- a/packages/language-server/src/plugins/typescript/features/WorkspaceSymbolProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/WorkspaceSymbolProvider.ts
@@ -1,0 +1,213 @@
+import { internalHelpers } from 'svelte2tsx';
+import ts from 'typescript';
+import { CancellationToken } from 'vscode-languageserver-protocol';
+import { SymbolKind, SymbolTag, WorkspaceSymbol } from 'vscode-languageserver-types';
+import { mapLocationToOriginal } from '../../../lib/documents';
+import { LSConfigManager } from '../../../ls-config';
+import { isNotNullOrUndefined } from '../../../utils';
+import { WorkspaceSymbolsProvider } from '../../interfaces';
+import { DocumentSnapshot, SvelteDocumentSnapshot } from '../DocumentSnapshot';
+import { LSAndTSDocResolver } from '../LSAndTSDocResolver';
+import { forAllServices, LanguageServiceContainer } from '../service';
+import {
+    convertRange,
+    isGeneratedSvelteComponentName,
+    isInScript,
+    isSvelteFilePath
+} from '../utils';
+import { isInGeneratedCode, SnapshotMap } from './utils';
+
+export class WorkspaceSymbolsProviderImpl implements WorkspaceSymbolsProvider {
+    constructor(lsAndTsDocResolver: LSAndTSDocResolver, configManager: LSConfigManager) {
+        this.configManager = configManager;
+        this.lsAndTsDocResolver = lsAndTsDocResolver;
+    }
+
+    private readonly configManager: LSConfigManager;
+    private readonly lsAndTsDocResolver: LSAndTSDocResolver;
+
+    async getWorkspaceSymbols(
+        query: string,
+        cancellationToken?: CancellationToken
+    ): Promise<WorkspaceSymbol[] | null> {
+        const allServices: LanguageServiceContainer[] = [];
+        await forAllServices((service) => {
+            allServices.push(service);
+        });
+
+        const symbols = new Map<string, Array<[ts.NavigateToItem, WorkspaceSymbol | undefined]>>();
+
+        // The config only exists for typescript. No javascript counterpart.
+        const preference = this.configManager.getTsUserPreferences('typescript', null);
+
+        for (const ls of allServices) {
+            if (cancellationToken?.isCancellationRequested) {
+                return null;
+            }
+            const service = ls.getService();
+            const projectItems = service.getNavigateToItems(
+                query,
+                /* maxResultCount */ 256,
+                /* fileName */ undefined,
+                /* excludeDtsFiles */ ls.snapshotManager.allFilesAreJsOrDts(),
+                preference.excludeLibrarySymbolsInNavTo
+            );
+
+            const snapshots = new SnapshotMap(this.lsAndTsDocResolver, ls);
+            for (const item of projectItems) {
+                if (
+                    this.isGeneratedName(item) ||
+                    (item.kind === ts.ScriptElementKind.alias && !item.containerName)
+                ) {
+                    continue;
+                }
+                const seen = symbols.get(item.name);
+                if (!seen) {
+                    symbols.set(item.name, [
+                        [
+                            item,
+                            this.mapWorkspaceSymbol(item, await snapshots.retrieve(item.fileName))
+                        ]
+                    ]);
+                    continue;
+                }
+
+                let skip = false;
+                for (const [seenItem] of seen) {
+                    if (this.navigateToItemIsEqualTo(seenItem, item)) {
+                        skip = true;
+                        break;
+                    }
+                }
+
+                if (skip) {
+                    continue;
+                }
+                const snapshot = await snapshots.retrieve(item.fileName);
+                if (
+                    snapshot instanceof SvelteDocumentSnapshot &&
+                    isInGeneratedCode(snapshot.getFullText(), item.textSpan.start)
+                ) {
+                    continue;
+                }
+                seen.push([
+                    item,
+                    this.mapWorkspaceSymbol(item, await snapshots.retrieve(item.fileName))
+                ]);
+            }
+        }
+
+        return Array.from(symbols.values())
+            .flatMap((items) => items.map(([_, symbol]) => symbol))
+            .filter(isNotNullOrUndefined);
+    }
+
+    private isGeneratedName(item: ts.NavigateToItem) {
+        if (!isSvelteFilePath(item.fileName)) {
+            return false;
+        }
+
+        return (
+            item.name === internalHelpers.renderName ||
+            item.name.startsWith('__sveltets_') ||
+            item.name.startsWith('$$')
+        );
+    }
+
+    private mapWorkspaceSymbol(
+        item: ts.NavigateToItem,
+        snapshot: DocumentSnapshot
+    ): WorkspaceSymbol | undefined {
+        let location = mapLocationToOriginal(snapshot, convertRange(snapshot, item.textSpan));
+        if (location.range.start.line < 0) {
+            if (isGeneratedSvelteComponentName(item.name)) {
+                location = {
+                    uri: snapshot.getURL(),
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 1 }
+                    }
+                };
+            } else {
+                return undefined;
+            }
+        }
+
+        return {
+            kind: this.convertSymbolKindForWorkspaceSymbol(item.kind),
+            name: this.getLabel(item),
+            containerName:
+                snapshot instanceof SvelteDocumentSnapshot &&
+                (item.containerName === internalHelpers.renderName || !item.containerName)
+                    ? isInScript(location.range.start, snapshot)
+                        ? 'script'
+                        : undefined
+                    : item.containerName,
+            location,
+            tags: item.kindModifiers?.includes('deprecated') ? [SymbolTag.Deprecated] : undefined
+        };
+    }
+
+    /**
+     *
+     * https://github.com/microsoft/TypeScript/blob/81c951894e93bdc37c6916f18adcd80de76679bc/src/server/session.ts#L2878
+     */
+    private navigateToItemIsEqualTo(a: ts.NavigateToItem, b: ts.NavigateToItem): boolean {
+        if (a === b) {
+            return true;
+        }
+        if (!a || !b) {
+            return false;
+        }
+        return (
+            a.containerKind === b.containerKind &&
+            a.containerName === b.containerName &&
+            a.fileName === b.fileName &&
+            a.isCaseSensitive === b.isCaseSensitive &&
+            a.kind === b.kind &&
+            a.kindModifiers === b.kindModifiers &&
+            a.matchKind === b.matchKind &&
+            a.name === b.name &&
+            a.textSpan.start === b.textSpan.start &&
+            a.textSpan.length === b.textSpan.length
+        );
+    }
+
+    /**
+     * Don't reuse our symbolKindFromString function, this should the same as the one in vscode
+     * so that vscode deduplicate the symbols from svelte and the typescript server.
+     * https://github.com/microsoft/vscode/blob/18ed64835ec8f8227dbd8562d2d9fd9fa339abbb/extensions/typescript-language-features/src/languageFeatures/workspaceSymbols.ts#L17
+     */
+    private convertSymbolKindForWorkspaceSymbol(kind: string) {
+        switch (kind) {
+            case ts.ScriptElementKind.memberFunctionElement:
+                return SymbolKind.Method;
+            case ts.ScriptElementKind.enumElement:
+                return SymbolKind.Enum;
+            case ts.ScriptElementKind.enumMemberElement:
+                return SymbolKind.EnumMember;
+            case ts.ScriptElementKind.functionElement:
+                return SymbolKind.Function;
+            case ts.ScriptElementKind.classElement:
+                return SymbolKind.Class;
+            case ts.ScriptElementKind.interfaceElement:
+                return SymbolKind.Interface;
+            case ts.ScriptElementKind.typeElement:
+                return SymbolKind.Class;
+            case ts.ScriptElementKind.memberVariableElement:
+            case ts.ScriptElementKind.memberGetAccessorElement:
+            case ts.ScriptElementKind.memberSetAccessorElement:
+                return SymbolKind.Field;
+            default:
+                return SymbolKind.Variable;
+        }
+    }
+
+    private getLabel(item: ts.NavigateToItem) {
+        const label = item.name;
+        if (item.kind === 'method' || item.kind === 'function') {
+            return label + '()';
+        }
+        return label;
+    }
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -326,7 +326,8 @@ export function startServer(options?: LSOptions) {
                 },
                 documentHighlightProvider:
                     evt.initializationOptions?.configuration?.svelte?.plugin?.svelte
-                        ?.documentHighlight?.enable ?? true
+                        ?.documentHighlight?.enable ?? true,
+                workspaceSymbolProvider: true
             }
         };
     });
@@ -499,6 +500,8 @@ export function startServer(options?: LSOptions) {
     connection.onDocumentHighlight((evt) =>
         pluginHost.findDocumentHighlight(evt.textDocument, evt.position)
     );
+
+    connection.onWorkspaceSymbol((evt, token) => pluginHost.getWorkspaceSymbols(evt.query, token));
 
     const diagnosticsManager = new DiagnosticsManager(
         connection.sendDiagnostics,

--- a/packages/language-server/test/plugins/typescript/features/WorkspaceSymbolsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/WorkspaceSymbolsProvider.test.ts
@@ -1,0 +1,142 @@
+import assert from 'assert';
+import path from 'path';
+import ts from 'typescript';
+import { WorkspaceSymbol } from 'vscode-languageserver-protocol';
+import { Document, DocumentManager } from '../../../../src/lib/documents';
+import { LSConfigManager } from '../../../../src/ls-config';
+import { LSAndTSDocResolver } from '../../../../src/plugins';
+import { WorkspaceSymbolsProviderImpl } from '../../../../src/plugins/typescript/features/WorkspaceSymbolProvider';
+import { pathToUrl } from '../../../../src/utils';
+import { serviceWarmup } from '../test-utils';
+
+const testDir = path.join(__dirname, '..');
+
+describe('WorkspaceSymbolsProvider', function () {
+    serviceWarmup(this, testDir, pathToUrl(testDir));
+
+    function getFullPath(filename: string) {
+        return path.join(testDir, 'testfiles', 'workspace-symbols', filename);
+    }
+    function getUri(filename: string) {
+        return pathToUrl(getFullPath(filename));
+    }
+
+    function setup(filename: string) {
+        const docManager = new DocumentManager(
+            (textDocument) => new Document(textDocument.uri, textDocument.text)
+        );
+        const lsConfigManager = new LSConfigManager();
+        const lsAndTsDocResolver = new LSAndTSDocResolver(
+            docManager,
+            [pathToUrl(testDir)],
+            lsConfigManager
+        );
+        const provider = new WorkspaceSymbolsProviderImpl(lsAndTsDocResolver, lsConfigManager);
+        const filePath = getFullPath(filename);
+        const document = docManager.openClientDocument(<any>{
+            uri: pathToUrl(filePath),
+            text: ts.sys.readFile(filePath)
+        });
+        return { provider, document, docManager, lsAndTsDocResolver };
+    }
+
+    it('should return workspace symbols', async () => {
+        const { provider, document, lsAndTsDocResolver } = setup('workspace-symbols.svelte');
+        await lsAndTsDocResolver.getLSAndTSDoc(document);
+
+        const symbols = await provider.getWorkspaceSymbols('longName');
+        assert.deepStrictEqual(symbols, [
+            {
+                containerName: 'script',
+                kind: 12,
+                location: {
+                    range: {
+                        end: {
+                            character: 5,
+                            line: 3
+                        },
+                        start: {
+                            character: 4,
+                            line: 2
+                        }
+                    },
+                    uri: getUri('workspace-symbols.svelte')
+                },
+                name: 'longLongName()',
+                tags: undefined
+            },
+            {
+                containerName: '',
+                kind: 11,
+                location: {
+                    range: {
+                        end: {
+                            character: 1,
+                            line: 5
+                        },
+                        start: {
+                            character: 0,
+                            line: 3
+                        }
+                    },
+                    uri: getUri('imported.ts')
+                },
+                name: 'longLongName2',
+                tags: [1]
+            },
+            {
+                containerName: 'longLongName2',
+                kind: 8,
+                location: {
+                    range: {
+                        end: {
+                            character: 26,
+                            line: 4
+                        },
+                        start: {
+                            character: 4,
+                            line: 4
+                        }
+                    },
+                    uri: getUri('imported.ts')
+                },
+                name: 'longLongName3',
+                tags: undefined
+            },
+            {
+                containerName: undefined,
+                kind: 13,
+                location: {
+                    range: {
+                        end: {
+                            character: 28,
+                            line: 8
+                        },
+                        start: {
+                            character: 15,
+                            line: 8
+                        }
+                    },
+                    uri: getUri('workspace-symbols.svelte')
+                },
+                name: 'longLongName4',
+                tags: undefined
+            }
+        ]);
+    });
+
+    it('filter out generated symbols', async () => {
+        const { provider, document, lsAndTsDocResolver } = setup('workspace-symbols.svelte');
+        await lsAndTsDocResolver.getLSAndTSDoc(document);
+
+        const symbols = await provider.getWorkspaceSymbols('_');
+        assert.deepStrictEqual(onlyInWorkspaceSymbolsDir(symbols), []);
+
+        const symbols2 = await provider.getWorkspaceSymbols('$');
+        assert.deepStrictEqual(onlyInWorkspaceSymbolsDir(symbols2), []);
+    });
+
+    function onlyInWorkspaceSymbolsDir(symbols: WorkspaceSymbol[] | null) {
+        return symbols?.filter((f) => f.location.uri.includes('workspace-symbols'));
+    }
+});

--- a/packages/language-server/test/plugins/typescript/testfiles/workspace-symbols/imported.ts
+++ b/packages/language-server/test/plugins/typescript/testfiles/workspace-symbols/imported.ts
@@ -1,0 +1,6 @@
+/**
+ * @deprecated
+ */
+export interface longLongName2 {
+    longLongName3: string;
+}

--- a/packages/language-server/test/plugins/typescript/testfiles/workspace-symbols/workspace-symbols.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/workspace-symbols/workspace-symbols.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    import { longLongName2 } from './imported'
+    function longLongName() {
+    }
+</script>
+
+<Component></Component>
+
+{#each [''] as longLongName4}
+    {longLongName4}
+{/each}}

--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -179,6 +179,12 @@
                     "title": "TypeScript: Semantic Tokens",
                     "description": "Enable semantic tokens (semantic highlight) for TypeScript."
                 },
+                "svelte.plugin.typescript.workspaceSymbols.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "TypeScript: Workspace Symbols",
+                    "description": "Enable workspace symbols for TypeScript."
+                },
                 "svelte.plugin.css.enable": {
                     "type": "boolean",
                     "default": true,

--- a/packages/typescript-plugin/src/language-service/call-hierarchy.ts
+++ b/packages/typescript-plugin/src/language-service/call-hierarchy.ts
@@ -8,6 +8,7 @@ import {
     isSvelteFilePath,
     offsetOfGeneratedComponentExport
 } from '../utils';
+import { internalHelpers } from 'svelte2tsx';
 
 const ENSURE_COMPONENT_HELPER = '__sveltets_2_ensureComponent';
 
@@ -76,7 +77,7 @@ export function decorateCallHierarchy(
                       .find(
                           (statement): statement is ts.FunctionDeclaration =>
                               typescript.isFunctionDeclaration(statement) &&
-                              statement.name?.getText() === 'render'
+                              statement.name?.getText() === internalHelpers.renderName
                       )
                       ?.name?.getStart()
                 : -1;
@@ -181,7 +182,7 @@ export function decorateCallHierarchy(
             return toComponentCallHierarchyItem(snapshot, item.file);
         }
 
-        if (item.name === 'render') {
+        if (item.name === internalHelpers.renderName) {
             const end = item.selectionSpan.start + item.selectionSpan.length;
             const renderFunction = sourceFile.statements.find(
                 (statement) =>


### PR DESCRIPTION
#2375. 
Adding support in the Svelte language server so that you don't need to open ts/js files to use this feature. You can trigger this feature with `Ctrl + T` and search for symbol names. Some of the handling is also synced to the typescript-plugin so that it's more consistent, which also means vscode can better deduplicate the results from both tsserver and Svelte language server. 

If users are using an lsp client that doesn't deduplicate results from different language servers, you can also disable this feature so that it doesn't show duplicate entries. Or if your client allows you to write your own middleware, you can skip the calculation if the ts extension is running. 