### PR TITLE
fix: apply text synchronize change in order

### DIFF
--- a/.changeset/fifty-hairs-wish.md
+++ b/.changeset/fifty-hairs-wish.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+fix: apply text synchronize change in order

--- a/packages/language-server/test/lib/documents/Document.test.ts
+++ b/packages/language-server/test/lib/documents/Document.test.ts
@@ -91,7 +91,8 @@ describe('Document', () => {
         assert.strictEqual(document.getText(), 'Hello, svelte!');
     });
 
-    it('updates multiple text ranges', () => {
+    it('updates multiple text ranges (end to start)', () => {
+        // offset can be calculated by the original document content
         const document = new Document('file:///hello.svelte', 'Hello, world! This is a test.');
         document.update([
             {
@@ -101,6 +102,22 @@ describe('Document', () => {
             {
                 text: 'Svelte!\n',
                 range: { start: { line: 0, character: 7 }, end: { line: 0, character: 13 } }
+            }
+        ]);
+        assert.strictEqual(document.getText(), 'Hello, Svelte!\n This is a example.');
+    });
+
+    it('updates multiple text ranges (start to end)', () => {
+        // offset needs to be recalculated after applying each edit
+        const document = new Document('file:///hello.svelte', 'Hello, world! This is a test.');
+        document.update([
+            {
+                text: 'Svelte!\n',
+                range: { start: { line: 0, character: 7 }, end: { line: 0, character: 13 } }
+            },
+            {
+                text: 'example',
+                range: { start: { line: 1, character: 11 }, end: { line: 1, character: 15 } }
             }
         ]);
         assert.strictEqual(document.getText(), 'Hello, Svelte!\n This is a example.');


### PR DESCRIPTION
Part of the optimisation in #2923 doesn't work in neovim. Unlike VSCode, the order of the changes is from start to end. 

LSP spec permits both kinds of changes. It can be "end to start" (descending) or "start to end"(ascending). I missed the JSDoc in the spec that the position should be recalculated after applying the change. If it's "end to start", then the position can be calculated with the original content, but it can't when it's "start to end"
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange