### PR TITLE
fix: "Build-Free Editing with Project References" in SvelteKit page.ts files

### DIFF
--- a/packages/typescript-plugin/src/language-service/sveltekit.ts
+++ b/packages/typescript-plugin/src/language-service/sveltekit.ts
@@ -23,6 +23,7 @@ declare module 'typescript/lib/tsserverlibrary' {
         /** @internal */ getPackageJsonAutoImportProvider?(): ts.Program | undefined;
 
         /** @internal*/ getModuleResolutionCache?(): ts.ModuleResolutionCache;
+        /** @internal */ useSourceOfProjectReferenceRedirect?(): boolean;
     }
 }
 
@@ -780,6 +781,11 @@ function getProxiedLanguageService(info: ts.server.PluginCreateInfo, ts: _ts, lo
         getModuleResolutionCache = originalLanguageServiceHost.getModuleResolutionCache
             ? () => originalLanguageServiceHost.getModuleResolutionCache!()
             : undefined;
+
+        useSourceOfProjectReferenceRedirect =
+            originalLanguageServiceHost.useSourceOfProjectReferenceRedirect
+                ? () => originalLanguageServiceHost.useSourceOfProjectReferenceRedirect!()
+                : undefined;
     }
 
     // Ideally we'd create a full Proxy of the language service, but that seems to have cache issues


### PR DESCRIPTION
#2786 Proxying the internal `useSourceOfProjectReferenceRedirect` api in the typescript-plugin's SvelteKit language service. 