### PR TITLE
fix(svelte-check): flush stdout/stderr before exit

### DIFF
--- a/.changeset/chubby-drinks-occur.md
+++ b/.changeset/chubby-drinks-occur.md
@@ -2,4 +2,4 @@
 'svelte-check': patch
 ---
 
-flush stdout/stderr before exit
+fix: flush stdout/stderr before exit

--- a/.changeset/chubby-drinks-occur.md
+++ b/.changeset/chubby-drinks-occur.md
@@ -1,0 +1,5 @@
+---
+'svelte-check': patch
+---
+
+flush stdout/stderr before exit

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -37,10 +37,11 @@
         "typescript": ">=5.0.0"
     },
     "scripts": {
-        "build": "cd ../svelte2tsx && pnpm build && cd ../language-server && pnpm build && cd ../svelte-check && rollup -c && pnpm test:sanity",
+        "build": "cd ../svelte2tsx && pnpm build && cd ../language-server && pnpm build && cd ../svelte-check && rollup -c && pnpm test:sanity && pnpm test:flush",
         "prepublishOnly": "pnpm build",
         "test": "pnpm build",
-        "test:sanity": "node test-sanity.js"
+        "test:sanity": "node test-sanity.js",
+        "test:flush": "node test-flush.js"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -37,7 +37,7 @@
         "typescript": ">=5.0.0"
     },
     "scripts": {
-        "build": "cd ../svelte2tsx && pnpm build && cd ../language-server && pnpm build && cd ../svelte-check && rollup -c && pnpm test:sanity && pnpm test:flush",
+        "build": "cd ../svelte2tsx && pnpm build && cd ../language-server && pnpm build && cd ../svelte-check && rollup -c && pnpm test:sanity",
         "prepublishOnly": "pnpm build",
         "test": "pnpm build",
         "test:sanity": "node test-sanity.js",

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -564,6 +564,18 @@ async function watchWithVirtualFiles(opts: SvelteCheckCliOptions, writer: Writer
         .add(opts.workspaceUri.fsPath);
 }
 
+// `process.stdout.write` is asynchronous on non-TTY pipes, and `process.exit`
+// does not wait for queued writes to drain. Under heavy diagnostic load this
+// caused the output to be cut short when using `--output machine-verbose`.
+function exitAfterFlush(code: number): void {
+    let pending = 2;
+    const done = () => {
+        if (--pending === 0) process.exit(code);
+    };
+    process.stdout.write('', done);
+    process.stderr.write('', done);
+}
+
 parseOptions(async (opts) => {
     try {
         const writer = instantiateWriter(opts);
@@ -580,15 +592,13 @@ parseOptions(async (opts) => {
             await watchWithVirtualFiles(opts, writer);
         } else if (useVirtualFiles) {
             const result = await runWithVirtualFiles(opts, writer);
-            if (
+            const exitCode =
                 result &&
                 result.errorCount === 0 &&
                 (!opts.failOnWarnings || result.warningCount === 0)
-            ) {
-                process.exit(0);
-            } else {
-                process.exit(1);
-            }
+                    ? 0
+                    : 1;
+            exitAfterFlush(exitCode);
         } else if (opts.watch) {
             // Wire callbacks that can reference the watcher instance created below
             let watcher: DiagnosticsWatcher;
@@ -614,15 +624,13 @@ parseOptions(async (opts) => {
                 await openAllDocuments(opts.workspaceUri, opts.filePathsToIgnore, svelteCheck);
             }
             const result = await getDiagnostics(opts.workspaceUri, writer, svelteCheck);
-            if (
+            const exitCode =
                 result &&
                 result.errorCount === 0 &&
                 (!opts.failOnWarnings || result.warningCount === 0)
-            ) {
-                process.exit(0);
-            } else {
-                process.exit(1);
-            }
+                    ? 0
+                    : 1;
+            exitAfterFlush(exitCode);
         }
     } catch (_err) {
         console.error(_err);

--- a/packages/svelte-check/test-flush.js
+++ b/packages/svelte-check/test-flush.js
@@ -1,0 +1,119 @@
+// @ts-check
+/**
+ * Regression test for the machine-verbose truncated output bug (https://github.com/sveltejs/language-tools/issues/3013).
+ *
+ * Usage: node test-flush.js
+ */
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const FIXTURE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'svelte-check-flush-'));
+const CLI = path.join(__dirname, 'dist', 'src', 'index.js');
+const ITERATIONS = 10;
+const N_DIAGS = 1500;
+
+function setupFixture() {
+    const refs = [];
+    for (let i = 0; i < N_DIAGS; i++) {
+        refs.push(`undeclaredIdentifierNumber${i};`);
+    }
+    const svelte = `<script lang="ts">\n${refs.join('\n')}\n</script>\n`;
+    fs.writeFileSync(path.join(FIXTURE_DIR, 'Index.svelte'), svelte);
+
+    const tsconfig = {
+        compilerOptions: {
+            target: 'ESNext',
+            moduleResolution: 'node',
+            strict: true,
+            skipLibCheck: true
+        },
+        include: ['Index.svelte']
+    };
+    fs.writeFileSync(path.join(FIXTURE_DIR, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
+}
+
+/**
+ * @returns {Promise<{ code: number | null, signal: NodeJS.Signals | null, stdout: string, stderr: string }>}
+ */
+function runOnce() {
+    return new Promise((resolve, reject) => {
+        const child = spawn(
+            process.execPath,
+            [
+                CLI,
+                '--workspace',
+                FIXTURE_DIR,
+                '--tsconfig',
+                path.join(FIXTURE_DIR, 'tsconfig.json'),
+                '--output',
+                'machine-verbose',
+                '--threshold',
+                'error'
+            ],
+            { stdio: ['ignore', 'pipe', 'pipe'] }
+        );
+
+        let stdout = '';
+        let stderr = '';
+
+        // Throttle the consumer so the kernel pipe stays full: after each
+        // data chunk, pause for 5 ms before resuming. Without this the OS
+        // drains the pipe faster than the child writes and the bug is
+        // invisible.
+        child.stdout.on('data', (chunk) => {
+            stdout += chunk.toString();
+            child.stdout.pause();
+            setTimeout(() => child.stdout.resume(), 5);
+        });
+
+        child.stderr.on('data', (d) => {
+            stderr += d.toString();
+        });
+
+        child.on('error', reject);
+
+        child.on('close', (code, signal) => {
+            resolve({ code, signal, stdout, stderr });
+        });
+    });
+}
+
+(async () => {
+    console.log('svelte-check stdout-flush regression test\n');
+    setupFixture();
+
+    let failures = 0;
+    for (let i = 1; i <= ITERATIONS; i++) {
+        const { code, stdout, stderr } = await runOnce();
+        const lines = stdout.split('\n').filter((l) => l.length > 0);
+        const last = lines[lines.length - 1] || '';
+        const ok = /^\d+ COMPLETED/.test(last);
+        if (ok) {
+            console.log(`  PASS: run ${i} (${lines.length} lines)`);
+        } else {
+            failures++;
+            console.log(
+                `  FAIL: run ${i} — exit=${code}, lines=${lines.length}, last=${JSON.stringify(
+                    last.slice(0, 120)
+                )}`
+            );
+            if (process.env.DEBUG_FLUSH_TEST) {
+                console.log('    stderr tail:', stderr.slice(-300));
+            }
+        }
+    }
+
+    fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+
+    if (failures > 0) {
+        console.log(`\n${failures}/${ITERATIONS} runs missing trailing COMPLETED summary`);
+        process.exit(1);
+    }
+    console.log(`\n${ITERATIONS}/${ITERATIONS} runs ended cleanly with COMPLETED summary`);
+})().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
Resolves: #3013 

`process.stdout.write` is asynchronous on non-TTY pipes, and per Node's docs `process.exit` does not wait for queued I/O. Under heavy diagnostic load (1000+ ERROR/WARNING lines, enough to saturate the kernel pipe buffer) the trailing `COMPLETED` summary of `--output machine-verbose` was dropped when the CLI exited, even though the run was clean.

Replace the bare `process.exit(N)` calls in both CLI completion paths (default and `useVirtualFiles`) with the canonical flush-then-exit pattern.

Add a regression test `test-flush.js` (`pnpm run test:flush`) that runs the CLI against a fixture emitting 1500 diagnostics, throttles the consumer to keep the pipe full, and asserts the last non-empty line matches `^\d+ COMPLETED` across 10 runs. This is useful for testing this fix but I don't know if it's worth actually commiting it to the repo or not. 

`test-flush.js` is AI generated and manually reviewed.