### PR TITLE
fix: enable fallback watcher when dynamicRegistration is false

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -123,7 +123,7 @@ export function startServer(options?: LSOptions) {
             Logger.error('No workspace path set');
         }
 
-        if (!evt.capabilities.workspace?.didChangeWatchedFiles) {
+        if (!evt.capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration) {
             const workspacePaths = workspaceUris.map(urlToPath).filter(isNotNullOrUndefined);
             watcher = new FallbackWatcher(watchExtensions, workspacePaths);
             watcher.onDidChangeWatchedFiles(onDidChangeWatchedFiles);


### PR DESCRIPTION
#2008

In Linux, neovim's client capability is `didChangeWatchedFiles: { dynamicRegistration: false }`. When this first happened, I think it was the client's responsibility to add the watcher in this case; however, it turned out to be a bit problematic, and it is the top 3 most commented closed issue 😅 . The neovim+Linux users are probably a lot more than the users using an lsp client that has a watcher config in the client. It also isn't as capable as our fallback watcher: it likely doesn't support as many file extensions, and we can't add a watcher outside the project root. 