### PR TITLE
fix: respect tsconfig/jsconfig exclude patterns in file watcher

### DIFF
--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -145,18 +145,42 @@ async function getDiagnostics(
 
 class DiagnosticsWatcher {
     private updateDiagnostics: any;
+    private tsconfigCache: Map<string, { excludes: string[], mtime: number }> = new Map();
+    private tsconfigExcludes: string[] = [];
+    private svelteConfigPath?: string;
+    private svelteConfigMtime?: number;
+    private lastConfigCheck: number = 0;
+    private configCheckInterval: number = 5000; // Check every 5 seconds max
 
     constructor(
         private workspaceUri: URI,
         private svelteCheck: SvelteCheck,
         private writer: Writer,
         filePathsToIgnore: string[],
-        ignoreInitialAdd: boolean
+        ignoreInitialAdd: boolean,
+        private tsconfigPath?: string,
+        private respectTsconfigExcludes: boolean = true
     ) {
         const fileEnding = /\.(svelte|d\.ts|ts|js|jsx|tsx|mjs|cjs|mts|cts)$/;
         const viteConfigRegex = /vite\.config\.(js|ts)\.timestamp-/;
         const userIgnored = createIgnored(filePathsToIgnore);
         const offset = workspaceUri.fsPath.length + 1;
+        
+        // Look for svelte config
+        const possibleSvelteConfigs = ['svelte.config.js', 'svelte.config.mjs', 'svelte.config.cjs'];
+        for (const configName of possibleSvelteConfigs) {
+            const configPath = path.join(workspaceUri.fsPath, configName);
+            if (fs.existsSync(configPath)) {
+                this.svelteConfigPath = configPath;
+                this.svelteConfigMtime = fs.statSync(configPath).mtimeMs;
+                break;
+            }
+        }
+        
+        // Load initial tsconfig excludes
+        if (respectTsconfigExcludes && tsconfigPath) {
+            this.loadTsconfigExcludes();
+        }
 
         watch(workspaceUri.fsPath, {
             ignored: (path, stats) => {
@@ -168,12 +192,35 @@ class DiagnosticsWatcher {
                     return true;
                 }
 
+                const relativePath = path.slice(offset);
+
+                // Check user-specified ignores
                 if (userIgnored.length !== 0) {
-                    path = path.slice(offset);
                     for (const i of userIgnored) {
-                        if (i(path)) {
+                        if (i(relativePath)) {
                             return true;
                         }
+                    }
+                }
+
+                
+                for (const exclude of this.tsconfigExcludes) {
+                    if (exclude.endsWith('/**')) {
+                        const dir = exclude.slice(0, -3);
+                        if (relativePath.startsWith(dir + '/')) {
+                            return true;
+                        }
+                    } else if (exclude.includes('*')) {
+                        const regexPattern = exclude
+                            .replace(/\*\*/g, '.*')
+                            .replace(/\*/g, '[^/]*')
+                            .replace(/\./g, '\\.');
+                        const regex = new RegExp('^' + regexPattern + '$');
+                        if (regex.test(relativePath)) {
+                            return true;
+                        }
+                    } else if (relativePath.startsWith(exclude)) {
+                        return true;
                     }
                 }
 
@@ -213,9 +260,110 @@ class DiagnosticsWatcher {
     scheduleDiagnostics() {
         clearTimeout(this.updateDiagnostics);
         this.updateDiagnostics = setTimeout(
-            () => getDiagnostics(this.workspaceUri, this.writer, this.svelteCheck),
+            () => {
+                this.checkConfigReload(); // Check config periodically
+                getDiagnostics(this.workspaceUri, this.writer, this.svelteCheck);
+            },
             1000
         );
+    }
+    
+    private async loadTsconfigExcludes(): Promise<void> {
+        if (!this.tsconfigPath || !fs.existsSync(this.tsconfigPath)) {
+            return;
+        }
+        
+        try {
+            // Try to use TypeScript if available
+            const ts = await import('typescript');
+            const excludes = await this.parseWithTypeScript(ts, this.tsconfigPath);
+            this.tsconfigExcludes = excludes;
+        } catch (e) {
+            console.warn(`[svelte-check] Warning: Could not parse tsconfig excludes. TypeScript may not be installed or config may be invalid.`);
+            console.warn(`[svelte-check] Continuing without respecting tsconfig excludes.`);
+            this.tsconfigExcludes = [];
+        }
+    }
+    
+    private async parseWithTypeScript(ts: typeof import('typescript'), configPath: string): Promise<string[]> {
+        const excludes: string[] = [];
+        const visited = new Set<string>();
+        
+        const parseConfig = (filePath: string) => {
+            if (visited.has(filePath)) return;
+            visited.add(filePath);
+            
+            try {
+                const stat = fs.statSync(filePath);
+                this.tsconfigCache.set(filePath, { excludes: [], mtime: stat.mtimeMs });
+                
+                const configFile = ts.readConfigFile(filePath, ts.sys.readFile);
+                if (configFile.error) {
+                    console.warn(`[svelte-check] Warning: Error reading ${filePath}: ${configFile.error.messageText}`);
+                    return;
+                }
+                
+                const config = configFile.config;
+                
+                // Handle extends
+                if (config.extends) {
+                    const extendedPath = path.resolve(path.dirname(filePath), config.extends);
+                    if (fs.existsSync(extendedPath)) {
+                        parseConfig(extendedPath);
+                    } else if (fs.existsSync(extendedPath + '.json')) {
+                        parseConfig(extendedPath + '.json');
+                    }
+                }
+                
+                // Collect excludes
+                if (config.exclude && Array.isArray(config.exclude)) {
+                    excludes.push(...config.exclude);
+                }
+            } catch (e) {
+                console.warn(`[svelte-check] Warning: Error parsing ${filePath}:`, e);
+            }
+        };
+        
+        parseConfig(configPath);
+        return excludes;
+    }
+    
+    private checkConfigReload(): void {
+        if (!this.respectTsconfigExcludes || !this.tsconfigPath) {
+            return;
+        }
+        
+        const now = Date.now();
+        if (now - this.lastConfigCheck < this.configCheckInterval) {
+            return; // Skip check if we checked recently
+        }
+        this.lastConfigCheck = now;
+        
+        // Check if svelte config changed
+        if (this.svelteConfigPath && fs.existsSync(this.svelteConfigPath)) {
+            const currentMtime = fs.statSync(this.svelteConfigPath).mtimeMs;
+            if (currentMtime !== this.svelteConfigMtime) {
+                this.svelteConfigMtime = currentMtime;
+                this.tsconfigCache.clear();
+                this.loadTsconfigExcludes();
+                return;
+            }
+        }
+        
+        // Check if any cached config changed
+        for (const [filePath, cache] of this.tsconfigCache) {
+            if (!fs.existsSync(filePath)) {
+                this.tsconfigCache.clear();
+                this.loadTsconfigExcludes();
+                return;
+            }
+            const currentMtime = fs.statSync(filePath).mtimeMs;
+            if (currentMtime !== cache.mtime) {
+                this.tsconfigCache.clear();
+                this.loadTsconfigExcludes();
+                return;
+            }
+        }
     }
 }
 
@@ -270,7 +418,9 @@ parseOptions(async (opts) => {
                 new SvelteCheck(opts.workspaceUri.fsPath, svelteCheckOptions),
                 writer,
                 opts.filePathsToIgnore,
-                !!opts.tsconfig
+                !!opts.tsconfig,
+                opts.tsconfig,
+                opts.respectTsconfigExcludes
             );
         } else {
             const svelteCheck = new SvelteCheck(opts.workspaceUri.fsPath, svelteCheckOptions);

--- a/packages/svelte-check/src/options.ts
+++ b/packages/svelte-check/src/options.ts
@@ -14,6 +14,7 @@ export interface SvelteCheckCliOptions {
     compilerWarnings: Record<string, 'error' | 'ignore'>;
     diagnosticSources: DiagnosticSource[];
     threshold: Threshold;
+    respectTsconfigExcludes: boolean;
 }
 
 export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
@@ -65,6 +66,11 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
             'Filters the diagnostics to display. `error` will output only errors while `warning` will output warnings and errors.',
             'warning'
         )
+        .option(
+            '--ignore-tsconfig-excludes',
+            'Disable respecting tsconfig exclude patterns for file watching. By default, svelte-check respects tsconfig excludes to prevent watching unnecessary files.',
+            false
+        )
         // read by sade and preprocessor like sass
         .option('--color', 'Force enabling of color output', false)
         .option('--no-color', 'Force disabling of color output', false)
@@ -86,7 +92,8 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
                 failOnWarnings: !!opts['fail-on-warnings'],
                 compilerWarnings: getCompilerWarnings(opts),
                 diagnosticSources: getDiagnosticSources(opts),
-                threshold: getThreshold(opts)
+                threshold: getThreshold(opts),
+                respectTsconfigExcludes: !opts['ignore-tsconfig-excludes']
             });
         });
 


### PR DESCRIPTION
- Add support for tsconfig/jsconfig exclude patterns in watch mode
- Support extended configs with proper inheritance chain
- Dynamic config reloading with 5-second debounce
- Watch svelte.config.js changes for generated aliases
- Use async TypeScript import to avoid hard dependency
- Add --ignore-tsconfig-excludes CLI flag for backwards compatibility