### PR TITLE
fix: support CSS completions in nested style tags

### DIFF
--- a/.changeset/flat-rocks-search.md
+++ b/.changeset/flat-rocks-search.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+feat: support CSS completions in nested style tags

--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -174,9 +174,9 @@ export function extractStyleTag(source: string, html?: HTMLDocument): TagInforma
 export function extractStyleTagAtOffset(
     source: string,
     offset: number,
-    html?: HTMLDocument
+    html: HTMLDocument
 ): TagInformation | null {
-    const node = (html ?? parseHtml(source)).findNodeAt(offset);
+    const node = html.findNodeAt(offset);
 
     if (node.tag !== 'style') {
         return null;

--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -65,7 +65,7 @@ function extractTags(
         .filter((tag) => {
             return isNotInsideControlFlowTag(tag) && isNotInsideHtmlTag(tag);
         });
-    return matchedNodes.map(transformToTagInfo);
+    return matchedNodes.map((node) => transformToTagInfo(node, text));
 
     /**
      * For every match AFTER the tag do a search for `{/X`.
@@ -119,28 +119,28 @@ function extractTags(
             rootContentBeforeTag.lastIndexOf('}')
         );
     }
+}
 
-    function transformToTagInfo(matchedNode: Node) {
-        const start = matchedNode.startTagEnd ?? matchedNode.start;
-        const end = matchedNode.endTagStart ?? matchedNode.end;
-        const startPos = positionAt(start, text);
-        const endPos = positionAt(end, text);
-        const container = {
-            start: matchedNode.start,
-            end: matchedNode.end
-        };
-        const content = text.substring(start, end);
+function transformToTagInfo(matchedNode: Node, text: string): TagInformation {
+    const start = matchedNode.startTagEnd ?? matchedNode.start;
+    const end = matchedNode.endTagStart ?? matchedNode.end;
+    const startPos = positionAt(start, text);
+    const endPos = positionAt(end, text);
+    const container = {
+        start: matchedNode.start,
+        end: matchedNode.end
+    };
+    const content = text.substring(start, end);
 
-        return {
-            content,
-            attributes: parseAttributes(matchedNode.attributes),
-            start,
-            end,
-            startPos,
-            endPos,
-            container
-        };
-    }
+    return {
+        content,
+        attributes: parseAttributes(matchedNode.attributes),
+        start,
+        end,
+        startPos,
+        endPos,
+        container
+    };
 }
 
 export function extractScriptTags(
@@ -169,6 +169,22 @@ export function extractStyleTag(source: string, html?: HTMLDocument): TagInforma
 
     // There can only be one style tag
     return styles[0];
+}
+
+export function extractStyleTags(source: string, html?: HTMLDocument): TagInformation[] {
+    const rootNodes = html?.roots || parseHtml(source).roots;
+    const styles: TagInformation[] = [];
+
+    rootNodes.forEach(collectStyleTags);
+    return styles;
+
+    function collectStyleTags(node: Node) {
+        if (node.tag === 'style') {
+            styles.push(transformToTagInfo(node, source));
+        }
+
+        node.children?.forEach(collectStyleTags);
+    }
 }
 
 export function extractTemplateTag(source: string, html?: HTMLDocument): TagInformation | null {

--- a/packages/language-server/src/lib/documents/utils.ts
+++ b/packages/language-server/src/lib/documents/utils.ts
@@ -171,20 +171,24 @@ export function extractStyleTag(source: string, html?: HTMLDocument): TagInforma
     return styles[0];
 }
 
-export function extractStyleTags(source: string, html?: HTMLDocument): TagInformation[] {
-    const rootNodes = html?.roots || parseHtml(source).roots;
-    const styles: TagInformation[] = [];
+export function extractStyleTagAtOffset(
+    source: string,
+    offset: number,
+    html?: HTMLDocument
+): TagInformation | null {
+    const node = (html ?? parseHtml(source)).findNodeAt(offset);
 
-    rootNodes.forEach(collectStyleTags);
-    return styles;
-
-    function collectStyleTags(node: Node) {
-        if (node.tag === 'style') {
-            styles.push(transformToTagInfo(node, source));
-        }
-
-        node.children?.forEach(collectStyleTags);
+    if (node.tag !== 'style') {
+        return null;
     }
+
+    const styleInfo = transformToTagInfo(node, source);
+
+    if (offset < styleInfo.start || offset > styleInfo.end) {
+        return null;
+    }
+
+    return styleInfo;
 }
 
 export function extractTemplateTag(source: string, html?: HTMLDocument): TagInformation | null {

--- a/packages/language-server/src/plugins/css/CSSDocument.ts
+++ b/packages/language-server/src/plugins/css/CSSDocument.ts
@@ -17,12 +17,13 @@ export class CSSDocument extends ReadableDocument implements DocumentMapper {
 
     constructor(
         private parent: Document,
-        languageServices: CSSLanguageServices
+        languageServices: CSSLanguageServices,
+        styleInfo = parent.styleInfo
     ) {
         super();
 
-        if (this.parent.styleInfo) {
-            this.styleInfo = this.parent.styleInfo;
+        if (styleInfo) {
+            this.styleInfo = styleInfo;
         } else {
             this.styleInfo = {
                 attributes: {},

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -480,8 +480,8 @@ export class CSSPlugin
     }
 
     findDocumentHighlight(document: Document, position: Position): DocumentHighlight[] | null {
-        const cssDocument = this.getCSSDoc(document);
-        if (cssDocument.isInGenerated(position)) {
+        const cssDocument = this.getCSSDocAtPosition(document, position);
+        if (cssDocument) {
             if (shouldExcludeDocumentHighlights(cssDocument)) {
                 return wordHighlightForTag(document, position, document.styleInfo, wordPattern);
             }
@@ -537,7 +537,8 @@ export class CSSPlugin
 
         if (
             isInTag(position, document.scriptInfo) ||
-            isInTag(position, document.moduleScriptInfo)
+            isInTag(position, document.moduleScriptInfo) ||
+            isInTag(position, document.templateInfo)
         ) {
             return null;
         }

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -32,7 +32,7 @@ import {
     isInTag,
     mapRangeToOriginal,
     TagInformation,
-    extractStyleTags
+    extractStyleTagAtOffset
 } from '../../lib/documents';
 import { LSConfigManager, LSCSSConfig } from '../../ls-config';
 import {
@@ -179,10 +179,11 @@ export class CSSPlugin
         }
 
         const cssDocument = this.getCSSDocAtPosition(document, position);
-        if (shouldExcludeHover(cssDocument)) {
-            return null;
-        }
-        if (cssDocument.isInGenerated(position)) {
+        if (cssDocument) {
+            if (shouldExcludeHover(cssDocument)) {
+                return null;
+            }
+
             return this.doHoverInternal(cssDocument, position);
         }
         const attributeContext = getAttributeContextAtPosition(document, position);
@@ -231,7 +232,7 @@ export class CSSPlugin
 
         const cssDocument = this.getCSSDocAtPosition(document, position);
 
-        if (cssDocument.isInGenerated(position)) {
+        if (cssDocument) {
             return this.getCompletionsInternal(document, position, cssDocument);
         }
 
@@ -248,7 +249,7 @@ export class CSSPlugin
                 new StyleAttributeDocument(document, start, end, this.cssLanguageServices)
             );
         } else {
-            return getIdClassCompletion(cssDocument, attributeContext);
+            return getIdClassCompletion(this.getCSSDoc(document), attributeContext);
         }
     }
 
@@ -529,19 +530,25 @@ export class CSSPlugin
         return cssDoc;
     }
 
-    private getCSSDocAtPosition(document: Document, position: Position) {
-        const cssDoc = this.getCSSDoc(document);
-
-        if (cssDoc.isInGenerated(position)) {
-            return cssDoc;
+    private getCSSDocAtPosition(document: Document, position: Position): CSSDocument | null {
+        if (isInTag(position, document.styleInfo)) {
+            return this.getCSSDoc(document);
         }
 
-        const offset = document.offsetAt(position);
-        const styleInfo = extractStyleTags(document.getText(), document.html).find(
-            (style) => offset >= style.start && offset <= style.end
+        if (
+            isInTag(position, document.scriptInfo) ||
+            isInTag(position, document.moduleScriptInfo)
+        ) {
+            return null;
+        }
+
+        const styleInfo = extractStyleTagAtOffset(
+            document.getText(),
+            document.offsetAt(position),
+            document.html
         );
 
-        return styleInfo ? new CSSDocument(document, this.cssLanguageServices, styleInfo) : cssDoc;
+        return styleInfo ? new CSSDocument(document, this.cssLanguageServices, styleInfo) : null;
     }
 
     private updateConfigs() {

--- a/packages/language-server/src/plugins/css/CSSPlugin.ts
+++ b/packages/language-server/src/plugins/css/CSSPlugin.ts
@@ -31,7 +31,8 @@ import {
     mapSelectionRangeToParent,
     isInTag,
     mapRangeToOriginal,
-    TagInformation
+    TagInformation,
+    extractStyleTags
 } from '../../lib/documents';
 import { LSConfigManager, LSCSSConfig } from '../../ls-config';
 import {
@@ -177,7 +178,7 @@ export class CSSPlugin
             return null;
         }
 
-        const cssDocument = this.getCSSDoc(document);
+        const cssDocument = this.getCSSDocAtPosition(document, position);
         if (shouldExcludeHover(cssDocument)) {
             return null;
         }
@@ -228,7 +229,7 @@ export class CSSPlugin
             return null;
         }
 
-        const cssDocument = this.getCSSDoc(document);
+        const cssDocument = this.getCSSDocAtPosition(document, position);
 
         if (cssDocument.isInGenerated(position)) {
             return this.getCompletionsInternal(document, position, cssDocument);
@@ -526,6 +527,21 @@ export class CSSPlugin
             this.cssDocuments.set(document, cssDoc);
         }
         return cssDoc;
+    }
+
+    private getCSSDocAtPosition(document: Document, position: Position) {
+        const cssDoc = this.getCSSDoc(document);
+
+        if (cssDoc.isInGenerated(position)) {
+            return cssDoc;
+        }
+
+        const offset = document.offsetAt(position);
+        const styleInfo = extractStyleTags(document.getText(), document.html).find(
+            (style) => offset >= style.start && offset <= style.end
+        );
+
+        return styleInfo ? new CSSDocument(document, this.cssLanguageServices, styleInfo) : cssDoc;
     }
 
     private updateConfigs() {

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -184,7 +184,8 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionRe
                     'SnippetBlock',
                     'IfBlock',
                     'EachBlock',
-                    'AwaitBlock'
+                    'AwaitBlock',
+                    'Style'
                 ].includes(svelteNode.parent?.type as any)) ||
             // Cursor is at <div>|</div> in which case there's no TextNode inbetween
             document.getText().substring(originalOffset - 1, originalOffset + 2) === '></'

--- a/packages/language-server/test/plugins/css/CSSPlugin.test.ts
+++ b/packages/language-server/test/plugins/css/CSSPlugin.test.ts
@@ -84,6 +84,18 @@ describe('CSS Plugin', () => {
             const { plugin, document } = setup('<div style="height: {}"></div>');
             assert.deepStrictEqual(plugin.doHover(document, Position.create(0, 13)), null);
         });
+
+        it('provides hover info inside nested style tag', () => {
+            const { plugin, document } = setup('<svelte:head><style>h1 {}</style></svelte:head>');
+
+            assert.deepStrictEqual(plugin.doHover(document, Position.create(0, 20)), <Hover>{
+                contents: [
+                    { language: 'html', value: '<h1>' },
+                    '[Selector Specificity](https://developer.mozilla.org/docs/Web/CSS/Specificity): (0, 0, 1)'
+                ],
+                range: Range.create(0, 20, 0, 22)
+            });
+        });
     });
 
     describe('provides completions', () => {
@@ -207,6 +219,24 @@ describe('CSS Plugin', () => {
                         }
                     }
                 }
+            );
+        });
+
+        it('provides completions inside nested style tag', async () => {
+            const { plugin, document } = setup(`<svelte:head><style></style></svelte:head>`);
+
+            const completions = await plugin.getCompletions(document, Position.create(0, 20), {
+                triggerCharacter: '.'
+            } as CompletionContext);
+
+            assert.ok(
+                Array.isArray(completions?.items),
+                'Expected completion items to be an array'
+            );
+            assert.ok(completions.items.length > 0, 'Expected completions to have length');
+            assert.ok(
+                completions.items.some((item) => item.label === '@charset'),
+                'Expected CSS completions'
             );
         });
     });


### PR DESCRIPTION
fix #2175

Fixes CSS completions and hover for nested `<style>` tags.

Previously, the CSS plugin used `document.styleInfo`, which only represents the top-level style tag. As a result, positions inside nested style tags were not treated as being inside a generated CSS document, so completions and hover did not work.

This PR resolves the CSS document based on the current cursor position. If the current position is inside a nested `<style>` tag, the CSS plugin creates a `CSSDocument` using that tag's `styleInfo`.



## Changes
- Add `extractStyleTagAtOffset` to resolve the style tag at the current position using the HTML AST
- Allow `CSSDocument` to be created with a specific `styleInfo`
- Use a position-based CSS document for completions and hover
- Add regression tests for:
  - `<svelte:head><style></style></svelte:head>`
  - a nested `<style>` tag