### PR TITLE
fix: support TypeScript 7 under npm alias

### DIFF
--- a/.changeset/light-streets-divide.md
+++ b/.changeset/light-streets-divide.md
@@ -1,0 +1,5 @@
+---
+'svelte-check': patch
+---
+
+fix: support TypeScript 7 rc under npm alias

--- a/.changeset/proud-gifts-dig.md
+++ b/.changeset/proud-gifts-dig.md
@@ -1,0 +1,5 @@
+---
+'svelte2tsx': patch
+---
+
+fix: throw a friendly error for TypeScript 7 stable

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -59,7 +59,7 @@ TypeScript 7 support currently requires the `--tsgo` or `--tsgo-experimental-api
 You can setup both version with an npm alias:
 
 ```sh
-npm install --save-dev typescript@~6 typescript-7@npm:typescript@7
+npm install --save-dev typescript@~6 @typescript/native@npm:typescript@7
 ```
 
 ### Args:

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -54,9 +54,9 @@ Usage:
 
 #### TypeScript 7 supports
 
-TypeScript 7 support currently requires `--tsgo` or `--tsgo-experimental-api` flag. You need to install both TypeScript 7 and TypeScript 6.
+TypeScript 7 support currently requires the `--tsgo` or `--tsgo-experimental-api` flag. You need to install both TypeScript 7 and TypeScript 6.
 
-You can setup both version with npm alias
+You can setup both version with an npm alias:
 
 ```sh
 npm install --save-dev typescript@~6 typescript-7@npm:typescript@7

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -54,22 +54,12 @@ Usage:
 
 #### TypeScript 7 supports
 
-TypeScript 7 support currently requires `--tsgo` or `--tsgo-experimental-api` flag. You need to install both TypeScript 7 and TypeScript 6. Before TypeScript 7 stable is released. You can install `@typescript/native-preview`
+TypeScript 7 support currently requires `--tsgo` or `--tsgo-experimental-api` flag. You need to install both TypeScript 7 and TypeScript 6.
+
+You can setup both version with npm alias
 
 ```sh
-npm install --save-dev @typescript/native-preview
-```
-
-Or you can install TypeScript 7 RC with
-
-```sh
-npm install --save-dev typescript@~6 typescript-7@npm:typescript@rc
-```
-
-Once TypeScript 7 stable is released, you can install TypeScript 7 with
-
-```sh
-npm install --save-dev typescript@~6 typescript-7@npm:typescript
+npm install --save-dev typescript@~6 typescript-7@npm:typescript@7
 ```
 
 ### Args:

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -14,7 +14,9 @@ Requires Node 16 or later.
 
 Installation:
 
-`npm i svelte-check --save-dev`
+```sh
+npm i svelte-check --save-dev
+```
 
 Package.json:
 
@@ -41,12 +43,34 @@ Usage:
 
 Installation:
 
-`npm i svelte-check svelte -g`
+```sh
+npm i svelte-check svelte -g
+```
 
 Usage:
 
 1. Go to folder where to start checking
 2. `svelte-check`
+
+#### TypeScript 7 supports
+
+TypeScript 7 support currently requires `--tsgo` or `--tsgo-experimental-api` flag. You need to install both TypeScript 7 and TypeScript 6. Before TypeScript 7 stable is released. You can install `@typescript/native-preview`
+
+```sh
+npm install --save-dev @typescript/native-preview
+```
+
+Or you can install TypeScript 7 RC with
+
+```sh
+npm install --save-dev typescript@~6 typescript-7@npm:typescript@rc
+```
+
+Once TypeScript 7 stable is released, you can install TypeScript 7 with
+
+```sh
+npm install --save-dev typescript@~6 typescript-7@npm:typescript
+```
 
 ### Args:
 

--- a/packages/svelte-check/bin/svelte-check
+++ b/packages/svelte-check/bin/svelte-check
@@ -1,2 +1,4 @@
 #!/usr/bin/env node
+
+require('./ts-version-check.js');
 require('../dist/src/index.js');

--- a/packages/svelte-check/bin/ts-version-check.js
+++ b/packages/svelte-check/bin/ts-version-check.js
@@ -33,7 +33,7 @@ function checkTypeScriptVersion(version) {
         'TypeScript 7 support currently requires both TypeScript 7 and TypeScript 6 installed in your project, ' +
         'and requires using the --tsgo or --tsgo-experimental-api flag. ' +
         'You can setup both version with an npm alias via the following command.\n' +
-        'npm install --save-dev typescript@~6 typescript-7@npm:typescript@7\n';
+        'npm install --save-dev typescript@~6 @typescript/native@npm:typescript@7\n';
 
     throw new Error(message);
 }

--- a/packages/svelte-check/bin/ts-version-check.js
+++ b/packages/svelte-check/bin/ts-version-check.js
@@ -1,0 +1,38 @@
+// @ts-check
+
+let version;
+try {
+    const pkg = require('typescript/package.json');
+    version = pkg.version;
+} catch {}
+checkTypeScriptVersion(version);
+
+/**
+ *
+ * @param {string | undefined} version
+ * @returns
+ */
+function checkTypeScriptVersion(version) {
+    const requirement = 'svelte-check requires TypeScript >= 5.0 and <= 6.0. ';
+
+    let message = '';
+    if (version) {
+        const major = parseInt(version.split('.')[0], 10);
+        if (major < 5) {
+            message +=
+                requirement + `You are using unsupported TypeScript ${version}. \n\nNoted that `;
+        } else if (major < 7) {
+            return;
+        }
+    } else {
+        message +=
+            'TypeScript is not installed in the workspace. ' + requirement + '\n\nNoted that ';
+    }
+
+    message +=
+        'TypeScript 7 support currently requires both TypeScript 7 and TypeScript 6 installed in your project, ' +
+        'and requires using --tsgo or --tsgo-experimental-api flag ' +
+        'Visit https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check#typescript-7-supports for more information.\n';
+
+    throw new Error(message);
+}

--- a/packages/svelte-check/bin/ts-version-check.js
+++ b/packages/svelte-check/bin/ts-version-check.js
@@ -20,19 +20,19 @@ function checkTypeScriptVersion(version) {
         const major = parseInt(version.split('.')[0], 10);
         if (major < 5) {
             message +=
-                requirement + `You are using unsupported TypeScript ${version}. \n\nNoted that `;
+                requirement + `You are using unsupported TypeScript ${version}. \n\nNote that `;
         } else if (major < 7) {
             return;
         }
     } else {
         message +=
-            'TypeScript is not installed in the workspace. ' + requirement + '\n\nNoted that ';
+            'TypeScript is not installed in the workspace. ' + requirement + '\n\nNote that ';
     }
 
     message +=
         'TypeScript 7 support currently requires both TypeScript 7 and TypeScript 6 installed in your project, ' +
-        'and requires using --tsgo or --tsgo-experimental-api flag ' +
-        'You can setup both version with npm alias with the following command.\n' +
+        'and requires using the --tsgo or --tsgo-experimental-api flag. ' +
+        'You can setup both version with an npm alias via the following command.\n' +
         'npm install --save-dev typescript@~6 typescript-7@npm:typescript@7\n';
 
     throw new Error(message);

--- a/packages/svelte-check/bin/ts-version-check.js
+++ b/packages/svelte-check/bin/ts-version-check.js
@@ -32,7 +32,8 @@ function checkTypeScriptVersion(version) {
     message +=
         'TypeScript 7 support currently requires both TypeScript 7 and TypeScript 6 installed in your project, ' +
         'and requires using --tsgo or --tsgo-experimental-api flag ' +
-        'Visit https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check#typescript-7-supports for more information.\n';
+        'You can setup both version with npm alias with the following command.\n' +
+        'npm install --save-dev typescript@~6 typescript-7@npm:typescript@7\n';
 
     throw new Error(message);
 }

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -35,7 +35,7 @@
     },
     "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "typescript": ">=5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0"
     },
     "scripts": {
         "build": "cd ../load-config && pnpm build && cd ../svelte2tsx && pnpm build && cd ../language-server && pnpm build && cd ../svelte-check && rollup -c && pnpm test:sanity",

--- a/packages/svelte-check/src/incremental.ts
+++ b/packages/svelte-check/src/incremental.ts
@@ -13,7 +13,7 @@ import {
 } from 'svelte-language-server';
 import { loadConfig } from '@sveltejs/load-config';
 import { findFiles } from './utils';
-import { parseTsGoVersion } from './tsgo';
+import { formatTsGoNotFoundError, tryParseTsGoVersion } from './tsgo';
 
 type ManifestEntry = {
     sourcePath: string;
@@ -514,7 +514,10 @@ export function runTypeScriptDiagnostics(
 }
 
 function getTsGoBinPath(tsconfigPath: string): string | undefined {
-    const pkg = parseTsGoVersion(tsconfigPath);
+    const pkg = tryParseTsGoVersion(tsconfigPath);
+    if (!pkg) {
+        throw new Error(formatTsGoNotFoundError('--tsgo'));
+    }
 
     const binPathRelative =
         pkg.bin[pkg.moduleName === '@typescript/native-preview' ? 'tsgo' : 'tsc'];

--- a/packages/svelte-check/src/incremental.ts
+++ b/packages/svelte-check/src/incremental.ts
@@ -520,7 +520,7 @@ function getTsGoBinPath(tsconfigPath: string): string | undefined {
     }
 
     const binPathRelative =
-        pkg.bin[pkg.moduleName === '@typescript/native-preview' ? 'tsgo' : 'tsc'];
+        pkg.bin[pkg.pkgJsonName === '@typescript/native-preview' ? 'tsgo' : 'tsc'];
 
     return binPathRelative ? path.join(path.dirname(pkg.path), binPathRelative) : undefined;
 }

--- a/packages/svelte-check/src/incremental.ts
+++ b/packages/svelte-check/src/incremental.ts
@@ -13,6 +13,7 @@ import {
 } from 'svelte-language-server';
 import { loadConfig } from '@sveltejs/load-config';
 import { findFiles } from './utils';
+import { parseTsGoVersion } from './tsgo';
 
 type ManifestEntry = {
     sourcePath: string;
@@ -461,19 +462,19 @@ export function runTypeScriptDiagnostics(
     incremental: boolean,
     cwd: string
 ): Promise<ParsedDiagnostic[]> {
-    const args = [
-        useTsgo
-            ? path.join(
-                  path.dirname(require.resolve('@typescript/native-preview/package.json')),
-                  'bin/tsgo.js'
-              )
-            : require.resolve('typescript/bin/tsc'),
-        '-p',
-        tsconfigPath,
-        '--pretty',
-        'true',
-        '--noErrorTruncation'
-    ];
+    let binPath: string;
+    if (useTsgo) {
+        const pkg = parseTsGoVersion(tsconfigPath);
+        binPath = path.join(
+            path.dirname(pkg.path),
+            'bin',
+            pkg.pkgJsonName === 'typescript' ? 'tsc' : 'tsgo.js'
+        );
+    } else {
+        binPath = require.resolve('typescript/bin/tsc');
+    }
+
+    const args = [binPath, '-p', tsconfigPath, '--pretty', 'true', '--noErrorTruncation'];
 
     if (incremental) {
         args.push('--incremental');

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -25,11 +25,7 @@ import {
     writeOverlayTsconfig
 } from './incremental';
 import { createIgnored, findFiles } from './utils';
-import {
-    tryLoadApi as tryLoadTsApi,
-    tryLoadAst as tryLoadTsAst,
-    tryParseTsGoVersion
-} from './tsgo';
+import { tryLoadApi as tryLoadTsApi, tryLoadAst as tryLoadTsAst, parseTsGoVersion } from './tsgo';
 
 type Result = {
     fileCount: number;
@@ -603,12 +599,7 @@ parseOptions(async (opts) => {
             if (opts.incremental) {
                 throw new Error('--tsgo-experimental-api cannot be used with --incremental');
             }
-            const version = tryParseTsGoVersion(opts.tsconfig);
-            if (!version) {
-                throw new Error(
-                    '--tsgo-experimental-api requires @typescript/native-preview to be installed in the workspace'
-                );
-            }
+            const version = parseTsGoVersion(opts.tsconfig);
 
             const minPre7_0Nightly = 'dev.20260614.1';
             if (
@@ -630,7 +621,7 @@ parseOptions(async (opts) => {
             const astModule = await tryLoadTsAst(opts.tsconfig, version);
             if (!apiModule || !astModule) {
                 throw new Error(
-                    `Unsupported ${version.name} version. Please ensure you have the latest version installed.` +
+                    `Unsupported ${version.pkgJsonName} version. Please ensure you have the latest version installed.` +
                         'If the problem persists, please report an issue in https://github.com/sveltejs/language-tools/issues.'
                 );
             }

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -25,7 +25,12 @@ import {
     writeOverlayTsconfig
 } from './incremental';
 import { createIgnored, findFiles } from './utils';
-import { tryLoadApi as tryLoadTsApi, tryLoadAst as tryLoadTsAst, parseTsGoVersion } from './tsgo';
+import {
+    formatTsGoNotFoundError,
+    tryLoadApi as tryLoadTsApi,
+    tryLoadAst as tryLoadTsAst,
+    tryParseTsGoVersion
+} from './tsgo';
 
 type Result = {
     fileCount: number;
@@ -599,17 +604,20 @@ parseOptions(async (opts) => {
             if (opts.incremental) {
                 throw new Error('--tsgo-experimental-api cannot be used with --incremental');
             }
-            const version = parseTsGoVersion(opts.tsconfig);
+            const pkg = tryParseTsGoVersion(opts.tsconfig);
+            if (!pkg) {
+                throw new Error(formatTsGoNotFoundError('--tsgo-experimental-api'));
+            }
 
             const minPre7_0Nightly = 'dev.20260614.1';
             if (
-                version.major === 7 &&
-                version.minor === 0 &&
-                version.patch === 0 &&
-                version.preRelease?.includes('dev')
+                pkg.major === 7 &&
+                pkg.minor === 0 &&
+                pkg.patch === 0 &&
+                pkg.preRelease?.includes('dev')
             ) {
                 // ex: 7.0.0-dev.20260518.1
-                if (version.preRelease.localeCompare(minPre7_0Nightly) < 0) {
+                if (pkg.preRelease.localeCompare(minPre7_0Nightly) < 0) {
                     throw new Error(
                         'Unsupported @typescript/native-preview version. Please upgrade to at least 7.0.0-' +
                             minPre7_0Nightly
@@ -617,11 +625,11 @@ parseOptions(async (opts) => {
                 }
             }
 
-            const apiModule = await tryLoadTsApi(opts.tsconfig, version);
-            const astModule = await tryLoadTsAst(opts.tsconfig, version);
+            const apiModule = await tryLoadTsApi(opts.tsconfig, pkg);
+            const astModule = await tryLoadTsAst(opts.tsconfig, pkg);
             if (!apiModule || !astModule) {
                 throw new Error(
-                    `Unsupported ${version.pkgJsonName} version. Please ensure you have the latest version installed.` +
+                    `Unsupported ${pkg.pkgJsonName} version. Please ensure you have the latest version installed.` +
                         'If the problem persists, please report an issue in https://github.com/sveltejs/language-tools/issues.'
                 );
             }

--- a/packages/svelte-check/src/tsgo.ts
+++ b/packages/svelte-check/src/tsgo.ts
@@ -13,7 +13,7 @@ interface PkgInfo {
     bin: Record<string, string>;
 }
 
-export function parseTsGoVersion(tsconfigPath: string): PkgInfo {
+export function tryParseTsGoVersion(tsconfigPath: string): PkgInfo | null {
     const pkg =
         tryParsePkg(tsconfigPath, 'typescript-7') ??
         tryParsePkg(tsconfigPath, '@typescript/native-preview');
@@ -26,11 +26,14 @@ export function parseTsGoVersion(tsconfigPath: string): PkgInfo {
         return pkg;
     }
 
-    const message =
-        'TypeScript 7 not installed in the workspace.' +
-        'Please visit https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check#typescript-7-supports for instructions';
+    return null;
+}
 
-    throw new Error(message);
+export function formatTsGoNotFoundError(flagName: string) {
+    return (
+        `svelte-check ${flagName} requires TypeScript 7 to be installed in the workspace.` +
+        `Please visit https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check#typescript-7-supports for instructions`
+    );
 }
 
 function tryParsePkg(tsconfigPath: string, name: string): PkgInfo | null {

--- a/packages/svelte-check/src/tsgo.ts
+++ b/packages/svelte-check/src/tsgo.ts
@@ -13,18 +13,16 @@ interface PkgInfo {
 }
 
 export function parseTsGoVersion(tsconfigPath: string): PkgInfo {
-    const preview = tryParsePkg(tsconfigPath, '@typescript/native-preview');
-    if (preview) {
-        return preview;
-    }
-    const ts7Alias = tryParsePkg(tsconfigPath, 'typescript-7');
+    const pkg =
+        tryParsePkg(tsconfigPath, 'typescript-7') ??
+        tryParsePkg(tsconfigPath, '@typescript/native-preview');
+
     if (
-        ts7Alias &&
-        (ts7Alias.pkgJsonName === 'typescript' ||
-            ts7Alias.pkgJsonName === '@typescript/native-preview') &&
-        ts7Alias.major >= 7
+        pkg &&
+        (pkg.pkgJsonName === 'typescript' || pkg.pkgJsonName === '@typescript/native-preview') &&
+        pkg.major >= 7
     ) {
-        return ts7Alias;
+        return pkg;
     }
 
     const message =

--- a/packages/svelte-check/src/tsgo.ts
+++ b/packages/svelte-check/src/tsgo.ts
@@ -15,7 +15,7 @@ interface PkgInfo {
 
 export function tryParseTsGoVersion(tsconfigPath: string): PkgInfo | null {
     const pkg =
-        tryParsePkg(tsconfigPath, 'typescript-7') ??
+        tryParsePkg(tsconfigPath, '@typescript/native') ??
         tryParsePkg(tsconfigPath, '@typescript/native-preview');
 
     if (
@@ -33,7 +33,7 @@ export function formatTsGoNotFoundError(flagName: string) {
     return (
         `svelte-check ${flagName} requires TypeScript 7 to be installed in the workspace.` +
         `You can setup TypeScript 7 with an npm alias via the following command.\n` +
-        `npm install --save-dev typescript@~6 typescript-7@npm:typescript@7\n`
+        `npm install --save-dev typescript@~6 @typescript/native@npm:typescript@7\n`
     );
 }
 

--- a/packages/svelte-check/src/tsgo.ts
+++ b/packages/svelte-check/src/tsgo.ts
@@ -32,7 +32,8 @@ export function tryParseTsGoVersion(tsconfigPath: string): PkgInfo | null {
 export function formatTsGoNotFoundError(flagName: string) {
     return (
         `svelte-check ${flagName} requires TypeScript 7 to be installed in the workspace.` +
-        `Please visit https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check#typescript-7-supports for instructions`
+        `You can setup TypeScript 7 with npm alias with the following command.\n` +
+        `npm install --save-dev typescript@~6 typescript-7@npm:typescript@7\n`
     );
 }
 

--- a/packages/svelte-check/src/tsgo.ts
+++ b/packages/svelte-check/src/tsgo.ts
@@ -3,26 +3,43 @@ import * as syncAst from '@typescript/native-preview/unstable/ast';
 import { pathToFileURL } from 'url';
 
 interface PkgInfo {
-    name: string;
+    pkgJsonName: string;
+    moduleName: string;
     major: number;
     minor: number;
     patch: number;
     preRelease: string | null;
+    path: string;
 }
 
-export function tryParseTsGoVersion(tsconfigPath: string): PkgInfo | null {
-    // TODO: Most likely it'll eventually be released under the 'typescript' package.
-    // When it happened, check where the nightly versions are released and decide which package to prioritize.
+export function parseTsGoVersion(tsconfigPath: string): PkgInfo {
+    const preview = tryParsePkg(tsconfigPath, '@typescript/native-preview');
+    if (preview) {
+        return preview;
+    }
+    const ts7Alias = tryParsePkg(tsconfigPath, 'typescript-7');
+    if (
+        ts7Alias &&
+        (ts7Alias.pkgJsonName === 'typescript' ||
+            ts7Alias.pkgJsonName === '@typescript/native-preview') &&
+        ts7Alias.major >= 7
+    ) {
+        return ts7Alias;
+    }
 
-    return tryParsePkg(tsconfigPath, '@typescript/native-preview');
+    const message =
+        'TypeScript 7 not installed in the workspace.' +
+        'Please visit https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check#typescript-7-supports for instructions';
+
+    throw new Error(message);
 }
 
 function tryParsePkg(tsconfigPath: string, name: string): PkgInfo | null {
     try {
-        const apiPath = require.resolve(name + '/package.json', {
+        const pkgPath = require.resolve(name + '/package.json', {
             paths: [tsconfigPath, __dirname]
         });
-        const pkg = require(apiPath);
+        const pkg = require(pkgPath);
         const version: string = pkg.version || '';
 
         const parts = version.split('.');
@@ -32,7 +49,15 @@ function tryParsePkg(tsconfigPath: string, name: string): PkgInfo | null {
         const [major, minor] = parts.slice(0, 2).map((part) => parseInt(part, 10));
         const patch = parseInt(parts[2].split('-')[0], 10);
         const preRelease = version.includes('-') ? version.split('-')[1] : null;
-        return { major, minor, patch, preRelease, name: pkg.name };
+        return {
+            major,
+            minor,
+            patch,
+            preRelease,
+            pkgJsonName: pkg.name,
+            moduleName: name,
+            path: pkgPath
+        };
     } catch (e) {
         return null;
     }
@@ -43,8 +68,8 @@ export async function tryLoadApi(
     info: PkgInfo
 ): Promise<typeof syncApi | null> {
     return (
-        (await tryImport(info.name + '/unstable/sync', tsconfigPath)) ??
-        (await tryImport(info.name + '/sync', tsconfigPath))
+        (await tryImport(info.moduleName + '/unstable/sync', tsconfigPath)) ??
+        (await tryImport(info.moduleName + '/sync', tsconfigPath))
     );
 }
 
@@ -53,8 +78,8 @@ export async function tryLoadAst(
     info: PkgInfo
 ): Promise<typeof syncAst | null> {
     return (
-        (await tryImport(info.name + '/unstable/ast', tsconfigPath)) ??
-        (await tryImport(info.name + '/ast', tsconfigPath))
+        (await tryImport(info.moduleName + '/unstable/ast', tsconfigPath)) ??
+        (await tryImport(info.moduleName + '/ast', tsconfigPath))
     );
 }
 

--- a/packages/svelte-check/src/tsgo.ts
+++ b/packages/svelte-check/src/tsgo.ts
@@ -32,7 +32,7 @@ export function tryParseTsGoVersion(tsconfigPath: string): PkgInfo | null {
 export function formatTsGoNotFoundError(flagName: string) {
     return (
         `svelte-check ${flagName} requires TypeScript 7 to be installed in the workspace.` +
-        `You can setup TypeScript 7 with npm alias with the following command.\n` +
+        `You can setup TypeScript 7 with an npm alias via the following command.\n` +
         `npm install --save-dev typescript@~6 typescript-7@npm:typescript@7\n`
     );
 }

--- a/packages/svelte2tsx/src/emitDts.ts
+++ b/packages/svelte2tsx/src/emitDts.ts
@@ -56,7 +56,7 @@ function throwIfTypeScript7() {
     const major = parseInt(ts.version.split('.')[0], 10);
     if (major >= 7) {
         throw new Error(
-            `emitDts is not compatible with TypeScript ${ts.version}. Please use TypeScript 6.0.3 or lower.`
+            `emitDts is not compatible with TypeScript ${ts.version}. Please use a TypeScript version lower than 7.x.`
         );
     }
 }

--- a/packages/svelte2tsx/src/emitDts.ts
+++ b/packages/svelte2tsx/src/emitDts.ts
@@ -10,6 +10,8 @@ export interface EmitDtsConfig {
 }
 
 export async function emitDts(config: EmitDtsConfig) {
+    throwIfTypeScript7();
+
     const svelteMap = await createSvelteMap(config);
     const { options, filenames, absDeclarationDir } = loadTsconfig(config, svelteMap);
     const host = await createTsCompilerHost(options, svelteMap, absDeclarationDir);
@@ -46,6 +48,15 @@ export async function emitDts(config: EmitDtsConfig) {
                     return `${file}\n${errors.map((error) => `  - ${error}`).join('\n')}`;
                 })
                 .join('\n')
+        );
+    }
+}
+
+function throwIfTypeScript7() {
+    const major = parseInt(ts.version.split('.')[0], 10);
+    if (major >= 7) {
+        throw new Error(
+            `emitDts is not compatible with TypeScript ${ts.version}. Please use TypeScript 6.0.3 or lower.`
         );
     }
 }


### PR DESCRIPTION
#3063 This PR adds a version check in bin/svelte-check before importing the main entry point. This way, we can throw an error about TypeScript 7 without having to remove all the top-level ts import just yet. 

This also allows loading TypeScript 7 through an npm alias. i.e. install TypeScript 7 as `"@typescript/native": "npm:typescript@rc"`. This is mostly preparing for TypeScript 7 stable. According to the TypeScript RC announcement, once the stable version is released, the nightly version will also be released under "typescript" instead of "@typescript/native-preview".

I was originally considering moving all top-level imports to a few dynamic imports. And we try to load TypeScript 6 from `@typescript/typescript-6`. But even if we do that, people might still run into issues with `svelte-kit sync` and `typescript-eslint`