### PR TITLE
Return DocumentSymbol[] on textDocument/documentSymbol

### DIFF
--- a/packages/language-server/src/lib/documents/DocumentMapper.ts
+++ b/packages/language-server/src/lib/documents/DocumentMapper.ts
@@ -12,7 +12,8 @@ import {
     SelectionRange,
     TextEdit,
     InsertReplaceEdit,
-    Location
+    Location,
+    DocumentSymbol
 } from 'vscode-languageserver';
 import { TagInformation, offsetAt, positionAt, getLineOffsets } from './utils';
 import { Logger } from '../../logger';
@@ -353,9 +354,10 @@ export function mapColorPresentationToOriginal(
 
 export function mapSymbolInformationToOriginal(
     fragment: Pick<DocumentMapper, 'getOriginalPosition'>,
-    info: SymbolInformation
-): SymbolInformation {
-    return { ...info, location: mapObjWithRangeToOriginal(fragment, info.location) };
+    info: DocumentSymbol
+): DocumentSymbol {
+    const range = mapRangeToOriginal(fragment, info.range);
+    return { ...info, range, selectionRange: range };
 }
 
 export function mapLocationLinkToOriginal(

--- a/packages/language-server/src/plugins/PluginHost.ts
+++ b/packages/language-server/src/plugins/PluginHost.ts
@@ -35,7 +35,8 @@ import {
     TextEdit,
     WorkspaceEdit,
     InlayHint,
-    WorkspaceSymbol
+    WorkspaceSymbol,
+    DocumentSymbol
 } from 'vscode-languageserver';
 import { DocumentManager, getNodeIfIsInHTMLStartTag } from '../lib/documents';
 import { Logger } from '../logger';
@@ -298,7 +299,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
     async getDocumentSymbols(
         textDocument: TextDocumentIdentifier,
         cancellationToken: CancellationToken
-    ): Promise<SymbolInformation[]> {
+    ): Promise<DocumentSymbol[]> {
         const document = this.getDocument(textDocument.uri);
 
         // VSCode requested document symbols twice for the outline view and the sticky scroll
@@ -308,7 +309,7 @@ export class PluginHost implements LSProvider, OnWatchFileChanges {
             return [];
         }
         return flatten(
-            await this.execute<SymbolInformation[]>(
+            await this.execute<DocumentSymbol[]>(
                 'getDocumentSymbols',
                 [document, cancellationToken],
                 ExecuteMode.Collect,

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -50,7 +50,7 @@ import { getIdClassCompletion } from './features/getIdClassCompletion';
 import { AttributeContext, getAttributeContextAtPosition } from '../../lib/documents/parseHtml';
 import { StyleAttributeDocument } from './StyleAttributeDocument';
 import { getDocumentContext } from '../documentContext';
-import { FoldingRange, FoldingRangeKind } from 'vscode-languageserver-types';
+import { DocumentSymbol, FoldingRange, FoldingRangeKind } from 'vscode-languageserver-types';
 import { indentBasedFoldingRangeForTag } from '../../lib/foldingRange/indentFolding';
 import { wordHighlightForTag } from '../../lib/documentHighlight/wordHighlight';
 import { isNotNullOrUndefined, urlToPath } from '../../utils';
@@ -362,7 +362,7 @@ export class CSSPlugin
             .map((colorPres) => mapColorPresentationToOriginal(cssDocument, colorPres));
     }
 
-    getDocumentSymbols(document: Document): SymbolInformation[] {
+    getDocumentSymbols(document: Document): DocumentSymbol[] {
         if (!this.featureEnabled('documentColors')) {
             return [];
         }
@@ -373,20 +373,14 @@ export class CSSPlugin
             return [];
         }
 
-        return this.getLanguageService(extractLanguage(cssDocument))
-            .findDocumentSymbols(cssDocument, cssDocument.stylesheet)
-            .map((symbol) => {
-                if (!symbol.containerName) {
-                    return {
-                        ...symbol,
-                        // TODO: this could contain other things, e.g. style.myclass
-                        containerName: 'style'
-                    };
-                }
+        function mapSymbol(symbol: DocumentSymbol) {
+            symbol.children = symbol.children?.map(mapSymbol);
+            return mapSymbolInformationToOriginal(cssDocument, symbol);
+        }
 
-                return symbol;
-            })
-            .map((symbol) => mapSymbolInformationToOriginal(cssDocument, symbol));
+        return this.getLanguageService(extractLanguage(cssDocument))
+            .findDocumentSymbols2(cssDocument, cssDocument.stylesheet)
+            .map(mapSymbol);
     }
 
     getFoldingRanges(document: Document): FoldingRange[] {

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -10,7 +10,6 @@ import {
     CompletionList,
     Hover,
     Position,
-    SymbolInformation,
     CompletionItem,
     CompletionItemKind,
     TextEdit,
@@ -19,7 +18,8 @@ import {
     LinkedEditingRanges,
     CompletionContext,
     FoldingRange,
-    DocumentHighlight
+    DocumentHighlight,
+    DocumentSymbol
 } from 'vscode-languageserver';
 import {
     DocumentManager,
@@ -300,7 +300,7 @@ export class HTMLPlugin
         return isInsideMoustacheTag(document.getText(), node.start, offset);
     }
 
-    getDocumentSymbols(document: Document): SymbolInformation[] {
+    getDocumentSymbols(document: Document): DocumentSymbol[] {
         if (!this.featureEnabled('documentSymbols')) {
             return [];
         }
@@ -310,7 +310,7 @@ export class HTMLPlugin
             return [];
         }
 
-        return this.lang.findDocumentSymbols(document, html);
+        return this.lang.findDocumentSymbols2(document, html);
     }
 
     rename(document: Document, position: Position, newName: string): WorkspaceEdit | null {

--- a/packages/language-server/src/plugins/interfaces.ts
+++ b/packages/language-server/src/plugins/interfaces.ts
@@ -22,6 +22,7 @@ import {
     DefinitionLink,
     Diagnostic,
     DocumentHighlight,
+    DocumentSymbol,
     FoldingRange,
     FormattingOptions,
     Hover,
@@ -97,7 +98,7 @@ export interface DocumentSymbolsProvider {
     getDocumentSymbols(
         document: Document,
         cancellationToken?: CancellationToken
-    ): Resolvable<SymbolInformation[]>;
+    ): Resolvable<DocumentSymbol[]>;
 }
 
 export interface DefinitionsProvider {

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -69,9 +69,9 @@ describe('TypescriptPlugin', function () {
             .map((s) => ({ ...s, name: harmonizeNewLines(s.name) }))
             .sort(
                 (s1, s2) =>
-                    s1.location.range.start.line * 100 +
-                    s1.location.range.start.character -
-                    (s2.location.range.start.line * 100 + s2.location.range.start.character)
+                    s1.range.start.line * 100 +
+                    s1.range.start.character -
+                    (s2.range.start.line * 100 + s2.range.start.character)
             );
 
         assert.deepStrictEqual(symbols, [


### PR DESCRIPTION
Closes https://github.com/sveltejs/language-tools/issues/1519

Return hierarchical `DocumentSymbol` instead of the deprecated `SymbolInformation`, useful for breadcrumb feature in various clients.

<details><summary> Screenshots from Emacs with LSP-Bridge </summary>
<p>

<img width="936" height="600" alt="Screenshot From 2025-08-08 03-47-37" src="https://github.com/user-attachments/assets/42299597-5f14-4b80-b2b5-565e7c3732ca" />

<img width="936" height="600" alt="Screenshot From 2025-08-08 03-49-38" src="https://github.com/user-attachments/assets/ae998cea-b37d-4bcd-88b9-3003f743097c" />

<img width="928" height="580" alt="Screenshot From 2025-08-08 04-04-56" src="https://github.com/user-attachments/assets/07b5d5c9-28a2-4d43-b450-c12389a1ec31" />

</p>
</details> 

