### PR TITLE
fix: mark optional members with a trailing ? in completion labels (#3043)

### DIFF
--- a/.changeset/optional-completion-label.md
+++ b/.changeset/optional-completion-label.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+fix: mark optional members with a trailing `?` in completion labels

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -765,17 +765,13 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionRe
             };
         }
 
-        // Optional members are reported by TypeScript through the `optional` kind
-        // modifier. Surface that in the label with a trailing `?` (matching the
-        // TypeScript language service), while keeping the inserted text as the
-        // bare name so the `?` is display-only.
         const isOptional = kindModifiers
             ?.split(/,|\s+/)
             .includes(ts.ScriptElementKindModifier.optionalModifier);
 
         return {
             label: isOptional ? `${name}?` : name,
-            insertText: isOptional ? (insertText ?? name) : insertText,
+            insertText,
             isSvelteComp,
             isRunesCompletion
         };

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -765,9 +765,17 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionRe
             };
         }
 
+        // Optional members are reported by TypeScript through the `optional` kind
+        // modifier. Surface that in the label with a trailing `?` (matching the
+        // TypeScript language service), while keeping the inserted text as the
+        // bare name so the `?` is display-only.
+        const isOptional = kindModifiers
+            ?.split(/,|\s+/)
+            .includes(ts.ScriptElementKindModifier.optionalModifier);
+
         return {
-            label: name,
-            insertText,
+            label: isOptional ? `${name}?` : name,
+            insertText: isOptional ? (insertText ?? name) : insertText,
             isSvelteComp,
             isRunesCompletion
         };

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -767,11 +767,11 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionRe
 
         const isOptional = kindModifiers
             ?.split(/,|\s+/)
-            insertText: isOptional ? (insertText ?? name) : insertText, // else label with ? is used if no insertText available
+            .includes(ts.ScriptElementKindModifier.optionalModifier);
 
         return {
             label: isOptional ? `${name}?` : name,
-            insertText,
+            insertText: isOptional ? (insertText ?? name) : insertText, // else label with ? is used if no insertText available,
             isSvelteComp,
             isRunesCompletion
         };

--- a/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
+++ b/packages/language-server/src/plugins/typescript/features/CompletionProvider.ts
@@ -767,7 +767,7 @@ export class CompletionsProviderImpl implements CompletionsProvider<CompletionRe
 
         const isOptional = kindModifiers
             ?.split(/,|\s+/)
-            .includes(ts.ScriptElementKindModifier.optionalModifier);
+            insertText: isOptional ? (insertText ?? name) : insertText, // else label with ? is used if no insertText available
 
         return {
             label: isOptional ? `${name}?` : name,

--- a/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
+++ b/packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts
@@ -1775,6 +1775,28 @@ describe('CompletionProviderImpl', function () {
         });
     });
 
+    it('marks optional object literal members with a trailing ? in the label', async () => {
+        const { completionProvider, document } = setup('object-member.svelte');
+
+        const completions = await completionProvider.getCompletions(
+            document,
+            {
+                line: 14,
+                character: 30
+            },
+            {
+                triggerKind: CompletionTriggerKind.Invoked
+            }
+        );
+
+        const item = completions?.items.find((item) => item.label === 'baz?');
+
+        assert.ok(item, 'Expected optional property completion to be labelled "baz?"');
+        // The `?` is display-only — the inserted text must remain the bare name.
+        assert.strictEqual(item?.insertText ?? item?.label, 'baz');
+        assert.strictEqual(item?.data?.name, 'baz');
+    });
+
     it('provides import completions store that isnt imported yet', async () => {
         const { completionProvider, document } = setup('importcompletions-store.svelte');
 

--- a/packages/language-server/test/plugins/typescript/testfiles/completions/object-member.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/completions/object-member.svelte
@@ -10,4 +10,7 @@
     class A implements SayHi {
         h
     }
+
+    function takeOptions(options: { bar: boolean; baz?: number }) {}
+    takeOptions({ bar: false,  })
 </script>


### PR DESCRIPTION
## Summary

- Optional object/class members were missing the trailing `?` in their completion labels (e.g. `baz?: number` completed as `baz`), unlike the TypeScript language service / vtsls.
- TypeScript reports optionality via the `optional` kind modifier on the completion entry, which `getCompletionLabelAndInsert` ignored.

## Changes

- `packages/language-server/src/plugins/typescript/features/CompletionProvider.ts`: detect `ts.ScriptElementKindModifier.optionalModifier` and append `?` to the label, keeping `insertText` as the bare name so the `?` is display-only.
- `packages/language-server/test/plugins/typescript/testfiles/completions/object-member.svelte`: add an optional-property scenario.
- `packages/language-server/test/plugins/typescript/features/CompletionProvider.test.ts`: regression test asserting the `baz?` label and bare insert text.
- `.changeset/optional-completion-label.md`: patch changeset for `svelte-language-server`.

## Test plan

`pnpm --filter svelte-language-server test` — 69/69 pass; new test fails without the source change.

Fixes #3043