### PR TITLE
fix: rewrite relative imports reaching outside root

### DIFF
--- a/.changeset/icy-clubs-sniff.md
+++ b/.changeset/icy-clubs-sniff.md
@@ -1,0 +1,7 @@
+---
+'svelte-language-server': patch
+'svelte-check': patch
+'svelte2tsx': patch
+---
+
+fix: handle relative imports reaching outside working directory when using `--incremental/--tsgo` flags

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -72,6 +72,10 @@ export interface SvelteSnapshotOptions {
     transformOnTemplateError: boolean;
     typingsNamespace: string;
     emitJsDoc?: boolean;
+    rewriteExternalImports?: {
+        workspacePath: string;
+        generatedPath: string;
+    };
 }
 
 const ambientPathPattern = /node_modules[\/\\]svelte[\/\\]types[\/\\]ambient\.d\.ts$/;
@@ -213,7 +217,8 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
             accessors:
                 document.config?.compilerOptions?.accessors ??
                 document.config?.compilerOptions?.customElement,
-            emitJsDoc: options.emitJsDoc
+            emitJsDoc: options.emitJsDoc,
+            rewriteExternalImports: options.rewriteExternalImports
         });
         text = tsx.code;
         tsxMap = tsx.map as EncodedSourceMap;

--- a/packages/language-server/src/svelte-check.ts
+++ b/packages/language-server/src/svelte-check.ts
@@ -29,7 +29,13 @@ import { groupBy } from 'lodash';
 export function mapSvelteCheckDiagnostics(
     sourcePath: string,
     sourceText: string,
-    tsDiagnostics: ts.Diagnostic[]
+    tsDiagnostics: ts.Diagnostic[],
+    options?: {
+        rewriteExternalImports?: {
+            workspacePath: string;
+            generatedPath: string;
+        };
+    }
 ): Diagnostic[] {
     const document = new Document(pathToUrl(sourcePath), sourceText);
     const snapshot = DocumentSnapshot.fromDocument(document, {
@@ -37,7 +43,8 @@ export function mapSvelteCheckDiagnostics(
         version: document.compiler?.VERSION,
         transformOnTemplateError: false,
         typingsNamespace: 'svelteHTML',
-        emitJsDoc: true
+        emitJsDoc: true,
+        rewriteExternalImports: options?.rewriteExternalImports
     } satisfies SvelteSnapshotOptions) as SvelteDocumentSnapshot;
 
     return mapAndFilterDiagnostics(tsDiagnostics, document, snapshot);

--- a/packages/svelte-check/test-error/Index.svelte
+++ b/packages/svelte-check/test-error/Index.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import Jsdoc from './Jsdoc.svelte';
     import { foo } from './relative';
+    import nope from '../../outside';
 
     let count: number = 'oops';
     let x = 0;

--- a/packages/svelte-check/test-sanity.js
+++ b/packages/svelte-check/test-sanity.js
@@ -139,25 +139,31 @@ test('clean project (incremental, warm cache)', {
 const errors = [
     {
         file: 'Index.svelte',
-        line: 4,
+        line: 3,
+        column: 21,
+        code: 2307
+    },
+    {
+        file: 'Index.svelte',
+        line: 5,
         column: 8,
         code: 2322
     },
     {
         file: 'Index.svelte',
-        line: 7,
+        line: 8,
         column: 4,
         code: 2367
     },
     {
         file: 'Index.svelte',
-        line: 10,
+        line: 11,
         column: 4,
         code: 2367
     },
     {
         file: 'Index.svelte',
-        line: 14,
+        line: 15,
         column: 1,
         code: 2741
     },

--- a/packages/svelte2tsx/index.d.ts
+++ b/packages/svelte2tsx/index.d.ts
@@ -90,6 +90,11 @@ export function svelte2tsx(
          * valid JS that tsc can process without errors.
          */
         emitJsDoc?: boolean;
+        /**
+         * Rewrites relative imports that resolve outside the workspace so they stay valid
+         * from the generated file location.
+         */
+        rewriteExternalImports?: InternalHelpers.RewriteExternalImportsConfig;
     }
 ): SvelteCompiledToTsx
 
@@ -163,7 +168,8 @@ export const internalHelpers: {
         fileName: string,
         kitFilesSettings: InternalHelpers.KitFilesSettings,
         getSource: () => ts.SourceFile | undefined,
-        surround?: (code: string) => string
+        surround?: (code: string) => string,
+        rewriteExternalImports?: InternalHelpers.RewriteExternalImportsConfig
     ) => { text: string; addedCode: InternalHelpers.AddedCode[] } | undefined,
     toVirtualPos: (pos: number, addedCode: InternalHelpers.AddedCode[]) => number,
     toOriginalPos: (pos: number, addedCode: InternalHelpers.AddedCode[]) => {pos: number; inGenerated: boolean},
@@ -200,5 +206,10 @@ export namespace InternalHelpers {
         clientHooksPath: string;
         universalHooksPath: string;
         paramsPath: string;
+    }
+
+    export interface RewriteExternalImportsConfig {
+        workspacePath: string;
+        generatedPath: string;
     }
 }

--- a/packages/svelte2tsx/src/helpers/rewriteExternalImports.ts
+++ b/packages/svelte2tsx/src/helpers/rewriteExternalImports.ts
@@ -1,0 +1,153 @@
+import path from 'path';
+import type ts from 'typescript';
+
+export type RewriteExternalImportsOptions = {
+    sourcePath: string;
+    generatedPath: string;
+    workspacePath: string;
+};
+
+export type ExternalImportRewrite = {
+    rewritten: string;
+    insertedPrefix: string;
+};
+
+function toPosixPath(value: string): string {
+    return value.replace(/\\/g, '/');
+}
+
+function isWithinDirectory(filePath: string, directoryPath: string): boolean {
+    const relative = path.relative(path.resolve(directoryPath), path.resolve(filePath));
+    return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function splitImportSpecifier(specifier: string): { pathPart: string; suffix: string } {
+    const queryIndex = specifier.indexOf('?');
+    const hashIndex = specifier.indexOf('#');
+    const cutIndex =
+        queryIndex === -1
+            ? hashIndex
+            : hashIndex === -1
+              ? queryIndex
+              : Math.min(queryIndex, hashIndex);
+
+    if (cutIndex === -1) {
+        return { pathPart: specifier, suffix: '' };
+    }
+
+    return {
+        pathPart: specifier.slice(0, cutIndex),
+        suffix: specifier.slice(cutIndex)
+    };
+}
+
+export function getExternalImportRewrite(
+    specifier: string,
+    options: RewriteExternalImportsOptions
+): ExternalImportRewrite | null {
+    const sourceDir = path.dirname(options.sourcePath);
+    const generatedDir = path.dirname(options.generatedPath);
+    const { pathPart, suffix } = splitImportSpecifier(specifier);
+    if (!pathPart.startsWith('../')) {
+        return null;
+    }
+
+    const targetPath = path.resolve(sourceDir, pathPart);
+    if (isWithinDirectory(targetPath, options.workspacePath)) {
+        return null;
+    }
+
+    const rewrittenRelative = toPosixPath(path.relative(generatedDir, targetPath));
+    const rewritten = `${rewrittenRelative}${suffix}`;
+    if (rewritten === specifier) {
+        return null;
+    }
+
+    return {
+        rewritten,
+        insertedPrefix: rewrittenRelative.slice(0, rewrittenRelative.length - pathPart.length)
+    };
+}
+
+export function getImportTypeSpecifierLiteral(
+    ts_impl: typeof ts,
+    node: ts.ImportTypeNode
+): ts.StringLiteralLike | undefined {
+    const argument = node.argument;
+    if (ts_impl.isLiteralTypeNode(argument) && ts_impl.isStringLiteralLike(argument.literal)) {
+        return argument.literal;
+    }
+    return undefined;
+}
+
+function rewriteImportTypesInNode(
+    ts_impl: typeof ts,
+    node: ts.Node,
+    applyImportRewrite: (module_specifier: ts.StringLiteralLike) => void
+) {
+    if (ts_impl.isImportTypeNode(node)) {
+        const specifier = getImportTypeSpecifierLiteral(ts_impl, node);
+        if (specifier) {
+            applyImportRewrite(specifier);
+        }
+    }
+    ts_impl.forEachChild(node, (child) =>
+        rewriteImportTypesInNode(ts_impl, child, applyImportRewrite)
+    );
+}
+
+export function rewriteExternalImportsInNode(
+    ts_impl: typeof ts,
+    node: ts.Node,
+    options: RewriteExternalImportsOptions,
+    on_rewrite: (module_specifier: ts.StringLiteralLike, rewrite: ExternalImportRewrite) => void
+) {
+    const applyImportRewrite = (module_specifier: ts.StringLiteralLike) => {
+        const rewrite = getExternalImportRewrite(module_specifier.text, options);
+        if (rewrite) {
+            on_rewrite(module_specifier, rewrite);
+        }
+    };
+
+    if (ts_impl.isImportDeclaration(node) || ts_impl.isExportDeclaration(node)) {
+        if (node.moduleSpecifier && ts_impl.isStringLiteralLike(node.moduleSpecifier)) {
+            applyImportRewrite(node.moduleSpecifier);
+        }
+    } else if (ts_impl.isCallExpression(node)) {
+        const firstArg = node.arguments[0];
+        if (firstArg && ts_impl.isStringLiteralLike(firstArg)) {
+            const isDynamicImport = node.expression.kind === ts_impl.SyntaxKind.ImportKeyword;
+            const isRequireCall =
+                ts_impl.isIdentifier(node.expression) && node.expression.text === 'require';
+            if (isDynamicImport || isRequireCall) {
+                applyImportRewrite(firstArg);
+            }
+        }
+    } else if (ts_impl.isImportTypeNode(node)) {
+        const specifier = getImportTypeSpecifierLiteral(ts_impl, node);
+        if (specifier) {
+            applyImportRewrite(specifier);
+        }
+    }
+
+    const jsDoc = (node as ts.Node & { jsDoc?: ts.NodeArray<ts.JSDoc> }).jsDoc;
+    if (jsDoc) {
+        for (const doc of jsDoc) {
+            rewriteImportTypesInNode(ts_impl, doc, applyImportRewrite);
+        }
+    }
+}
+
+export function forEachExternalImportRewrite(
+    ts_impl: typeof ts,
+    source: ts.SourceFile,
+    options: RewriteExternalImportsOptions,
+    on_rewrite: (module_specifier: ts.StringLiteralLike, rewrite: ExternalImportRewrite) => void
+) {
+    const visit = (node: ts.Node) => {
+        rewriteExternalImportsInNode(ts_impl, node, options, on_rewrite);
+        ts_impl.forEachChild(node, visit);
+    };
+
+    ts_impl.forEachChild(source, visit);
+}

--- a/packages/svelte2tsx/test/helpers.ts
+++ b/packages/svelte2tsx/test/helpers.ts
@@ -239,13 +239,19 @@ export function test_samples(dir: string, transform: TransformSampleFn, js: 'js'
             filename: svelteFile,
             sampleName: sample.name,
             emitOnTemplateError: sample.emitOnTemplateError,
-            preserveAttributeCase: sample.name.endsWith('-foreign-ns')
+            preserveAttributeCase: sample.name.endsWith('-foreign-ns'),
+            ...JSON.parse(sample.get('config.json') || '{}')
         };
 
         if (process.env.CI) {
             sample.checkDirectory({
                 required: ['*.svelte', `expectedv2.${js}`],
-                allowed: ['expected.js', `expected-svelte5.${js}`, 'expected.error.json']
+                allowed: [
+                    'expected.js',
+                    `expected-svelte5.${js}`,
+                    'expected.error.json',
+                    'config.json'
+                ]
             });
         } else {
             sample.checkDirectory({
@@ -254,7 +260,8 @@ export function test_samples(dir: string, transform: TransformSampleFn, js: 'js'
                     'expected.js',
                     `expectedv2.${js}`,
                     `expected-svelte5.${js}`,
-                    'expected.error.json'
+                    'expected.error.json',
+                    'config.json'
                 ]
             });
 
@@ -364,6 +371,7 @@ export function test_samples(dir: string, transform: TransformSampleFn, js: 'js'
 type BaseConfig = {
     emitOnTemplateError?: boolean;
     filename?: string;
+    rewriteExternalImports?: Svelte2TsxConfig['rewriteExternalImports'];
 };
 type Svelte2TsxConfig = Required<Parameters<typeof svelte2tsx>[1]>;
 
@@ -377,7 +385,8 @@ export function get_svelte2tsx_config(base: BaseConfig, sampleName: string): Sve
         mode: sampleName.endsWith('-dts') ? 'dts' : 'ts',
         accessors: sampleName.startsWith('accessors-config'),
         emitJsDoc: sampleName.startsWith('jsdoc-'),
-        version: VERSION
+        version: VERSION,
+        rewriteExternalImports: base.rewriteExternalImports
     };
 }
 

--- a/packages/svelte2tsx/test/svelte2tsx/samples/rewrite-imports/config.json
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/rewrite-imports/config.json
@@ -1,0 +1,7 @@
+{
+    "filename": "/x/y/input.svelte",
+    "rewriteExternalImports": {
+        "workspacePath": "/x/y",
+        "generatedPath": "/x/y/generated/input.svelte"
+    }
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/rewrite-imports/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/rewrite-imports/expectedv2.ts
@@ -1,0 +1,37 @@
+///<reference types="svelte" />
+;
+    import foo1 from '../../../foo';
+    import('../../../bar');
+    export { x } from '../..';
+
+    /** @param {import('../../../mhm'.mhm)} mhm */
+    function f(mhm) {}
+;;
+
+import foo2 from '../../../foo';
+function $$render() {
+
+    
+    import('../../../bar');
+
+    /** @type {import('../../../mhm').mhm} */
+    let mhm = true;
+
+    /** @param {import('../../../mhm'.mhm)} mhm */
+    function f(mhm) {}
+;
+async () => {
+
+
+
+  { svelteHTML.createElement("button", {  "onclick":() => {
+        import('../../../bar');
+        /** @type {import('../../../mhm').mhm} */
+        let mhm = true;
+        /** @param {import('../../../mhm').mhm} mhm */
+        function f(mhm) {}
+    },});  }};
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event($$render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/rewrite-imports/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/rewrite-imports/input.svelte
@@ -1,0 +1,29 @@
+<script context="module">
+    import foo1 from '../../foo';
+    import('../../bar');
+    export { x } from '../../x';
+
+    /** @param {import('../../mhm'.mhm)} mhm */
+    function f(mhm) {}
+</script>
+
+<script>
+    import foo2 from '../../foo';
+    import('../../bar');
+
+    /** @type {import('../../mhm').mhm} */
+    let mhm = true;
+
+    /** @param {import('../../mhm'.mhm)} mhm */
+    function f(mhm) {}
+</script>
+
+<button
+    onclick={() => {
+        import('../../bar');
+        /** @type {import('../../mhm').mhm} */
+        let mhm = true;
+        /** @param {import('../../mhm').mhm} mhm */
+        function f(mhm) {}
+    }}
+>click</button>


### PR DESCRIPTION
When using svelte-check's `--incremental/--tsgo` flags the files are written to a generated folder, making use of the rootDirs tsconfig feature. This has one limitation: when a relative import within a generated file reaches into a directory that is not covered by rootDirs, it cannot be resolved.

This therefore adds a new option to svelte2tsx to rewrite imports as part of the transformation. Note that this will not help with transforming files outside of the working directory, but when you e.g. import a regular TS/JS file that way it now works.