### PR TITLE
perf: use failed path to invalidate module cache

### DIFF
--- a/.changeset/dark-falcons-pump.md
+++ b/.changeset/dark-falcons-pump.md
@@ -1,0 +1,6 @@
+---
+'svelte-language-server': patch
+'svelte-check': patch
+---
+
+perf: more precise module cache invalidation

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -10,7 +10,7 @@
         "./bin/server.js": "./bin/server.js"
     },
     "scripts": {
-        "test": "cross-env TS_NODE_TRANSPILE_ONLY=true mocha --require ts-node/register \"test/**/*.test.ts\"",
+        "test": "cross-env TS_NODE_TRANSPILE_ONLY=true mocha --require ts-node/register \"test/**/*.test.ts\" --no-experimental-strip-types",
         "build": "tsc",
         "prepublishOnly": "npm run build",
         "watch": "tsc -w"

--- a/packages/language-server/src/lib/documents/DocumentManager.ts
+++ b/packages/language-server/src/lib/documents/DocumentManager.ts
@@ -50,14 +50,13 @@ export class DocumentManager {
             // open state should only be updated when the document is closed
             document.openedByClient ||= openedByClient;
             document.setText(textDocument.text);
+            this.notify('documentChange', document);
         } else {
             document = this.createDocument(textDocument);
             document.openedByClient = openedByClient;
             this.documents.set(textDocument.uri, document);
             this.notify('documentOpen', document);
         }
-
-        this.notify('documentChange', document);
 
         return document;
     }

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -99,9 +99,11 @@ export class CSSPlugin
             this.updateConfigs();
         });
 
-        docManager.on('documentChange', (document) =>
-            this.cssDocuments.set(document, new CSSDocument(document, this.cssLanguageServices))
-        );
+        const sync = (document: Document) => {
+            this.cssDocuments.set(document, new CSSDocument(document, this.cssLanguageServices));
+        };
+        docManager.on('documentChange', sync);
+        docManager.on('documentOpen', sync);
         docManager.on('documentClose', (document) => this.cssDocuments.delete(document));
     }
 

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -76,9 +76,11 @@ export class HTMLPlugin
         configManager.onChange(() =>
             this.lang.setDataProviders(false, this.getCustomDataProviders())
         );
-        docManager.on('documentChange', (document) => {
+        const sync = (document: Document) => {
             this.documents.set(document, document.html);
-        });
+        };
+        docManager.on('documentChange', sync);
+        docManager.on('documentOpen', sync);
     }
 
     doHover(document: Document, position: Position): Hover | null {

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -371,7 +371,7 @@ export function createSvelteModuleLoader(
         });
 
         if (toRemoves.length) {
-            moduleCache.deleteByValues(Array.from(toRemoves));
+            moduleCache.deleteByValues(toRemoves);
             resolutionWithFailedLookup.forEach((r) => {
                 if (toRemoves.includes(r)) {
                     resolutionWithFailedLookup.delete(r);

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -7,7 +7,8 @@ import {
     ensureRealSvelteFilePath,
     getExtensionFromScriptKind,
     isSvelteFilePath,
-    isVirtualSvelteFilePath
+    isVirtualSvelteFilePath,
+    toVirtualSvelteFilePath
 } from './utils';
 
 const CACHE_KEY_SEPARATOR = ':::';
@@ -15,7 +16,7 @@ const CACHE_KEY_SEPARATOR = ':::';
  * Caches resolved modules.
  */
 class ModuleResolutionCache {
-    private cache = new FileMap<ts.ResolvedModule | undefined>();
+    private cache = new FileMap<ts.ResolvedModuleWithFailedLookupLocations>();
     private pendingInvalidations = new FileSet();
     private getCanonicalFileName = createGetCanonicalFileName(ts.sys.useCaseSensitiveFileNames);
 
@@ -23,7 +24,10 @@ class ModuleResolutionCache {
      * Tries to get a cached module.
      * Careful: `undefined` can mean either there's no match found, or that the result resolved to `undefined`.
      */
-    get(moduleName: string, containingFile: string): ts.ResolvedModule | undefined {
+    get(
+        moduleName: string,
+        containingFile: string
+    ): ts.ResolvedModuleWithFailedLookupLocations | undefined {
         return this.cache.get(this.getKey(moduleName, containingFile));
     }
 
@@ -37,7 +41,11 @@ class ModuleResolutionCache {
     /**
      * Caches resolved module (or undefined).
      */
-    set(moduleName: string, containingFile: string, resolvedModule: ts.ResolvedModule | undefined) {
+    set(
+        moduleName: string,
+        containingFile: string,
+        resolvedModule: ts.ResolvedModuleWithFailedLookupLocations
+    ) {
         this.cache.set(this.getKey(moduleName, containingFile), resolvedModule);
     }
 
@@ -48,7 +56,11 @@ class ModuleResolutionCache {
     delete(resolvedModuleName: string): void {
         resolvedModuleName = this.getCanonicalFileName(resolvedModuleName);
         this.cache.forEach((val, key) => {
-            if (val && this.getCanonicalFileName(val.resolvedFileName) === resolvedModuleName) {
+            if (
+                val.resolvedModule &&
+                this.getCanonicalFileName(val.resolvedModule.resolvedFileName) ===
+                    resolvedModuleName
+            ) {
                 this.cache.delete(key);
                 this.pendingInvalidations.add(key.split(CACHE_KEY_SEPARATOR).shift() || '');
             }
@@ -59,17 +71,10 @@ class ModuleResolutionCache {
      * Deletes everything from cache that resolved to `undefined`
      * and which might match the path.
      */
-    deleteUnresolvedResolutionsFromCache(path: string): void {
-        const fileNameWithoutEnding =
-            getLastPartOfPath(this.getCanonicalFileName(path)).split('.').shift() || '';
+    deleteByValues(list: ts.ResolvedModuleWithFailedLookupLocations[]): void {
         this.cache.forEach((val, key) => {
-            if (val) {
-                return;
-            }
-            const [containingFile, moduleName = ''] = key.split(CACHE_KEY_SEPARATOR);
-            if (moduleName.includes(fileNameWithoutEnding)) {
+            if (list.includes(val)) {
                 this.cache.delete(key);
-                this.pendingInvalidations.add(containingFile);
             }
         });
     }
@@ -181,13 +186,13 @@ export function createSvelteModuleLoader(
             svelteSys.deleteFromCache(path);
             moduleCache.delete(path);
         },
-        deleteUnresolvedResolutionsFromCache: (path: string) => {
+        scheduleResolutionFailedLocationCheck: (path: string) => {
             svelteSys.deleteFromCache(path);
-            moduleCache.deleteUnresolvedResolutionsFromCache(path);
-            pendingFailedLocationCheck.add(path);
-
-            tsModuleCache.clear();
-            typeReferenceCache.clear();
+            if (isSvelteFilePath(path)) {
+                pendingFailedLocationCheck.add(toVirtualSvelteFilePath(path));
+            } else {
+                pendingFailedLocationCheck.add(path);
+            }
         },
         resolveModuleNames,
         resolveTypeReferenceDirectiveReferences,
@@ -206,8 +211,9 @@ export function createSvelteModuleLoader(
         containingSourceFile?: ts.SourceFile | undefined
     ): Array<ts.ResolvedModule | undefined> {
         return moduleNames.map((moduleName, index) => {
-            if (moduleCache.has(moduleName, containingFile)) {
-                return moduleCache.get(moduleName, containingFile);
+            const cached = moduleCache.get(moduleName, containingFile);
+            if (cached) {
+                return cached.resolvedModule;
             }
 
             const resolvedModule = resolveModuleName(
@@ -221,7 +227,7 @@ export function createSvelteModuleLoader(
 
             cacheResolutionWithFailedLookup(resolvedModule, containingFile);
 
-            moduleCache.set(moduleName, containingFile, resolvedModule?.resolvedModule);
+            moduleCache.set(moduleName, containingFile, resolvedModule);
             return resolvedModule?.resolvedModule;
         });
     }
@@ -347,17 +353,15 @@ export function createSvelteModuleLoader(
     }
 
     function invalidateFailedLocationResolution() {
+        const toRemoves: ts.ResolvedModuleWithFailedLookupLocations[] = [];
         resolutionWithFailedLookup.forEach((resolvedModule) => {
-            if (
-                !resolvedModule.resolvedModule ||
-                !resolvedModule.files ||
-                !resolvedModule.failedLookupLocations
-            ) {
+            if (!resolvedModule.failedLookupLocations) {
                 return;
             }
+
             for (const location of resolvedModule.failedLookupLocations) {
                 if (pendingFailedLocationCheck.has(location)) {
-                    moduleCache.delete(resolvedModule.resolvedModule.resolvedFileName);
+                    toRemoves.push(resolvedModule);
                     resolvedModule.files?.forEach((file) => {
                         failedLocationInvalidated.add(file);
                     });
@@ -366,6 +370,16 @@ export function createSvelteModuleLoader(
             }
         });
 
+        if (toRemoves.length) {
+            moduleCache.deleteByValues(Array.from(toRemoves));
+            resolutionWithFailedLookup.forEach((r) => {
+                if (toRemoves.includes(r)) {
+                    resolutionWithFailedLookup.delete(r);
+                }
+            });
+            tsModuleCache.clear();
+            tsTypeReferenceDirectiveCache.clear();
+        }
         pendingFailedLocationCheck.clear();
     }
 }

--- a/packages/language-server/test/lib/documents/DocumentManager.test.ts
+++ b/packages/language-server/test/lib/documents/DocumentManager.test.ts
@@ -68,19 +68,6 @@ describe('Document Manager', () => {
         assert.throws(() => manager.updateDocument(textDocument, []));
     });
 
-    it('emits a document change event on open and update', () => {
-        const manager = new DocumentManager(createTextDocument);
-        const cb = sinon.spy();
-
-        manager.on('documentChange', cb);
-
-        manager.openClientDocument(textDocument);
-        sinon.assert.calledOnce(cb);
-
-        manager.updateDocument(textDocument, []);
-        sinon.assert.calledTwice(cb);
-    });
-
     it('update document in case-insensitive fs with different casing', () => {
         const textDocument: TextDocumentItem = {
             uri: 'file:///hello2.svelte',

--- a/packages/language-server/test/plugins/typescript/testfiles/diagnostics/unresolvedimport2.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/diagnostics/unresolvedimport2.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+  import foo from './doesntexistyet.svelte';
+  foo;
+</script>


### PR DESCRIPTION
Alternative to the module cache handling of #2852. Still have to check why the "adding all missing imports" test failed in local.