### PR TITLE
(deps) Replace `pascal-case` with `scule` (Maintained & Lighter)

### DIFF
--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -66,6 +66,6 @@
     ],
     "dependencies": {
         "dedent-js": "^1.0.1",
-        "pascal-case": "^3.1.1"
+        "scule": "^1.3.0"
     }
 }

--- a/packages/svelte2tsx/rollup.config.mjs
+++ b/packages/svelte2tsx/rollup.config.mjs
@@ -107,7 +107,7 @@ export default [
             'svelte',
             'svelte/compiler',
             'dedent-js',
-            'pascal-case'
+            'scule'
         ]
     }
 ];

--- a/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/addComponentExport.ts
@@ -1,4 +1,4 @@
-import { pascalCase } from 'pascal-case';
+import { pascalCase } from 'scule';
 import path from 'path';
 import MagicString from 'magic-string';
 import { ExportedNames } from './nodes/ExportedNames';
@@ -380,7 +380,7 @@ function classNameFromFilename(filename: string, appendSuffix: boolean): string 
         const withoutInvalidCharacters = withoutExtensions
             .split('')
             // Although "-" is invalid, we leave it in, pascal-case-handling will throw it out later
-            .filter((char) => /[A-Za-z$_\d-]/.test(char))
+            .filter((char) => /[A-Za-z_\d-]/.test(char))
             .join('');
         const firstValidCharIdx = withoutInvalidCharacters
             .split('')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,9 @@ importers:
       dedent-js:
         specifier: ^1.0.1
         version: 1.0.1
-      pascal-case:
-        specifier: ^3.1.1
-        version: 3.1.2
+      scule:
+        specifier: ^1.3.0
+        version: 1.3.0
     devDependencies:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.5.0
@@ -1332,9 +1332,6 @@ packages:
   loupe@3.1.4:
     resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
 
-  lower-case@2.0.2:
-    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
-
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -1405,9 +1402,6 @@ packages:
   nise@5.1.4:
     resolution: {integrity: sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==}
 
-  no-case@3.0.4:
-    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -1426,9 +1420,6 @@ packages:
   p-map@3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
     engines: {node: '>=8'}
-
-  pascal-case@3.1.2:
-    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1564,6 +1555,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
   semver@7.5.1:
     resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
@@ -2789,10 +2783,6 @@ snapshots:
 
   loupe@3.1.4: {}
 
-  lower-case@2.0.2:
-    dependencies:
-      tslib: 2.5.2
-
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -2881,11 +2871,6 @@ snapshots:
       just-extend: 4.2.1
       path-to-regexp: 1.8.0
 
-  no-case@3.0.4:
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.5.2
-
   normalize-path@3.0.0: {}
 
   once@1.4.0:
@@ -2903,11 +2888,6 @@ snapshots:
   p-map@3.0.0:
     dependencies:
       aggregate-error: 3.1.0
-
-  pascal-case@3.1.2:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.5.2
 
   path-exists@4.0.0: {}
 
@@ -3048,6 +3028,8 @@ snapshots:
       mri: 1.2.0
 
   safe-buffer@5.2.1: {}
+
+  scule@1.3.0: {}
 
   semver@7.5.1:
     dependencies:


### PR DESCRIPTION
This PR replaces the unmaintained `pascal-case` package with a recommended one, `scule`.

#### **Why?**
- `pascal-case@3.1.1` is outdated, and `4.0.0` is deprecated.
- `scule` has **0 dependencies** and a smaller total footprint.

#### **Comparison:**
| Package       | Size  | Dependencies | Total Size |
|--------------|-------|-------------|------------|
| pascal-case  | 14KB  | 2 (`no-case` 25KB, `lower-case` 17KB) | **56KB** |
| scule  | 29KB  | 0 | **29KB** |

✅ **Net win**: Fewer dependencies, lower size, and a more future-proof solution.

---

One adjustment, before `Test3$$PropsProps` was stripping `$$` in the middle, not with scule. So I had to tweak the regex.

Playground to see;
https://svelte.dev/playground/96bd32583b4d45bf838699550bc795a7?version=5.38.7