### PR TITLE
feat: add links to diagnostic error codes via codeDescription

### DIFF
--- a/.changeset/good-steaks-judge.md
+++ b/.changeset/good-steaks-judge.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+feat: add links to diagnostic error codes via codeDescription

--- a/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
+++ b/packages/language-server/test/plugins/svelte/SveltePlugin.test.ts
@@ -45,6 +45,9 @@ describe('Svelte Plugin', () => {
             isSvelte5Plus ? 'a11y_missing_attribute' : 'a11y-missing-attribute',
             'svelte'
         );
+        diagnostic.codeDescription = {
+            href: 'https://svelte.dev/docs/svelte/compiler-warnings#a11y_missing_attribute'
+        };
 
         assert.deepStrictEqual(diagnostics, [diagnostic]);
     });
@@ -62,6 +65,13 @@ describe('Svelte Plugin', () => {
             isSvelte5Plus ? 'bind_invalid_name' : 'binding-undeclared',
             'svelte'
         );
+
+        diagnostic.codeDescription = {
+            href: isSvelte5Plus
+                ? 'https://svelte.dev/docs/svelte/compiler-errors#bind_invalid_name'
+                : // doesn't actually exist but at least points to the page
+                  'https://svelte.dev/docs/svelte/compiler-errors#binding_undeclared'
+        };
 
         assert.deepStrictEqual(diagnostics, [diagnostic]);
     });

--- a/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getDiagnostics.test.ts
@@ -475,7 +475,13 @@ describe('SveltePlugin#getDiagnostics', () => {
                     (isSvelte5Plus ? '\nhttps://svelte.dev/e/export_let_unused' : ''),
                 severity: 2,
                 source: 'svelte',
-                code: isSvelte5Plus ? 'export_let_unused' : 'unused-export-let'
+                code: isSvelte5Plus ? 'export_let_unused' : 'unused-export-let',
+                codeDescription: {
+                    href: isSvelte5Plus
+                        ? 'https://svelte.dev/docs/svelte/compiler-warnings#export_let_unused'
+                        : // doesn't actually exist but at least points to the page
+                          'https://svelte.dev/docs/svelte/compiler-warnings#unused_export_let'
+                }
             }
         ]);
     });
@@ -496,7 +502,12 @@ describe('SveltePlugin#getDiagnostics', () => {
                     source: 'svelte',
                     code: isSvelte5Plus
                         ? 'reactive_declaration_invalid_placement'
-                        : 'module-script-reactive-declaration'
+                        : 'module-script-reactive-declaration',
+                    codeDescription: {
+                        href: isSvelte5Plus
+                            ? 'https://svelte.dev/docs/svelte/compiler-warnings#reactive_declaration_invalid_placement'
+                            : 'https://svelte.dev/docs/svelte/compiler-warnings#module_script_reactive_declaration'
+                    }
                 }
             ]
         );
@@ -525,7 +536,13 @@ describe('SveltePlugin#getDiagnostics', () => {
                         }
                     },
                     severity: 2,
-                    source: 'svelte'
+                    source: 'svelte',
+                    codeDescription: {
+                        href: isSvelte5Plus
+                            ? 'https://svelte.dev/docs/svelte/compiler-warnings#export_let_unused'
+                            : // doesn't actually exist but at least points to the page
+                              'https://svelte.dev/docs/svelte/compiler-warnings#unused_export_let'
+                    }
                 },
                 {
                     code: isSvelte5Plus ? 'export_let_unused' : 'unused-export-let',
@@ -543,7 +560,13 @@ describe('SveltePlugin#getDiagnostics', () => {
                         }
                     },
                     severity: 2,
-                    source: 'svelte'
+                    source: 'svelte',
+                    codeDescription: {
+                        href: isSvelte5Plus
+                            ? 'https://svelte.dev/docs/svelte/compiler-warnings#export_let_unused'
+                            : // doesn't actually exist but at least points to the page
+                              'https://svelte.dev/docs/svelte/compiler-warnings#unused_export_let'
+                    }
                 }
             ]
         );


### PR DESCRIPTION
#2933

Alternative to #2934. I originally suggested we should use the short url format in that PR. After discussion with Simon, I think it might be better to use the full path. When using the "svelte.dev/e/xxx" format, the wrong code gets a 404 page. However, in full path, it at least goes to the page. This way, we can support Svelte 4 by replacing the "-" in diagnostics code with "_". 

(Yes. It's pretty much the original version of #2934. But the PR never run test properly.)