### PR TITLE
feat: custom component attributes via svelteHTML.ComponentAttributes

### DIFF
--- a/.changeset/component-custom-attributes.md
+++ b/.changeset/component-custom-attributes.md
@@ -1,0 +1,18 @@
+---
+'svelte2tsx': minor
+---
+
+feat: allow augmenting Svelte components with custom namespaced attributes via `svelteHTML.ComponentAttributes`
+
+Frameworks built on top of Svelte sometimes attach custom namespaced attributes to components (e.g. `<MyComponent mochi:defer />`). These previously caused type errors because the attribute is not part of the component's props. You can now declare such attributes globally — and have their values type-checked — by augmenting the `svelteHTML.ComponentAttributes` interface in a `d.ts` file (e.g. your `app.d.ts`):
+
+```ts
+declare namespace svelteHTML {
+    interface ComponentAttributes {
+        'mochi:defer'?: boolean;
+        'mochi:hydrate:visible'?: { rootMargin?: string };
+    }
+}
+```
+
+With this in place, `<MyComponent mochi:defer mochi:hydrate:visible={{ rootMargin: '200px' }} someOtherProps="foo" />` type-checks: the namespaced attributes are validated against the declared types, while regular props keep being checked against the component's own prop definition. Only attribute names containing a `:` are treated as custom component attributes, and any namespaced attribute you don't declare is reported as an error so typos are caught.

--- a/.changeset/component-custom-attributes.md
+++ b/.changeset/component-custom-attributes.md
@@ -4,15 +4,15 @@
 
 feat: allow augmenting Svelte components with custom namespaced attributes via `svelteHTML.ComponentAttributes`
 
-Frameworks built on top of Svelte sometimes attach custom namespaced attributes to components (e.g. `<MyComponent mochi:defer />`). These previously caused type errors because the attribute is not part of the component's props. You can now declare such attributes globally — and have their values type-checked — by augmenting the `svelteHTML.ComponentAttributes` interface in a `d.ts` file (e.g. your `app.d.ts`):
+Frameworks built on top of Svelte sometimes attach custom namespaced attributes to components (e.g. `<MyComponent custom:defer />`). These previously caused type errors because the attribute is not part of the component's props. You can now declare such attributes globally — and have their values type-checked — by augmenting the `svelteHTML.ComponentAttributes` interface in a `d.ts` file (e.g. your `app.d.ts`):
 
 ```ts
 declare namespace svelteHTML {
     interface ComponentAttributes {
-        'mochi:defer'?: boolean;
-        'mochi:hydrate:visible'?: { rootMargin?: string };
+        'custom:defer'?: boolean;
+        'custom:hydrate:visible'?: { rootMargin?: string };
     }
 }
 ```
 
-With this in place, `<MyComponent mochi:defer mochi:hydrate:visible={{ rootMargin: '200px' }} someOtherProps="foo" />` type-checks: the namespaced attributes are validated against the declared types, while regular props keep being checked against the component's own prop definition. Only attribute names containing a `:` are treated as custom component attributes, and any namespaced attribute you don't declare is reported as an error so typos are caught.
+With this in place, `<MyComponent custom:defer custom:hydrate:visible={{ rootMargin: '200px' }} someOtherProps="foo" />` type-checks: the namespaced attributes are validated against the declared types, while regular props keep being checked against the component's own prop definition. Only attribute names containing a `:` are treated as custom component attributes, and any namespaced attribute you don't declare is reported as an error so typos are caught.

--- a/docs/preprocessors/typescript.md
+++ b/docs/preprocessors/typescript.md
@@ -197,19 +197,19 @@ export function myAction(node: HTMLElement, parameter: Parameter): ActionReturn<
 
 ### I want to allow custom (namespaced) attributes on every Svelte component
 
-The typings above only add attributes to DOM elements. If you instead want to allow extra attributes on _any Svelte component_ — for example a framework that adds namespaced attributes such as `<MyComponent mochi:defer />` — augment the `svelteHTML.ComponentAttributes` interface:
+The typings above only add attributes to DOM elements. If you instead want to allow extra attributes on _any Svelte component_ — for example a framework that adds namespaced attributes such as `<MyComponent custom:defer />` — augment the `svelteHTML.ComponentAttributes` interface:
 
 ```ts
 declare namespace svelteHTML {
     interface ComponentAttributes {
         // All members should be optional. Namespaced names (containing a `:`) are supported.
-        'mochi:defer'?: boolean;
-        'mochi:hydrate:visible'?: { rootMargin?: string };
+        'custom:defer'?: boolean;
+        'custom:hydrate:visible'?: { rootMargin?: string };
     }
 }
 ```
 
-With this in place, `<MyComponent mochi:defer mochi:hydrate:visible={{ rootMargin: '200px' }} />` type-checks against the declared types on every component, while regular props (like `someOtherProps="foo"`) keep being checked against that component's own prop definition. Only attribute names containing a `:` are treated as custom component attributes; any namespaced attribute you don't declare here is reported as an error, so typos are caught. As with the DOM typings above, make sure the `d.ts` file is referenced by your `tsconfig.json`.
+With this in place, `<MyComponent custom:defer custom:hydrate:visible={{ rootMargin: '200px' }} />` type-checks against the declared types on every component, while regular props (like `someOtherProps="foo"`) keep being checked against that component's own prop definition. Only attribute names containing a `:` are treated as custom component attributes; any namespaced attribute you don't declare here is reported as an error, so typos are caught. As with the DOM typings above, make sure the `d.ts` file is referenced by your `tsconfig.json`.
 
 ### I'm getting deprecation warnings for svelte.JSX / I want to migrate to the new typings
 

--- a/docs/preprocessors/typescript.md
+++ b/docs/preprocessors/typescript.md
@@ -195,6 +195,22 @@ export function myAction(node: HTMLElement, parameter: Parameter): ActionReturn<
 }
 ```
 
+### I want to allow custom (namespaced) attributes on every Svelte component
+
+The typings above only add attributes to DOM elements. If you instead want to allow extra attributes on _any Svelte component_ — for example a framework that adds namespaced attributes such as `<MyComponent mochi:defer />` — augment the `svelteHTML.ComponentAttributes` interface:
+
+```ts
+declare namespace svelteHTML {
+    interface ComponentAttributes {
+        // All members should be optional. Namespaced names (containing a `:`) are supported.
+        'mochi:defer'?: boolean;
+        'mochi:hydrate:visible'?: { rootMargin?: string };
+    }
+}
+```
+
+With this in place, `<MyComponent mochi:defer mochi:hydrate:visible={{ rootMargin: '200px' }} />` type-checks against the declared types on every component, while regular props (like `someOtherProps="foo"`) keep being checked against that component's own prop definition. Only attribute names containing a `:` are treated as custom component attributes; any namespaced attribute you don't declare here is reported as an error, so typos are caught. As with the DOM typings above, make sure the `d.ts` file is referenced by your `tsconfig.json`.
+
 ### I'm getting deprecation warnings for svelte.JSX / I want to migrate to the new typings
 
 Since `svelte-check` version 3 and VS Code extension version 106, a different transformation is used to get intellisense for Svelte files. This also leads to the old way of enhancing HTML typings being deprecated. You should migrate all usages of `svelte.JSX` away to either `svelte/elements` or the new `svelteHTML` namespace.

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/components.d.ts
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/components.d.ts
@@ -1,0 +1,3 @@
+import { SvelteComponentTyped } from 'svelte';
+
+export class Comp extends SvelteComponentTyped<{ someOtherProps?: string }, any, any> {}

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/expectedv2.json
@@ -1,0 +1,43 @@
+[
+    {
+        "range": { "start": { "line": 9, "character": 6 }, "end": { "line": 9, "character": 27 } },
+        "severity": 1,
+        "source": "ts",
+        "message": "Type 'string' has no properties in common with type '{ rootMargin?: string; }'.",
+        "code": 2559,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 12, "character": 6 },
+            "end": { "line": 12, "character": 16 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Object literal may only specify known properties, and '\"mochi:typo\"' does not exist in type 'ComponentAttributes'.",
+        "code": 2353,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 15, "character": 6 },
+            "end": { "line": 15, "character": 20 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Type 'number' is not assignable to type 'string'.",
+        "code": 2322,
+        "tags": []
+    },
+    {
+        "range": {
+            "start": { "line": 16, "character": 6 },
+            "end": { "line": 16, "character": 17 }
+        },
+        "severity": 1,
+        "source": "ts",
+        "message": "Object literal may only specify known properties, and '\"unknownProp\"' does not exist in type '{ someOtherProps?: string; }'.",
+        "code": 2353,
+        "tags": []
+    }
+]

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/expectedv2.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/expectedv2.json
@@ -1,6 +1,6 @@
 [
     {
-        "range": { "start": { "line": 9, "character": 6 }, "end": { "line": 9, "character": 27 } },
+        "range": { "start": { "line": 9, "character": 6 }, "end": { "line": 9, "character": 28 } },
         "severity": 1,
         "source": "ts",
         "message": "Type 'string' has no properties in common with type '{ rootMargin?: string; }'.",
@@ -10,11 +10,11 @@
     {
         "range": {
             "start": { "line": 12, "character": 6 },
-            "end": { "line": 12, "character": 16 }
+            "end": { "line": 12, "character": 17 }
         },
         "severity": 1,
         "source": "ts",
-        "message": "Object literal may only specify known properties, and '\"mochi:typo\"' does not exist in type 'ComponentAttributes'.",
+        "message": "Object literal may only specify known properties, and '\"custom:typo\"' does not exist in type 'ComponentAttributes'.",
         "code": 2353,
         "tags": []
     },

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/input.svelte
@@ -3,14 +3,14 @@
 </script>
 
 <!-- valid: declared custom attributes -->
-<Comp mochi:defer />
-<Comp mochi:hydrate:visible={{ rootMargin: '200px' }} someOtherProps="foo" />
+<Comp custom:defer />
+<Comp custom:hydrate:visible={{ rootMargin: '200px' }} someOtherProps="foo" />
 
 <!-- invalid: declared custom attribute with wrong value type -->
-<Comp mochi:hydrate:visible="oops" />
+<Comp custom:hydrate:visible="oops" />
 
 <!-- invalid: undeclared custom (namespaced) attribute -->
-<Comp mochi:typo />
+<Comp custom:typo />
 
 <!-- invalid: regular prop still validated against the component's own props -->
 <Comp someOtherProps={123} />

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/input.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import { Comp } from './components';
+</script>
+
+<!-- valid: declared custom attributes -->
+<Comp mochi:defer />
+<Comp mochi:hydrate:visible={{ rootMargin: '200px' }} someOtherProps="foo" />
+
+<!-- invalid: declared custom attribute with wrong value type -->
+<Comp mochi:hydrate:visible="oops" />
+
+<!-- invalid: undeclared custom (namespaced) attribute -->
+<Comp mochi:typo />
+
+<!-- invalid: regular prop still validated against the component's own props -->
+<Comp someOtherProps={123} />
+<Comp unknownProp="x" />

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/svelte-ambient-typings.d.ts
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/svelte-ambient-typings.d.ts
@@ -1,0 +1,6 @@
+declare namespace svelteHTML {
+    interface ComponentAttributes {
+        'mochi:defer'?: boolean;
+        'mochi:hydrate:visible'?: { rootMargin?: string };
+    }
+}

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/svelte-ambient-typings.d.ts
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/svelte-ambient-typings.d.ts
@@ -1,6 +1,6 @@
 declare namespace svelteHTML {
     interface ComponentAttributes {
-        'mochi:defer'?: boolean;
-        'mochi:hydrate:visible'?: { rootMargin?: string };
+        'custom:defer'?: boolean;
+        'custom:hydrate:visible'?: { rootMargin?: string };
     }
 }

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/tsconfig.json
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/component-custom-attributes/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "strict": false,
+        "types": ["svelte"]
+    }
+}

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
@@ -103,6 +103,16 @@ export function handleAttribute(
                           value = ['""'];
                       }
                       value.push('})');
+                  } else if (attr.name.includes(':')) {
+                      // Namespaced attributes (e.g. `mochi:defer`) are not part of the
+                      // component's props definition. They can be opted into globally by
+                      // augmenting `svelteHTML.ComponentAttributes`, so route them through
+                      // a helper that validates against that interface instead.
+                      name.unshift('...__sveltets_2_componentAttr({');
+                      if (!value) {
+                          value = ['true'];
+                      }
+                      value.push('})');
                   }
                   element.addProp(name, value);
               };

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
@@ -104,7 +104,7 @@ export function handleAttribute(
                       }
                       value.push('})');
                   } else if (attr.name.includes(':')) {
-                      // Namespaced attributes (e.g. `mochi:defer`) are not part of the
+                      // Namespaced attributes (e.g. `custom:defer`) are not part of the
                       // component's props definition. They can be opted into globally by
                       // augmenting `svelteHTML.ComponentAttributes`, so route them through
                       // a helper that validates against that interface instead.

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -147,13 +147,13 @@ declare function __sveltets_2_componentAttr(attr: svelteHTML.ComponentAttributes
 declare namespace svelteHTML {
     /**
      * Augment this interface to globally allow custom namespaced attributes
-     * (e.g. `mochi:defer`) on any Svelte component. All members should be optional.
+     * (e.g. `custom:defer`) on any Svelte component. All members should be optional.
      *
      * ```ts
      * declare namespace svelteHTML {
      *     interface ComponentAttributes {
-     *         'mochi:defer'?: boolean;
-     *         'mochi:hydrate:visible'?: { rootMargin?: string };
+     *         'custom:defer'?: boolean;
+     *         'custom:hydrate:visible'?: { rootMargin?: string };
      *     }
      * }
      * ```

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -142,6 +142,25 @@ declare function __sveltets_2_nonNullable<T>(type: T): NonNullable<T>;
 
 declare function __sveltets_2_cssProp(prop: Record<string, any>): {};
 
+declare function __sveltets_2_componentAttr(attr: svelteHTML.ComponentAttributes): {};
+
+declare namespace svelteHTML {
+    /**
+     * Augment this interface to globally allow custom namespaced attributes
+     * (e.g. `mochi:defer`) on any Svelte component. All members should be optional.
+     *
+     * ```ts
+     * declare namespace svelteHTML {
+     *     interface ComponentAttributes {
+     *         'mochi:defer'?: boolean;
+     *         'mochi:hydrate:visible'?: { rootMargin?: string };
+     *     }
+     * }
+     * ```
+     */
+    interface ComponentAttributes {}
+}
+
 // @ts-ignore Svelte v3/v4 don't have this
 declare function __sveltets_2_ensureSnippet(val: ReturnType<import('svelte').Snippet> | undefined | null): any;
 

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -225,6 +225,25 @@ declare function __sveltets_2_nonNullable<T>(type: T): NonNullable<T>;
 
 declare function __sveltets_2_cssProp(prop: Record<string, any>): {};
 
+declare function __sveltets_2_componentAttr(attr: svelteHTML.ComponentAttributes): {};
+
+declare namespace svelteHTML {
+    /**
+     * Augment this interface to globally allow custom namespaced attributes
+     * (e.g. `mochi:defer`) on any Svelte component. All members should be optional.
+     *
+     * ```ts
+     * declare namespace svelteHTML {
+     *     interface ComponentAttributes {
+     *         'mochi:defer'?: boolean;
+     *         'mochi:hydrate:visible'?: { rootMargin?: string };
+     *     }
+     * }
+     * ```
+     */
+    interface ComponentAttributes {}
+}
+
 /** @internal PRIVATE API, DO NOT USE */
 type __sveltets_2_SvelteAnimationReturnType = {
     delay?: number,

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -230,13 +230,13 @@ declare function __sveltets_2_componentAttr(attr: svelteHTML.ComponentAttributes
 declare namespace svelteHTML {
     /**
      * Augment this interface to globally allow custom namespaced attributes
-     * (e.g. `mochi:defer`) on any Svelte component. All members should be optional.
+     * (e.g. `custom:defer`) on any Svelte component. All members should be optional.
      *
      * ```ts
      * declare namespace svelteHTML {
      *     interface ComponentAttributes {
-     *         'mochi:defer'?: boolean;
-     *         'mochi:hydrate:visible'?: { rootMargin?: string };
+     *         'custom:defer'?: boolean;
+     *         'custom:hydrate:visible'?: { rootMargin?: string };
      *     }
      * }
      * ```

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/component-custom-attribute/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/component-custom-attribute/expectedv2.js
@@ -1,0 +1,3 @@
+  { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {...__sveltets_2_componentAttr({"mochi:defer":true}),}});}
+ { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {    ...__sveltets_2_componentAttr({"mochi:hydrate:visible":{ rootMargin: '200px' }}),"someOtherProps":`foo`,}});}
+ { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {  ...__sveltets_2_componentAttr({"mochi:label":`hi ${name}`}),}});}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/component-custom-attribute/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/component-custom-attribute/expectedv2.js
@@ -1,3 +1,3 @@
-  { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {...__sveltets_2_componentAttr({"mochi:defer":true}),}});}
- { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {    ...__sveltets_2_componentAttr({"mochi:hydrate:visible":{ rootMargin: '200px' }}),"someOtherProps":`foo`,}});}
- { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {  ...__sveltets_2_componentAttr({"mochi:label":`hi ${name}`}),}});}
+  { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {...__sveltets_2_componentAttr({"custom:defer":true}),}});}
+ { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {    ...__sveltets_2_componentAttr({"custom:hydrate:visible":{ rootMargin: '200px' }}),"someOtherProps":`foo`,}});}
+ { const $$_tnenopmoC0C = __sveltets_2_ensureComponent(Component); new $$_tnenopmoC0C({ target: __sveltets_2_any(), props: {  ...__sveltets_2_componentAttr({"custom:label":`hi ${name}`}),}});}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/component-custom-attribute/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/component-custom-attribute/input.svelte
@@ -1,3 +1,3 @@
-<Component mochi:defer />
-<Component mochi:hydrate:visible={{ rootMargin: '200px' }} someOtherProps="foo" />
-<Component mochi:label="hi {name}" />
+<Component custom:defer />
+<Component custom:hydrate:visible={{ rootMargin: '200px' }} someOtherProps="foo" />
+<Component custom:label="hi {name}" />

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/component-custom-attribute/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/component-custom-attribute/input.svelte
@@ -1,0 +1,3 @@
+<Component mochi:defer />
+<Component mochi:hydrate:visible={{ rootMargin: '200px' }} someOtherProps="foo" />
+<Component mochi:label="hi {name}" />


### PR DESCRIPTION
Frameworks built on top of Svelte sometimes attach custom **namespaced** attributes to components (e.g. `<MyComponent custom:defer />`). Until now these triggered type errors because the attribute isn't part of the component's props.

You can now declare such attributes globally — and have their values type-checked — by augmenting the `svelteHTML.ComponentAttributes` interface in a `d.ts` file (e.g. your `app.d.ts`):

```ts
declare namespace svelteHTML {
    interface ComponentAttributes {
        'custom:defer'?: boolean;
        'custom:hydrate:visible'?: { rootMargin?: string };
    }
}
```

With this in place:

```svelte
<MyComponent custom:defer custom:hydrate:visible={{ rootMargin: '200px' }} someOtherProp="foo" />
```

- Only attribute names containing a `:` are treated as custom component attributes.
- Declared namespaced attributes are validated against their declared types.
- Regular props keep being checked against the component's own prop definitions.
- Any namespaced attribute you *don't* declare is reported as an error, so typos are caught.

### How it works

`svelte2tsx` routes colon-namespaced attributes on components through a new `__sveltets_2_componentAttr` helper whose parameter is the augmentable `svelteHTML.ComponentAttributes` interface (added to both shim sets).

Includes docs, a changeset, and htmlx2jsx + language-server diagnostics fixtures.
