### PR TITLE
fix: use pug syntax for emmet in template lang pug

### DIFF
--- a/.changeset/rotten-gifts-develop.md
+++ b/.changeset/rotten-gifts-develop.md
@@ -1,0 +1,5 @@
+---
+"svelte-language-server": patch
+---
+
+fix: use pug syntax for emmet in template lang pug

--- a/packages/language-server/src/plugins/html/HTMLPlugin.ts
+++ b/packages/language-server/src/plugins/html/HTMLPlugin.ts
@@ -125,6 +125,13 @@ export class HTMLPlugin
         return this.lang.doHover(document, position, html);
     }
 
+    private getEmmetSyntax(document: Document, position: Position) {
+        return isInTag(position, document.templateInfo) &&
+            document.getLanguageAttribute('template') === 'pug'
+            ? 'pug'
+            : 'html';
+    }
+
     async getCompletions(
         document: Document,
         position: Position,
@@ -158,7 +165,12 @@ export class HTMLPlugin
             this.configManager.getEmmetConfig().showExpandedAbbreviation !== 'never'
         ) {
             doEmmetCompleteInner = () =>
-                doEmmetComplete(document, position, 'html', this.configManager.getEmmetConfig());
+                doEmmetComplete(
+                    document,
+                    position,
+                    this.getEmmetSyntax(document, position),
+                    this.configManager.getEmmetConfig()
+                );
 
             this.lang.setCompletionParticipants([
                 {

--- a/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
+++ b/packages/language-server/test/plugins/html/HTMLPlugin.test.ts
@@ -201,6 +201,32 @@ describe('HTML Plugin', () => {
         assert.strictEqual(completions, null);
     });
 
+    it('provides pug emmet completions inside template lang="pug"', async () => {
+        const { plugin, document } = setup('<template lang="pug">\ndiv>\n</template>');
+
+        const completions = await plugin.getCompletions(document, Position.create(1, 4), {
+            triggerCharacter: '>',
+            triggerKind: CompletionTriggerKind.TriggerCharacter
+        });
+
+        assert.strictEqual(completions?.items[0]?.label, 'div>');
+        assert.strictEqual(completions?.items[0]?.textEdit?.newText, 'div ${0}');
+        assert.strictEqual(completions?.items[0]?.documentation, 'div |');
+    });
+
+    it('provides html emmet completions outside template lang="pug"', async () => {
+        const { plugin, document } = setup('<template lang="pug">\np\n</template>\ndiv>');
+
+        const completions = await plugin.getCompletions(document, Position.create(3, 4), {
+            triggerCharacter: '>',
+            triggerKind: CompletionTriggerKind.TriggerCharacter
+        });
+
+        assert.strictEqual(completions?.items[0]?.label, 'div>');
+        assert.strictEqual(completions?.items[0]?.textEdit?.newText, '<div>${0}</div>');
+        assert.strictEqual(completions?.items[0]?.documentation, '<div>|</div>');
+    });
+
     it('does not provide rename for element being uppercase', async () => {
         const { plugin, document } = setup('<Div></Div>');
 


### PR DESCRIPTION
fix #1597

This PR updates Emmet completion handling so that Svelte templates with `lang="pug"` use Pug syntax instead of HTML syntax.

Changes:
- Add a regression test for Emmet completions inside `<template lang="pug">`
- Use `pug` as the Emmet syntax when the template language attribute is `pug`
- Keep the default behavior as `html` for other templates