### PR TITLE
fix(svelte2tsx): don't crash on array binding holes in destructured exports

### DIFF
--- a/.changeset/svelte2tsx-export-destructure-array-hole.md
+++ b/.changeset/svelte2tsx-export-destructure-array-hole.md
@@ -1,0 +1,5 @@
+---
+'svelte2tsx': patch
+---
+
+fix: don't crash on array binding holes in destructured exports (e.g. `export let { d: [a, , c] } = obj`)

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -666,6 +666,10 @@ export class ExportedNames {
         }
 
         name.elements.forEach((child) => {
+            // Skip array binding holes (`[a, , c]`), which have no `name`.
+            if (ts.isOmittedExpression(child)) {
+                return;
+            }
             this.addExportForBindingPattern(child.name, isLet, undefined, type, required);
         });
     }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-destructuring-array-hole/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-destructuring-array-hole/expected-svelte5.ts
@@ -1,0 +1,13 @@
+///<reference types="svelte" />
+;function $$render() {
+
+    const o = { a: 1, b: { c: 2, d: [3, 4, 5] }, e: [6] };
+
+     let { a, b: { c, d: [d_one, , d_three] }, e: [e_one] } = o;
+     const { a: A, b: { c: C } } = o;
+;
+async () => {};
+return { props: {a: a , c: c , d_one: d_one , d_three: d_three , e_one: e_one , A: A , C: C}, exports: /** @type {{A: typeof A,C: typeof C}} */ ({}), bindings: "", slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(['a','c','d_one','d_three','e_one','A','C'], __sveltets_2_with_any_event($$render())));
+/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-destructuring-array-hole/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-destructuring-array-hole/expectedv2.ts
@@ -1,0 +1,13 @@
+///<reference types="svelte" />
+;function $$render() {
+
+    const o = { a: 1, b: { c: 2, d: [3, 4, 5] }, e: [6] };
+
+     let { a, b: { c, d: [d_one, , d_three] }, e: [e_one] } = o;
+     const { a: A, b: { c: C } } = o;
+;
+async () => {};
+return { props: {a: a , c: c , d_one: d_one , d_three: d_three , e_one: e_one , A: A , C: C}, slots: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(['a','c','d_one','d_three','e_one','A','C'], __sveltets_2_with_any_event($$render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/export-destructuring-array-hole/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/export-destructuring-array-hole/input.svelte
@@ -1,0 +1,6 @@
+<script>
+    const o = { a: 1, b: { c: 2, d: [3, 4, 5] }, e: [6] };
+
+    export let { a, b: { c, d: [d_one, , d_three] }, e: [e_one] } = o;
+    export const { a: A, b: { c: C } } = o;
+</script>


### PR DESCRIPTION
Array binding holes are nameless `OmittedExpressions`, causing `addExportForBindingPattern` to call `ts.isIdentifier(undefined)` and throw. Skip holes.