### PR TITLE
fix: skipLibCheck in svelte-check smoke test

### DIFF
--- a/packages/svelte-check/test/tsconfig.json
+++ b/packages/svelte-check/test/tsconfig.json
@@ -4,7 +4,8 @@
         "moduleResolution": "node",
         "strict": true,
         "allowJs": true,
-        "checkJs": true
+        "checkJs": true,
+        "skipLibCheck": true
     },
     "files": ["./Index.svelte"]
 }


### PR DESCRIPTION
The svelte-check test/build currently failed because esrap imports can't be found under `moduleResolution: node`, and there is also a problem with `esrap` references `@typescript-eslint/types` in the .d.ts. Enable `skipLibCheck` at least for now. Hopefully, we can re-enable it later to catch problems like this.