### PR TITLE
fix: ./$types imports were getting improperly replaced

### DIFF
--- a/.changeset/long-dolls-melt.md
+++ b/.changeset/long-dolls-melt.md
@@ -1,0 +1,6 @@
+---
+'typescript-svelte-plugin': patch
+'svelte-language-server': patch
+---
+
+fix: prevent incorrect $types imports being injected when moving +page.svelte files

--- a/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
@@ -118,13 +118,13 @@ export class UpdateImportsProviderImpl implements UpdateImportsProvider {
                     // If there is a better solution for this, please file a PR :)
                     change.fileName = change.fileName.replace(oldPathTsProgramCasing, newPath);
                 }
-                change.textChanges = change.textChanges.filter(
-                    (textChange) =>
+                if (path.basename(change.fileName).startsWith('+')) {
+                    change.textChanges = change.textChanges.filter((textChange) => {
                         // Filter out changes to './$type' imports for Kit route files,
                         // you'll likely want these to stay as-is
-                        !isKitTypePath(textChange.newText) ||
-                        !path.basename(change.fileName).startsWith('+')
-                );
+                        return !isKitTypePath(textChange.newText);
+                    });
+                }
                 return change;
             });
 

--- a/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
@@ -77,7 +77,6 @@ export class UpdateImportsProviderImpl implements UpdateImportsProvider {
             return;
         }
 
-        console.log(ls.getProgram()?.getSourceFile(oldPath)?.getText());
         const oldPathTsProgramCasing = ls.getProgram()?.getSourceFile(oldPath)?.fileName ?? oldPath;
         // `getEditsForFileRename` might take a while
         const fileChanges = ls

--- a/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/UpdateImportsProvider.ts
@@ -77,6 +77,7 @@ export class UpdateImportsProviderImpl implements UpdateImportsProvider {
             return;
         }
 
+        console.log(ls.getProgram()?.getSourceFile(oldPath)?.getText());
         const oldPathTsProgramCasing = ls.getProgram()?.getSourceFile(oldPath)?.fileName ?? oldPath;
         // `getEditsForFileRename` might take a while
         const fileChanges = ls
@@ -119,11 +120,11 @@ export class UpdateImportsProviderImpl implements UpdateImportsProvider {
                     change.fileName = change.fileName.replace(oldPathTsProgramCasing, newPath);
                 }
                 if (path.basename(change.fileName).startsWith('+')) {
-                    change.textChanges = change.textChanges.filter((textChange) => {
-                        // Filter out changes to './$type' imports for Kit route files,
-                        // you'll likely want these to stay as-is
-                        return !isKitTypePath(textChange.newText);
-                    });
+                    // Filter out changes to './$type' imports for Kit route files,
+                    // you'll likely want these to stay as-is
+                    change.textChanges = change.textChanges.filter(
+                        (textChange) => !isKitTypePath(textChange.newText)
+                    );
                 }
                 return change;
             });

--- a/packages/language-server/src/plugins/typescript/features/utils.ts
+++ b/packages/language-server/src/plugins/typescript/features/utils.ts
@@ -356,7 +356,8 @@ export function gatherDescendants<T extends ts.Node>(
 export const gatherIdentifiers = (node: ts.Node) => gatherDescendants(node, ts.isIdentifier);
 
 export function isKitTypePath(path?: string): boolean {
-    return !!path?.includes('.svelte-kit/types');
+    if (!path) return false;
+    return /\$types(?:\.[cm]?[jt]s)?$/.test(path);
 }
 
 export function getFormatCodeBasis(formatCodeSetting: ts.FormatCodeSettings): FormatCodeBasis {

--- a/packages/language-server/src/plugins/typescript/features/utils.ts
+++ b/packages/language-server/src/plugins/typescript/features/utils.ts
@@ -357,7 +357,7 @@ export const gatherIdentifiers = (node: ts.Node) => gatherDescendants(node, ts.i
 
 export function isKitTypePath(path?: string): boolean {
     if (!path) return false;
-    return /\$types(?:\.[cm]?[jt]s)?$/.test(path);
+    return path.endsWith('/$types.js') || path.endsWith('/$types') || path.endsWith('/$types.d.ts');
 }
 
 export function getFormatCodeBasis(formatCodeSetting: ts.FormatCodeSettings): FormatCodeBasis {

--- a/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
@@ -51,7 +51,7 @@ describe('UpdateImportsProviderImpl', function () {
 
     it('updates imports', async () => {
         const { updateImportsProvider, fileUri } = await setup(
-            'updateimports.svelte',
+            '+page.svelte',
             ts.sys.useCaseSensitiveFileNames
         );
 
@@ -70,9 +70,29 @@ describe('UpdateImportsProviderImpl', function () {
         ]);
     });
 
+    it("doesn't update imports for ./$types", async () => {
+        const { updateImportsProvider, fileUri } = await setup(
+            '+page.svelte',
+            ts.sys.useCaseSensitiveFileNames
+        );
+        const newUri = pathToUrl(join(updateImportTestDir, 'subdirectory/+page.svelte'));
+        const workspaceEdit = await updateImportsProvider.updateImports({
+            oldUri: fileUri,
+            newUri
+        });
+        assert.deepStrictEqual(workspaceEdit?.documentChanges, [
+            TextDocumentEdit.create(OptionalVersionedTextDocumentIdentifier.create(newUri, null), [
+                TextEdit.replace(
+                    Range.create(Position.create(1, 17), Position.create(1, 34)),
+                    '../imported.svelte'
+                )
+            ])
+        ]);
+    });
+
     async function testUpdateForFileCasingChanges(useCaseSensitiveFileNames: boolean) {
         const { updateImportsProvider, fileUri } = await setup(
-            'updateimports.svelte',
+            '+page.svelte',
             useCaseSensitiveFileNames
         );
 

--- a/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/UpdateImportsProvider.test.ts
@@ -51,7 +51,7 @@ describe('UpdateImportsProviderImpl', function () {
 
     it('updates imports', async () => {
         const { updateImportsProvider, fileUri } = await setup(
-            '+page.svelte',
+            'updateimports.svelte',
             ts.sys.useCaseSensitiveFileNames
         );
 
@@ -81,18 +81,16 @@ describe('UpdateImportsProviderImpl', function () {
             newUri
         });
         assert.deepStrictEqual(workspaceEdit?.documentChanges, [
-            TextDocumentEdit.create(OptionalVersionedTextDocumentIdentifier.create(newUri, null), [
-                TextEdit.replace(
-                    Range.create(Position.create(1, 17), Position.create(1, 34)),
-                    '../imported.svelte'
-                )
-            ])
+            TextDocumentEdit.create(
+                OptionalVersionedTextDocumentIdentifier.create(newUri, null),
+                []
+            )
         ]);
     });
 
     async function testUpdateForFileCasingChanges(useCaseSensitiveFileNames: boolean) {
         const { updateImportsProvider, fileUri } = await setup(
-            '+page.svelte',
+            'updateimports.svelte',
             useCaseSensitiveFileNames
         );
 

--- a/packages/language-server/test/plugins/typescript/testfiles/update-imports/$types.js
+++ b/packages/language-server/test/plugins/typescript/testfiles/update-imports/$types.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/packages/language-server/test/plugins/typescript/testfiles/update-imports/+page.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/update-imports/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+import Bla from './imported.svelte';
+import { foo } from './$types.js';
+
+const {params} = $props();
+</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/update-imports/+page.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/update-imports/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-import Bla from './imported.svelte';
 import { foo } from './$types.js';
 
 const {params} = $props();

--- a/packages/language-server/test/plugins/typescript/testfiles/update-imports/updateimports.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/update-imports/updateimports.svelte
@@ -1,0 +1,3 @@
+<script>
+import Bla from './imported.svelte';
+</script>

--- a/packages/language-server/test/plugins/typescript/testfiles/update-imports/updateimports.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/update-imports/updateimports.svelte
@@ -1,3 +1,0 @@
-<script>
-import Bla from './imported.svelte';
-</script>

--- a/packages/typescript-plugin/src/language-service/update-imports.ts
+++ b/packages/typescript-plugin/src/language-service/update-imports.ts
@@ -34,8 +34,11 @@ export function decorateUpdateImports(
                 if (path.basename(renameLocation.fileName).startsWith('+')) {
                     // Filter out changes to './$type' imports for Kit route files,
                     // you'll likely want these to stay as-is
-                    renameLocation.textChanges = renameLocation.textChanges.filter((change) =>
-                        /\$types(?:\.[cm]?[jt]s)?$/.test(change.newText)
+                    renameLocation.textChanges = renameLocation.textChanges.filter(
+                        (change) =>
+                            change.newText.endsWith('/$types.js') ||
+                            change.newText.endsWith('/$types') ||
+                            change.newText.endsWith('/$types.d.ts')
                     );
                 }
                 return renameLocation;

--- a/packages/typescript-plugin/src/language-service/update-imports.ts
+++ b/packages/typescript-plugin/src/language-service/update-imports.ts
@@ -34,9 +34,9 @@ export function decorateUpdateImports(
                 if (path.basename(renameLocation.fileName).startsWith('+')) {
                     // Filter out changes to './$type' imports for Kit route files,
                     // you'll likely want these to stay as-is
-                    renameLocation.textChanges = renameLocation.textChanges.filter((change) => {
-                        return !change.newText.includes('.svelte-kit/types/');
-                    });
+                    renameLocation.textChanges = renameLocation.textChanges.filter((change) =>
+                        /\$types(?:\.[cm]?[jt]s)?$/.test(change.newText)
+                    );
                 }
                 return renameLocation;
             });


### PR DESCRIPTION
svelte2tsx compiles `const { params } = $props();` into an import reference like 
`/*Ωignore_startΩ*/;type $$ComponentProps = { params: import('./$types.js').PageProps['params'] };/*Ωignore_endΩ*/`.

When renaming a file, the `import('./$types.js')` would be replaced with the path to the old file location (i.e. `'./routes/something/$types.js'`, and because the svelte2tsx code is generated, that new string would be injected in the wrong place, causing issues like this:

```svelte
<script>
  import './foo';./routes/something/$types.js

  const { params } = $props();
</script>
```

The root cause is the `isKitTypePath` function no longer working as expected. I replaced it with a check that the string ends with `$types`, but I'm not 100% confident in that fix. This PR does fix the error, though.