### PR TITLE
fix: add some limit to store auto-import

### DIFF
--- a/.changeset/gentle-seals-send.md
+++ b/.changeset/gentle-seals-send.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+fix: add some limit to store auto-import


### PR DESCRIPTION
The original plan was to have a more precise check to see if the variable actually has a `subscribe` method. Although it works, the check is costly and sometimes is slower than the auto-import itself. So this only adds a few constraints.

- It needs to be a variable and not a component. Although a class with a `static subscribe` method might work, we need the type check to check this, and it is probably rare.
- It doesn't already start with '$' because it's either a rune or an invalid import.
- It needs to be an auto-import. Not a global/DOM variable