### PR TITLE
fix: prevent file watcher issue 

### DIFF
--- a/.changeset/green-adults-hammer.md
+++ b/.changeset/green-adults-hammer.md
@@ -1,0 +1,5 @@
+---
+'svelte-check': patch
+---
+
+fix: prevent file watcher issue

--- a/.changeset/thirty-seas-post.md
+++ b/.changeset/thirty-seas-post.md
@@ -1,0 +1,6 @@
+---
+'svelte-language-server': patch
+'svelte-check': patch
+---
+
+perf: check if file content changed in tsconfig file watch


### PR DESCRIPTION
For #2855 and #2858

The issue happens when there is a file loaded in the parent directory of a tsconfig.json include directory. For example, vite.config.ts. It also depends on the order in which the file is loaded. 