### PR TITLE
fix: properly place svelte-ignore comment in quickfix when `<script module>` presents

### DIFF
--- a/.changeset/fifty-singers-smell.md
+++ b/.changeset/fifty-singers-smell.md
@@ -2,4 +2,4 @@
 'svelte-language-server': patch
 ---
 
-fix: svelte-ignore quickfix action could be improperly placed if a component contained a `<script module>` block
+fix: properly place svelte-ignore comment in quickfix when `<script module>` presents

--- a/.changeset/fifty-singers-smell.md
+++ b/.changeset/fifty-singers-smell.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+fix: svelte-ignore quickfix action could be improperly placed if a component contained a `<script module>` block

--- a/.changeset/ten-rivers-shop.md
+++ b/.changeset/ten-rivers-shop.md
@@ -2,4 +2,4 @@
 'svelte-language-server': patch
 ---
 
-fix: fix script indentation when inserting svelte-ignore comments
+fix: prevent extra script indentation when inserting svelte-ignore comments

--- a/.changeset/ten-rivers-shop.md
+++ b/.changeset/ten-rivers-shop.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+fix: fix script indentation when inserting svelte-ignore comments

--- a/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
@@ -82,7 +82,7 @@ async function createQuickfixActions(
         end: diagnosticEndOffset
     };
     const { html, instance, module } = ast;
-    const tree = [instance, module, html].find((part, i) => {
+    const tree = [instance, module, html].find((part) => {
         return (
             part &&
             part.start !== null &&

--- a/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
+++ b/packages/language-server/src/plugins/svelte/features/getCodeActions/getQuickfixes.ts
@@ -82,15 +82,14 @@ async function createQuickfixActions(
         end: diagnosticEndOffset
     };
     const { html, instance, module } = ast;
-    const tree = [html, instance, module].find((part) => {
+    const tree = [instance, module, html].find((part, i) => {
         return (
-            part?.start != null &&
+            part &&
+            part.start !== null &&
+            part.end !== null &&
             offsetRange.pos >= part.start &&
-            part?.end != null &&
             offsetRange.pos <= part.end &&
-            part?.end != null &&
             offsetRange.end <= part.end &&
-            part?.start != null &&
             offsetRange.end >= part.start
         );
     });
@@ -225,7 +224,7 @@ function getSvelteIgnoreEdit(
     const indent = getIndent(afterStartLineStart);
 
     // TODO: Make all code action's new line consistent
-    let ignore = `${indent}// svelte-ignore ${code}${EOL}${indent}`;
+    let ignore = `${indent}// svelte-ignore ${code}${EOL}`;
     if (isHtml) {
         ignore = `${indent}<!-- svelte-ignore ${code} -->${EOL}`;
     }

--- a/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
+++ b/packages/language-server/test/plugins/svelte/features/getCodeAction.test.ts
@@ -445,7 +445,7 @@ describe('SveltePlugin#getCodeAction', () => {
                             {
                                 edits: [
                                     {
-                                        newText: `\t// svelte-ignore state_referenced_locally${EOL}\t`,
+                                        newText: `\t// svelte-ignore state_referenced_locally${EOL}`,
                                         range: {
                                             end: {
                                                 character: 0,
@@ -460,6 +460,55 @@ describe('SveltePlugin#getCodeAction', () => {
                                 ],
                                 textDocument: {
                                     uri: getUri(svelteIgnoreCodeAction),
+                                    version: null
+                                }
+                            }
+                        ]
+                    },
+                    title: '(svelte) Disable state_referenced_locally for this line',
+                    kind: 'quickfix'
+                }
+            ]);
+        });
+
+        it('should properly place svelte ignore code actions when the html is on both sides of the script tag', async () => {
+            (
+                await expectCodeActionFor('svelte-ignore-correct-script-placement.svelte', {
+                    diagnostics: [
+                        {
+                            severity: DiagnosticSeverity.Warning,
+                            code: 'state_referenced_locally',
+                            range: Range.create(
+                                { line: 7, character: 16 },
+                                { line: 7, character: 17 }
+                            ),
+                            message: '',
+                            source: 'svelte'
+                        }
+                    ]
+                })
+            ).toEqual([
+                {
+                    edit: {
+                        documentChanges: [
+                            {
+                                edits: [
+                                    {
+                                        newText: `\t// svelte-ignore state_referenced_locally${EOL}`,
+                                        range: {
+                                            end: {
+                                                character: 0,
+                                                line: 7
+                                            },
+                                            start: {
+                                                character: 0,
+                                                line: 7
+                                            }
+                                        }
+                                    }
+                                ],
+                                textDocument: {
+                                    uri: getUri('svelte-ignore-correct-script-placement.svelte'),
                                     version: null
                                 }
                             }

--- a/packages/language-server/test/plugins/svelte/testfiles/svelte-ignore-correct-script-placement.svelte
+++ b/packages/language-server/test/plugins/svelte/testfiles/svelte-ignore-correct-script-placement.svelte
@@ -1,0 +1,11 @@
+<script context="module">
+</script>
+
+<p></p>
+
+<script>
+	let a = $state(1);
+	let b = $state(a);
+</script>
+
+<p></p>


### PR DESCRIPTION
In this component:
```svelte
<script module>
</script>

<script>
  let a = $state(1);
  let b = $state(a);
</script>

<p></p>
```

The quickfix action for inserting `// svelte-ignore state_referenced_locally` was instead inserting `<!-- svelte-ignore state_referenced_locally -->` above the 2nd `<script>` tag. This is because the html part of Svelte's AST technically includes the `\n\n` between the `<script module>` and `<script>` tags. The quickfix detected the diagnostic as being "inside" the html because the `<script>` block is sandwiched between that `\n\n` and the `<p></p>`.

Fix for this is to simply check if the diagnostic is inside the `<script>` block before checking if it's inside the component's html.

Also fixed a small indentation bug that was causing this:
```svelte
<script>
  let a = $state(1);
  // svelte-ignore state_referenced_locally
    let b = $state(a);

// ^ extra indent
</script>
```