### PR TITLE
language-server: fix 'occured' -> 'occurred' in HTML data provider

### DIFF
--- a/packages/language-server/src/plugins/html/dataProvider.ts
+++ b/packages/language-server/src/plugins/html/dataProvider.ts
@@ -374,7 +374,7 @@ const svelteTags: ITagData[] = [
         attributes: [
             {
                 name: 'onerror',
-                description: 'Called when an error occured within the boundary'
+                description: 'Called when an error occurred within the boundary'
             }
         ]
     }


### PR DESCRIPTION
Description string in `packages/language-server/src/plugins/html/dataProvider.ts` line 377 reads `error occured within the boundary`. Fixed to `occurred`. This string surfaces in IDE hover/completions. String-literal-only change.