### PR TITLE
chore: specify non-beta release as peer dependency for svelte@5

### DIFF
--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -33,7 +33,7 @@
         "sade": "^1.7.4"
     },
     "peerDependencies": {
-        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "svelte": "^4.0.0 || ^5.0.0",
         "typescript": ">=5.0.0"
     },
     "scripts": {


### PR DESCRIPTION
svelte-check does not currently accept the latest stable version of svelte as a peer dependency, but will fail gracefully with a warning. This PR should resolve that issue.