### PR TITLE
fix: load esm version of Vite

### DIFF
--- a/.changeset/chubby-crews-sip.md
+++ b/.changeset/chubby-crews-sip.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/load-config': patch
+'svelte-language-server': patch
+'svelte-check': patch
+---
+
+fix: load esm version of Vite

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -53,7 +53,7 @@
     },
     "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
-        "@sveltejs/load-config": "workspace:*",
+        "@sveltejs/load-config": "workspace:^",
         "@vscode/emmet-helper": "2.8.4",
         "chokidar": "^4.0.1",
         "estree-walker": "^2.0.1",

--- a/packages/load-config/src/index.ts
+++ b/packages/load-config/src/index.ts
@@ -221,8 +221,74 @@ async function loadSvelteConfig(configFilePath: string): Promise<LoadConfigResul
 
 async function tryImportVite(fromPath: string): Promise<ViteModule | undefined> {
     try {
+        const importPath = getViteImportPath(fromPath);
+        if (importPath) {
+            return await dynamicImport(pathToFileURL(importPath).href);
+        }
+    } catch {
+        // fall through to legacy import
+    }
+
+    return importViteLegacy(fromPath);
+}
+
+function getViteImportPath(fromPath: string): string | undefined {
+    const pkgPath = require.resolve('vite/package.json', { paths: [fromPath] });
+    const pkgDir = path.dirname(pkgPath);
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+        exports?: Record<string, unknown>;
+        module?: string;
+        main?: string;
+    };
+
+    const entry = resolvePackageImportExport(pkg.exports?.['.']);
+    if (entry) {
+        return path.join(pkgDir, entry);
+    }
+
+    const fallback = pkg.module ?? pkg.main;
+    return fallback ? path.join(pkgDir, fallback) : undefined;
+}
+
+function resolvePackageImportExport(exportEntry: unknown): string | undefined {
+    if (typeof exportEntry === 'string') {
+        return exportEntry;
+    }
+
+    if (!exportEntry || typeof exportEntry !== 'object') {
+        return undefined;
+    }
+
+    const entry = exportEntry as Record<string, unknown>;
+    const importEntry = entry.import;
+
+    if (typeof importEntry === 'string') {
+        return importEntry;
+    }
+
+    if (importEntry && typeof importEntry === 'object') {
+        const defaultEntry = (importEntry as Record<string, unknown>).default;
+        if (typeof defaultEntry === 'string') {
+            return defaultEntry;
+        }
+    }
+
+    if (typeof entry.default === 'string') {
+        return entry.default;
+    }
+
+    return undefined;
+}
+
+async function importViteLegacy(fromPath: string): Promise<ViteModule | undefined> {
+    try {
         const main = require.resolve('vite', { paths: [fromPath] });
-        return await dynamicImport(pathToFileURL(main).href);
+        // require.resolve will use the cjs version
+        const prev = process.env.VITE_CJS_IGNORE_WARNING;
+        process.env.VITE_CJS_IGNORE_WARNING = 'true';
+        const result = await dynamicImport(pathToFileURL(main).href);
+        process.env.VITE_CJS_IGNORE_WARNING = prev;
+        return result;
     } catch {
         return undefined;
     }

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
-        "@sveltejs/load-config": "workspace:*",
+        "@sveltejs/load-config": "workspace:^",
         "chokidar": "^4.0.1",
         "fdir": "^6.2.0",
         "picocolors": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         specifier: ^0.3.25
         version: 0.3.25
       '@sveltejs/load-config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../load-config
       '@vscode/emmet-helper':
         specifier: 2.8.4
@@ -137,7 +137,7 @@ importers:
         specifier: ^0.3.25
         version: 0.3.25
       '@sveltejs/load-config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../load-config
       chokidar:
         specifier: ^4.0.1


### PR DESCRIPTION
cjs version will be gone at some point, and it prints a warning already