### PR TITLE
fix: add tokenTypes config for triggering JSDoc completion

### DIFF
--- a/packages/svelte-vscode/package.json
+++ b/packages/svelte-vscode/package.json
@@ -473,7 +473,14 @@
                     "keyword.operator.bitwise.shift",
                     "meta.brace.angle",
                     "punctuation.definition.tag"
-                ]
+                ],
+                "tokenTypes": {
+                    "punctuation.definition.template-expression": "other",
+                    "entity.name.type.instance.jsdoc": "other",
+                    "entity.name.function.tagged-template": "other",
+                    "meta.import string.quoted": "other",
+                    "variable.other.jsdoc": "other"
+                }
             },
             {
                 "scopeName": "svelte.pug",


### PR DESCRIPTION
For #2915. Copied the tokenTypes config from VSCode's JavaScript extension. Another benefit is that this also enables bracket colorization inside JSdoc and template strings

Before
<img width="865" height="131" alt="圖片" src="https://github.com/user-attachments/assets/c974a064-e781-4ee3-add5-89c89e8c3373" />

After.
<img width="967" height="138" alt="圖片" src="https://github.com/user-attachments/assets/150bd4b5-ae77-4b92-bcb2-6762ed7d6c6d" />
