### PR TITLE
chore: replace builtin-modules with `node:module`

### DIFF
--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -49,7 +49,6 @@
         "@rollup/plugin-replace": "5.0.2",
         "@rollup/plugin-typescript": "^10.0.0",
         "@types/sade": "^1.7.2",
-        "builtin-modules": "^3.3.0",
         "rollup": "3.7.5",
         "rollup-plugin-cleanup": "^3.2.0",
         "rollup-plugin-copy": "^3.4.0",

--- a/packages/svelte-check/rollup.config.mjs
+++ b/packages/svelte-check/rollup.config.mjs
@@ -1,3 +1,4 @@
+import { builtinModules } from 'node:module';
 import typescript from '@rollup/plugin-typescript';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
@@ -5,7 +6,6 @@ import json from '@rollup/plugin-json';
 import replace from '@rollup/plugin-replace';
 import cleanup from 'rollup-plugin-cleanup';
 import copy from 'rollup-plugin-copy';
-import builtins from 'builtin-modules';
 
 export default [
     {
@@ -54,7 +54,7 @@ export default [
             clearScreen: false
         },
         external: [
-            ...builtins,
+            ...builtinModules,
             // svelte-check dependencies that are system-dependent and should
             // be installed as dependencies through npm
             'picocolors',

--- a/packages/svelte2tsx/package.json
+++ b/packages/svelte2tsx/package.json
@@ -29,7 +29,6 @@
         "@types/node": "^18.0.0",
         "@types/unist": "^2.0.3",
         "@types/vfile": "^3.0.2",
-        "builtin-modules": "^3.3.0",
         "estree-walker": "^2.0.1",
         "magic-string": "^0.30.11",
         "mocha": "^9.2.0",

--- a/packages/svelte2tsx/rollup.config.mjs
+++ b/packages/svelte2tsx/rollup.config.mjs
@@ -1,8 +1,8 @@
+import { builtinModules } from 'node:module';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
-import builtins from 'builtin-modules';
 import fs from 'fs';
 import path from 'path';
 import { decode } from '@jridgewell/sourcemap-codec';
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'url'
 
 const DEV = !!process.env.ROLLUP_WATCH;
 
+/** @returns {import('rollup').Plugin} */
 function repl() {
     const require = createRequire(import.meta.url);
     const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -102,7 +103,7 @@ export default [
             clearScreen: false
         },
         external: [
-            ...builtins,
+            ...builtinModules,
             'typescript',
             'svelte',
             'svelte/compiler',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,9 +155,6 @@ importers:
       '@types/sade':
         specifier: ^1.7.2
         version: 1.7.4
-      builtin-modules:
-        specifier: ^3.3.0
-        version: 3.3.0
       rollup:
         specifier: 3.7.5
         version: 3.7.5
@@ -283,9 +280,6 @@ importers:
       '@types/vfile':
         specifier: ^3.0.2
         version: 3.0.2
-      builtin-modules:
-        specifier: ^3.3.0
-        version: 3.3.0
       estree-walker:
         specifier: ^2.0.1
         version: 2.0.2


### PR DESCRIPTION
This PR removes the builtin-modules package in favour of a Node built-in solution
https://e18e.dev/docs/replacements/builtin-modules.html