### PR TITLE
perf: only parse html once in a batch update

### DIFF
--- a/.changeset/brave-ghosts-draw.md
+++ b/.changeset/brave-ghosts-draw.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+perf: only parse html once in a batch update

--- a/packages/language-server/src/lib/documents/DocumentManager.ts
+++ b/packages/language-server/src/lib/documents/DocumentManager.ts
@@ -124,18 +124,7 @@ export class DocumentManager {
             throw new Error('Cannot call methods on an unopened document');
         }
 
-        for (const change of changes) {
-            let start = 0;
-            let end = 0;
-            if ('range' in change) {
-                start = document.offsetAt(change.range.start);
-                end = document.offsetAt(change.range.end);
-            } else {
-                end = document.getTextLength();
-            }
-
-            document.update(change.text, start, end);
-        }
+        document.update(changes);
 
         this.notify('documentChange', document);
     }

--- a/packages/language-server/test/lib/documents/Document.test.ts
+++ b/packages/language-server/test/lib/documents/Document.test.ts
@@ -20,7 +20,12 @@ describe('Document', () => {
 
         document.setText('Hello, world!');
         assert.strictEqual(document.version, 1);
-        document.update('svelte', 7, 12);
+        document.update([
+            {
+                text: 'svelte',
+                range: { start: { line: 0, character: 7 }, end: { line: 0, character: 12 } }
+            }
+        ]);
         assert.strictEqual(document.version, 2);
     });
 
@@ -77,8 +82,28 @@ describe('Document', () => {
 
     it('updates the text range', () => {
         const document = new Document('file:///hello.svelte', 'Hello, world!');
-        document.update('svelte', 7, 12);
+        document.update([
+            {
+                text: 'svelte',
+                range: { start: { line: 0, character: 7 }, end: { line: 0, character: 12 } }
+            }
+        ]);
         assert.strictEqual(document.getText(), 'Hello, svelte!');
+    });
+
+    it('updates multiple text ranges', () => {
+        const document = new Document('file:///hello.svelte', 'Hello, world! This is a test.');
+        document.update([
+            {
+                text: 'example',
+                range: { start: { line: 0, character: 24 }, end: { line: 0, character: 28 } }
+            },
+            {
+                text: 'Svelte!\n',
+                range: { start: { line: 0, character: 7 }, end: { line: 0, character: 13 } }
+            }
+        ]);
+        assert.strictEqual(document.getText(), 'Hello, Svelte!\n This is a example.');
     });
 
     it('gets the correct position from offset', () => {

--- a/packages/language-server/test/lib/documents/DocumentManager.test.ts
+++ b/packages/language-server/test/lib/documents/DocumentManager.test.ts
@@ -26,20 +26,17 @@ describe('Document Manager', () => {
 
     it('updates the whole document', () => {
         const document = createTextDocument(textDocument);
-        const update = sinon.spy(document, 'update');
         const createDocument = sinon.stub().returns(document);
         const manager = new DocumentManager(createDocument);
 
         manager.openClientDocument(textDocument);
         manager.updateDocument(textDocument, [{ text: 'New content' }]);
 
-        sinon.assert.calledOnce(update);
-        sinon.assert.calledWith(update.firstCall, 'New content', 0, textDocument.text.length);
+        assert.strictEqual(document.getText(), 'New content');
     });
 
     it('updates the parts of the document', () => {
         const document = createTextDocument(textDocument);
-        const update = sinon.spy(document, 'update');
         const createDocument = sinon.stub().returns(document);
         const manager = new DocumentManager(createDocument);
 
@@ -57,9 +54,7 @@ describe('Document Manager', () => {
             }
         ]);
 
-        sinon.assert.calledTwice(update);
-        sinon.assert.calledWith(update.firstCall, 'svelte', 7, 12);
-        sinon.assert.calledWith(update.secondCall, 'Greetings', 0, 5);
+        assert.strictEqual(document.getText(), 'Greetings, svelte!');
     });
 
     it("fails to update if document isn't open", () => {

--- a/packages/language-server/test/plugins/typescript/service.test.ts
+++ b/packages/language-server/test/plugins/typescript/service.test.ts
@@ -273,7 +273,12 @@ describe('service', () => {
         lang.getProgram();
 
         // ensure updated document also works
-        document2.update(' ', 0, 0);
+        document2.update([
+            {
+                text: ' ',
+                range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }
+            }
+        ]);
         lang.getProgram();
 
         assert.doesNotThrow(() => {
@@ -327,7 +332,7 @@ describe('service', () => {
         const lang = ls.getService();
         lang.getProgram();
 
-        document2.update('<script', 0, document2.getTextLength());
+        document2.update([{ text: '<script' }]);
         ls.updateSnapshot(document2);
         ls.getService();
     });


### PR DESCRIPTION
Should only be a sub-second difference in most cases. If there are a lot of changes, VSCode will send a single big change. 