### PR TITLE
fix: don't show type inlay hint for component inside snippets

### DIFF
--- a/.changeset/afraid-things-sin.md
+++ b/.changeset/afraid-things-sin.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+fix: don't show type inlay hint for component inside snippets

--- a/.changeset/cuddly-boundaries-occurred.md
+++ b/.changeset/cuddly-boundaries-occurred.md
@@ -1,5 +1,5 @@
 ---
-"svelte-language-server": patch
+'svelte-language-server': patch
 ---
 
 fix: correct 'occured' typo in `svelte:boundary` `onerror` description (shown in editor IntelliSense)

--- a/packages/language-server/src/plugins/typescript/features/InlayHintProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/InlayHintProvider.ts
@@ -18,7 +18,8 @@ import {
     findChildOfKind,
     findRenderFunction,
     SnapshotMap,
-    startsWithIgnoredPosition
+    startsWithIgnoredPosition,
+    findClosestContainingNode
 } from './utils';
 import { convertRange, isSvelte2tsxShimFile } from '../utils';
 
@@ -238,7 +239,7 @@ export class InlayHintProviderImpl implements InlayHintProvider {
             return true;
         }
 
-        const declaration = findContainingNode(
+        const declaration = findClosestContainingNode(
             sourceFile,
             { start: inlayHint.position, length: 0 },
             ts.isVariableDeclaration

--- a/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/snippet.v5/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/snippet.v5/expectedv2.json
@@ -13,7 +13,7 @@
             },
             { "value": ":" }
         ],
-        "position": { "line": 4, "character": 13 },
+        "position": { "line": 5, "character": 13 },
         "kind": 2,
         "paddingRight": true
     }

--- a/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/snippet.v5/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/inlayHints/fixtures/snippet.v5/input.svelte
@@ -1,5 +1,6 @@
 {#snippet hi2(a = 1)}
     hello world
+    <Test />
 {/snippet}
 
 {@render hi2(1)}


### PR DESCRIPTION
Reported in Discord. The inlay hint is the type hint for the component's hidden variables.