### PR TITLE
perf: optimize path normalization

### DIFF
--- a/.changeset/cozy-foxes-shine.md
+++ b/.changeset/cozy-foxes-shine.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+perf: optimize path normalization

--- a/packages/language-server/src/plugins/typescript/module-loader.ts
+++ b/packages/language-server/src/plugins/typescript/module-loader.ts
@@ -88,7 +88,7 @@ class ModuleResolutionCache {
     }
 
     oneOfResolvedModuleChanged(path: string) {
-        return this.pendingInvalidations.has(path);
+        return this.pendingInvalidations.size > 0 && this.pendingInvalidations.has(path);
     }
 }
 
@@ -325,7 +325,7 @@ export function createSvelteModuleLoader(
         return (
             moduleCache.oneOfResolvedModuleChanged(path) ||
             // tried but failed file might now exist
-            failedLocationInvalidated.has(path)
+            (failedLocationInvalidated.size > 0 && failedLocationInvalidated.has(path))
         );
     }
 

--- a/packages/language-server/src/utils.ts
+++ b/packages/language-server/src/utils.ts
@@ -1,8 +1,7 @@
-import { isEqual, sum, uniqWith } from 'lodash';
-import { FoldingRange, Node } from 'vscode-html-languageservice';
+import { isEqual, uniqWith } from 'lodash';
+import { Node } from 'vscode-html-languageservice';
 import { Position, Range } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
-import { Document, TagInformation } from './lib/documents';
 
 type Predicate<T> = (x: T) => boolean;
 
@@ -38,12 +37,27 @@ export function pathToUrl(path: string) {
     return URI.file(path).toString();
 }
 
+const backslashRegEx = /\\/g;
+
 /**
  * Some paths (on windows) start with a upper case driver letter, some don't.
  * This is normalized here.
  */
 export function normalizePath(path: string): string {
-    return URI.file(path).fsPath.replace(/\\/g, '/');
+    return normalizeDriveLetter(path.replace(backslashRegEx, '/'));
+}
+
+function normalizeDriveLetter(path: string): string {
+    if (path.charCodeAt(1) !== /*:*/ 58) {
+        return path;
+    }
+
+    const driveLetter = path.charCodeAt(0);
+    if (driveLetter >= /*A*/ 65 && driveLetter <= /*Z*/ 90) {
+        return String.fromCharCode(driveLetter + 32) + path.slice(1);
+    }
+
+    return path;
 }
 
 /**

--- a/packages/language-server/test/utils.test.ts
+++ b/packages/language-server/test/utils.test.ts
@@ -1,6 +1,12 @@
-import { isBeforeOrEqualToPosition, modifyLines, regexLastIndexOf } from '../src/utils';
+import {
+    isBeforeOrEqualToPosition,
+    modifyLines,
+    normalizePath,
+    regexLastIndexOf
+} from '../src/utils';
 import { Position } from 'vscode-languageserver';
 import * as assert from 'assert';
+import { URI } from 'vscode-uri';
 
 describe('utils', () => {
     describe('#isBeforeOrEqualToPosition', () => {
@@ -59,6 +65,30 @@ describe('utils', () => {
                 return _;
             });
             assert.deepStrictEqual(idxs, [0, 1, 2, 3]);
+        });
+    });
+
+    describe('path normalization on Windows', () => {
+        it('should lowercase drive letters and normalize slashes', () => {
+            assert.strictEqual(
+                normalizePath('C:\\Users\\Test\\project\\file.ts'),
+                'c:/Users/Test/project/file.ts'
+            );
+
+            assert.strictEqual(
+                normalizePath('D:/Some/Other/Path/file.ts'),
+                'd:/Some/Other/Path/file.ts'
+            );
+
+            assert.strictEqual(
+                normalizePath('e:\\Mixed/Slashes\\Path/file.ts'),
+                'e:/Mixed/Slashes/Path/file.ts'
+            );
+
+            assert.strictEqual(
+                normalizePath('/already/normalized/path/file.ts'),
+                '/already/normalized/path/file.ts'
+            );
         });
     });
 });


### PR DESCRIPTION
Similar to #2902. The path normalisation and lowercasing can be expensive when there are a lot of files. This replaces the URI normalisation method with a custom function. A 100k times normalisation benchmark on my machine reduces the time from 85ms to 24ms. This also changed a few places to reduce normalisation when unnecessary. 