### PR TITLE
feat: add support for svelte config ts/mts files

### DIFF
--- a/.changeset/clever-times-build.md
+++ b/.changeset/clever-times-build.md
@@ -1,0 +1,6 @@
+---
+'svelte-language-server': patch
+'svelte-check': patch
+---
+
+feat: add support for svelte config ts/mts files

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -143,7 +143,12 @@ export class ConfigLoader {
                 return this.fs.existsSync(path) ? path : undefined;
             };
             const configPath =
-                tryFindConfigPath('js') || tryFindConfigPath('cjs') || tryFindConfigPath('mjs');
+                tryFindConfigPath('js') ||
+                tryFindConfigPath('ts') ||
+                tryFindConfigPath('cjs') ||
+                tryFindConfigPath('mjs') ||
+                tryFindConfigPath('mts');
+
             if (configPath) {
                 return configPath;
             }

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -47,10 +47,10 @@ const _dynamicImport = new Function('modulePath', 'return import(modulePath)') a
     modulePath: URL
 ) => Promise<any>;
 
-const configRegex = /\/svelte\.config\.(js|cjs|mjs)$/;
+const configRegex = /\/svelte\.config\.(js|ts|cjs|mjs|mts)$/;
 
 /**
- * Loads svelte.config.{js,cjs,mjs} files. Provides both a synchronous and asynchronous
+ * Loads svelte.config.{js,ts,cjs,mjs,mts} files. Provides both a synchronous and asynchronous
  * interface to get a config file because snapshots need access to it synchronously.
  * This means that another instance (the ts service host on startup) should make
  * sure that all config files are loaded before snapshots are retrieved.
@@ -221,8 +221,10 @@ export class ConfigLoader {
             currentDir = nextDir;
             const config =
                 this.tryGetConfig(file, currentDir, 'js') ||
+                this.tryGetConfig(file, currentDir, 'ts') ||
                 this.tryGetConfig(file, currentDir, 'cjs') ||
-                this.tryGetConfig(file, currentDir, 'mjs');
+                this.tryGetConfig(file, currentDir, 'mjs') ||
+                this.tryGetConfig(file, currentDir, 'mts');
             if (config) {
                 return config;
             }

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -48,6 +48,7 @@ const _dynamicImport = new Function('modulePath', 'return import(modulePath)') a
 ) => Promise<any>;
 
 const configRegex = /\/svelte\.config\.(js|ts|cjs|mjs|mts)$/;
+const configRegexWithoutTs = /\/svelte\.config\.(js|cjs|mjs)$/;
 
 /**
  * Loads svelte.config.{js,ts,cjs,mjs,mts} files. Provides both a synchronous and asynchronous
@@ -61,13 +62,20 @@ export class ConfigLoader {
     private configFilesAsync = new FileMap<Promise<SvelteConfig>>();
     private filePathToConfigPath = new FileMap<string>();
     private disabled = false;
+    private loadSvelteConfigTs: boolean;
 
     constructor(
         private globSync: typeof fdir,
         private fs: Pick<typeof _fs, 'existsSync'>,
         private path: Pick<typeof _path, 'dirname' | 'relative' | 'join'>,
-        private dynamicImport: typeof _dynamicImport
-    ) {}
+        private dynamicImport: typeof _dynamicImport,
+        processFeatures: (typeof process)['features'] & {
+            typescript?: false | 'transform';
+        }
+    ) {
+        this.loadSvelteConfigTs =
+            processFeatures && 'typescript' in processFeatures && !!processFeatures.typescript;
+    }
 
     /**
      * Enable/disable loading of configs (for security reasons for example)
@@ -83,6 +91,7 @@ export class ConfigLoader {
      * @param directory Directory where to load the configs from
      */
     async loadConfigs(directory: string): Promise<void> {
+        const targetRegex = this.loadSvelteConfigTs ? configRegex : configRegexWithoutTs;
         Logger.log('Trying to load configs for', directory);
 
         try {
@@ -93,7 +102,7 @@ export class ConfigLoader {
                     return path.includes('node_modules/') || path.includes('/.') || path[0] === '.';
                 })
                 .filter((path, isDir) => {
-                    return !isDir && configRegex.test(path);
+                    return !isDir && targetRegex.test(path);
                 })
                 .withRelativePaths()
                 .crawl(directory)
@@ -144,10 +153,10 @@ export class ConfigLoader {
             };
             const configPath =
                 tryFindConfigPath('js') ||
-                tryFindConfigPath('ts') ||
+                (this.loadSvelteConfigTs ? tryFindConfigPath('ts') : undefined) ||
                 tryFindConfigPath('cjs') ||
                 tryFindConfigPath('mjs') ||
-                tryFindConfigPath('mts');
+                (this.loadSvelteConfigTs ? tryFindConfigPath('mts') : undefined);
 
             if (configPath) {
                 return configPath;
@@ -226,10 +235,10 @@ export class ConfigLoader {
             currentDir = nextDir;
             const config =
                 this.tryGetConfig(file, currentDir, 'js') ||
-                this.tryGetConfig(file, currentDir, 'ts') ||
+                (this.loadSvelteConfigTs ? this.tryGetConfig(file, currentDir, 'ts') : undefined) ||
                 this.tryGetConfig(file, currentDir, 'cjs') ||
                 this.tryGetConfig(file, currentDir, 'mjs') ||
-                this.tryGetConfig(file, currentDir, 'mts');
+                (this.loadSvelteConfigTs ? this.tryGetConfig(file, currentDir, 'mts') : undefined);
             if (config) {
                 return config;
             }
@@ -312,4 +321,4 @@ export class ConfigLoader {
     }
 }
 
-export const configLoader = new ConfigLoader(fdir, _fs, _path, _dynamicImport);
+export const configLoader = new ConfigLoader(fdir, _fs, _path, _dynamicImport, process.features);

--- a/packages/language-server/test/lib/documents/configLoader.test.ts
+++ b/packages/language-server/test/lib/documents/configLoader.test.ts
@@ -58,7 +58,8 @@ describe('ConfigLoader', () => {
             mockFdir(['svelte.config.js', 'below/svelte.config.js']),
             { existsSync: () => true },
             path,
-            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } })
+            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } }),
+            process.features
         );
         await configLoader.loadConfigs(normalizePath('/some/path'));
 
@@ -92,7 +93,8 @@ describe('ConfigLoader', () => {
                     typeof p === 'string' && p.endsWith(path.join('some', 'svelte.config.js'))
             },
             path,
-            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } })
+            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } }),
+            process.features
         );
         await configLoader.loadConfigs(normalizePath('/some/path'));
 
@@ -104,7 +106,8 @@ describe('ConfigLoader', () => {
             mockFdir([]),
             { existsSync: () => false },
             path,
-            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } })
+            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } }),
+            process.features
         );
         await configLoader.loadConfigs(normalizePath('/some/path'));
 
@@ -140,7 +143,8 @@ describe('ConfigLoader', () => {
                 return new Promise((resolve) => {
                     setTimeout(() => resolve({ default: { preprocess: module.toString() } }), 500);
                 });
-            }
+            },
+            process.features
         );
         await Promise.all([
             configLoader.loadConfigs(normalizePath('/some/path')),
@@ -162,8 +166,12 @@ describe('ConfigLoader', () => {
     });
 
     it('can deal with missing config', () => {
-        const configLoader = new ConfigLoader(mockFdir([]), { existsSync: () => false }, path, () =>
-            Promise.resolve('unimportant')
+        const configLoader = new ConfigLoader(
+            mockFdir([]),
+            { existsSync: () => false },
+            path,
+            () => Promise.resolve('unimportant'),
+            process.features
         );
         assert.deepStrictEqual(
             configLoader.getConfig(normalizePath('/some/file.svelte')),
@@ -176,7 +184,8 @@ describe('ConfigLoader', () => {
             mockFdir([]),
             { existsSync: () => true },
             path,
-            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } })
+            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } }),
+            process.features
         );
         assert.deepStrictEqual(
             await configLoader.awaitConfig(normalizePath('some/file.svelte')),
@@ -190,10 +199,50 @@ describe('ConfigLoader', () => {
             mockFdir([]),
             { existsSync: () => true },
             path,
-            moduleLoader
+            moduleLoader,
+            process.features
         );
         configLoader.setDisabled(true);
         await configLoader.awaitConfig(normalizePath('some/file.svelte'));
         assert.deepStrictEqual(moduleLoader.notCalled, true);
+    });
+
+    it('can scan svelte.config.ts', async () => {
+        const configLoader = new ConfigLoader(
+            mockFdir(['/some/path/svelte.config.ts']),
+            { existsSync: (path) => typeof path === 'string' && path.endsWith('svelte.config.ts') },
+            path,
+            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } }),
+            { ...process.features, typescript: 'transform' }
+        );
+        await configLoader.loadConfigs(normalizePath('/some/path'));
+
+        await assertFindsConfig(
+            configLoader,
+            '/some/path/comp.svelte',
+            '/some/path/svelte.config.ts'
+        );
+    });
+
+    it('can skips svelte.config.ts loading', async () => {
+        const files = ['/some/path/svelte.config.ts', '/some/path/svelte.config.cjs'];
+        const configLoader = new ConfigLoader(
+            mockFdir(files),
+            {
+                existsSync: (path) => {
+                    return typeof path === 'string' && files.some((f) => f.endsWith(path));
+                }
+            },
+            path,
+            (module: URL) => Promise.resolve({ default: { preprocess: module.toString() } }),
+            { ...process.features, typescript: false }
+        );
+        await configLoader.loadConfigs(normalizePath('/some/path'));
+
+        await assertFindsConfig(
+            configLoader,
+            '/some/path/comp.svelte',
+            '/some/path/svelte.config.cjs'
+        );
     });
 });

--- a/packages/svelte-check/src/incremental.ts
+++ b/packages/svelte-check/src/incremental.ts
@@ -111,7 +111,12 @@ const dynamicImport = new Function('modulePath', 'return import(modulePath)') as
 async function loadKitFilesSettings(
     workspacePath: string
 ): Promise<InternalHelpers.KitFilesSettings> {
-    const configExtensions = ['js', 'cjs', 'mjs'];
+    const loadSvelteConfigTs =
+        process.features && 'typescript' in process.features && !!process.features.typescript;
+    const configExtensions = loadSvelteConfigTs
+        ? ['js', 'ts', 'cjs', 'mjs', 'mts']
+        : ['js', 'cjs', 'mjs'];
+
     let configPath: string | undefined;
 
     for (const ext of configExtensions) {

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -238,7 +238,7 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
             [
                 // /^tsconfig\.json$/,
                 // /^jsconfig\.json$/,
-                /^svelte\.config\.(js|cjs|mjs)$/,
+                /^svelte\.config\.(js|ts|cjs|mjs|mts)$/,
                 // https://prettier.io/docs/en/configuration.html
                 /^\.prettierrc$/,
                 /^\.prettierrc\.(json|yml|yaml|json5|toml)$/,

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -131,8 +131,10 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
     const serverModule = require.resolve(lsPath || 'svelte-language-server/bin/server.js');
     console.log('Loading server from ', serverModule);
 
+    const serverRuntime = runtimeConfig.get<string>('runtime');
+
     const runExecArgv: string[] = [];
-    if (add_experimental_strip_types_flag) {
+    if (!serverRuntime && add_experimental_strip_types_flag) {
         runExecArgv.push('--experimental-strip-types');
     }
 
@@ -166,7 +168,6 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
         }
     };
 
-    const serverRuntime = runtimeConfig.get<string>('runtime');
     if (serverRuntime) {
         serverOptions.run.runtime = serverRuntime;
         serverOptions.debug.runtime = serverRuntime;

--- a/packages/svelte-vscode/src/extension.ts
+++ b/packages/svelte-vscode/src/extension.ts
@@ -37,6 +37,13 @@ import {
     getMergedConfiguration as getMergedTsConfigurations,
     sendNotificationMiddleware
 } from './typescript/configurationMiddleware';
+import { versions } from 'node:process';
+
+const [node_major, node_minor] = (versions?.node ?? '0.0.0-unknown').split('.', 3).map(Number);
+
+const add_experimental_strip_types_flag =
+    (node_major === 22 && node_minor > 5 && node_minor < 18) || // flag added in 22.6.0, removed in 22.18.0
+    (node_major === 23 && node_minor < 6); // flag removed in 23.6.0
 
 namespace TagCloseRequest {
     export const type: RequestType<TextDocumentPositionParams, string, any> = new RequestType(
@@ -125,6 +132,9 @@ export function activateSvelteLanguageServer(context: ExtensionContext) {
     console.log('Loading server from ', serverModule);
 
     const runExecArgv: string[] = [];
+    if (add_experimental_strip_types_flag) {
+        runExecArgv.push('--experimental-strip-types');
+    }
 
     const runtimeArgs = runtimeConfig.get<string[]>('runtime-args');
     if (runtimeArgs !== undefined) {


### PR DESCRIPTION
Fixes #2834 

This is a follow-up to #2804 that was closed for some reason. It'd be great to get this in because I think it's the last blocker to being able to fully adopt `svelte.config.ts` files in a project. The only adjustment I made was adding @jrmajor's recommendation to remove the flag for Node 22.18 because it was [enabled by default](https://github.com/nodejs/node/blob/00a42d82053e2f59ef4130cd0fe9a85b623a64be/doc/changelogs/CHANGELOG_V22.md#2025-07-31-version-22180-jod-lts-aduh95) on that release