### PR TITLE
FIX: svelte-check --watch crashes on unix domain sockets

### DIFF
--- a/.changeset/fix-unix-sockets.md
+++ b/.changeset/fix-unix-sockets.md
@@ -1,0 +1,5 @@
+---
+'svelte-check': patch
+---
+
+fix: ignore Unix domain sockets in file watcher to prevent crashes

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -168,6 +168,7 @@ class DiagnosticsWatcher {
                 if (
                     path.includes('node_modules') ||
                     path.includes('.git') ||
+                    stats?.isSocket() ||
                     (stats?.isFile() &&
                         (!FILE_ENDING_REGEX.test(path) || VITE_CONFIG_REGEX.test(path)))
                 ) {


### PR DESCRIPTION
Process management tools like [overmind](https://github.com/DarthSim/overmind) may create a unix domain socket inside of the project directory.

Unix domain sockets inside of the project directory will cause `svelte-check --watch` to crash.

I've merely added an additional filter into the `DiagnosticsWatcher` constructor which will check whether a file is a unix domain socket and add to ignore list when setting up [chokidar](https://github.com/paulmillr/chokidar).

Fixes the following crash:

```
1770332812696 START "/Users/tyler/src/spend-sentry"
1770332815372 COMPLETED 2024 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
node:internal/fs/watchers:254
    const error = new UVException({
                  ^

Error: UNKNOWN: unknown error, watch '/Users/tyler/src/spend-sentry/.overmind.sock'
    at FSWatcher.<computed> (node:internal/fs/watchers:254:19)
    at watch (node:fs:2551:36)
    at createFsWatchInstance (/Users/tyler/src/spend-sentry/node_modules/chokidar/handler.js:131:31)
    at setFsWatchListener (/Users/tyler/src/spend-sentry/node_modules/chokidar/handler.js:176:19)
    at NodeFsHandler._watchWithNodeFs (/Users/tyler/src/spend-sentry/node_modules/chokidar/handler.js:330:22)
    at NodeFsHandler._handleFile (/Users/tyler/src/spend-sentry/node_modules/chokidar/handler.js:396:29)
    at NodeFsHandler._addToNodeFs (/Users/tyler/src/spend-sentry/node_modules/chokidar/handler.js:620:31)
Emitted 'error' event on FSWatcher instance at:
    at FSWatcher._handleError (/Users/tyler/src/spend-sentry/node_modules/chokidar/index.js:539:18)
    at NodeFsHandler._addToNodeFs (/Users/tyler/src/spend-sentry/node_modules/chokidar/handler.js:628:26) {
  errno: -102,
  syscall: 'watch',
  code: 'UNKNOWN',
  path: '/Users/tyler/src/spend-sentry/.overmind.sock',
  filename: '/Users/tyler/src/spend-sentry/.overmind.sock'
}

Node.js v24.13.0
error: "svelte-check" exited with code 1
```
