### PR TITLE
fix (svelte-check): `--tsgo-experimental-api` option is not honored

### DIFF
--- a/.changeset/cold-ads-double.md
+++ b/.changeset/cold-ads-double.md
@@ -2,4 +2,4 @@
 'svelte-check': patch
 ---
 
-Fix command-liee option parsing of --tsgo-experimental-api flag
+fix: correctly parse --tsgo-experimental-api flag

--- a/.changeset/cold-ads-double.md
+++ b/.changeset/cold-ads-double.md
@@ -1,0 +1,5 @@
+---
+'svelte-check': patch
+---
+
+Fix command-liee option parsing of --tsgo-experimental-api flag

--- a/packages/svelte-check/src/options.ts
+++ b/packages/svelte-check/src/options.ts
@@ -113,7 +113,7 @@ export function parseOptions(cb: (opts: SvelteCheckCliOptions) => any) {
                 compilerWarnings: getCompilerWarnings(opts),
                 diagnosticSources: getDiagnosticSources(opts),
                 threshold: getThreshold(opts),
-                tsgoExperimental: !!opts['tsgo-experimental']
+                tsgoExperimental: !!opts['tsgo-experimental-api']
             });
         });
 


### PR DESCRIPTION
The option is `--tsgo-experimental-api` but when using it, the code was looking at `opts['tsgo-experimental']` so it wasn't possible to actually enable the new flag in the published 4.7.0.

Manually verified the fix by building svelte-check and running it against my projects.

Fixes #3068