### PR TITLE
fix: prevent duplicate diagnostics

### DIFF
--- a/.changeset/common-suits-open.md
+++ b/.changeset/common-suits-open.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+fix: prevent duplicate diagnostics

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -640,7 +640,7 @@ export function startServer(options?: LSOptions) {
         async (evt, token) => await pluginHost.getOutgoingCalls(evt.item, token)
     );
 
-    docManager.on('documentChange', diagnosticsManager.scheduleUpdate.bind(diagnosticsManager));
+    docManager.on('documentChange', (document) => diagnosticsManager.scheduleUpdate(document));
     docManager.on('documentClose', (document: Document) =>
         diagnosticsManager.removeDiagnostics(document)
     );


### PR DESCRIPTION
Found a bug in the pull diagnostics mode. The diagnosticsManager is `PushDiagnosticsManager` first, but when it was switched to `PullDiagnosticsManager` in initialisation, the handler doesn't get replaced.