### PR TITLE
Remove outdated "experimental-modules" runtime flag

### DIFF
--- a/.changeset/long-cups-lie.md
+++ b/.changeset/long-cups-lie.md
@@ -1,5 +1,0 @@
----
-'svelte-vscode': patch
----
-
-Removed outdated usage of "experimental-modules" runtime flag in svelte-vscode package


### PR DESCRIPTION
Based on the comments in the code it seems like this is ready to be removed