### PR TITLE
fix: correct 'occured' typo in svelte:boundary onerror description

### DIFF
--- a/.changeset/cuddly-boundaries-occurred.md
+++ b/.changeset/cuddly-boundaries-occurred.md
@@ -1,0 +1,5 @@
+---
+"svelte-language-server": patch
+---
+
+fix: correct 'occured' typo in `svelte:boundary` `onerror` description (shown in editor IntelliSense)

--- a/packages/language-server/src/plugins/html/dataProvider.ts
+++ b/packages/language-server/src/plugins/html/dataProvider.ts
@@ -374,7 +374,7 @@ const svelteTags: ITagData[] = [
         attributes: [
             {
                 name: 'onerror',
-                description: 'Called when an error occured within the boundary'
+                description: 'Called when an error occurred within the boundary'
             }
         ]
     }


### PR DESCRIPTION
## Summary

Fixes a typo `occured` → `occurred` in the IntelliSense description for the `onerror` attribute of `<svelte:boundary>`.

This text is surfaced to users in editor autocomplete/hover (via the HTML data provider in the Svelte language server):

```ts
{
    name: 'onerror',
    description: 'Called when an error occurred within the boundary'
}
```

Spelling only — no behavior change.
