### PR TITLE
[perf]: early return in getCompletions if in style or script tag

### DIFF
--- a/.changeset/big-cheetahs-admire.md
+++ b/.changeset/big-cheetahs-admire.md
@@ -1,5 +1,5 @@
 ---
-"svelte-language-server": patch
+'svelte-language-server': patch
 ---
 
 [perf]: move return statement in `getCompletions` so it returns immediately if possible

--- a/packages/language-server/src/plugins/svelte/features/getCompletions.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCompletions.ts
@@ -37,7 +37,7 @@ export function getCompletions(
     if (inStyleOrScript(svelteDoc, position)) {
         return null;
     }
-    
+
     const offset = svelteDoc.offsetAt(position);
     const lastCharactersBeforePosition = svelteDoc
         .getText()


### PR DESCRIPTION
I don't think this alone will provide any noticeable gains in performance, but it can still be done, and when working with LSP's i have a feeling everything counts