### PR TITLE
fix: resolve tsgo bin path with package.json

### DIFF
--- a/.changeset/big-moments-make.md
+++ b/.changeset/big-moments-make.md
@@ -1,0 +1,5 @@
+---
+'svelte-check': patch
+---
+
+fix: resolve tsgo bin path with package.json

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -44,7 +44,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^18.0.0",
         "@types/sinon": "^7.5.2",
-        "@typescript/native-preview": "~7.0.0-dev.20260614.1",
+        "@typescript/native-preview": "~7.0.0-dev.20260703.1",
         "cross-env": "^7.0.2",
         "mocha": "^11.7.6",
         "sinon": "^11.0.0",

--- a/packages/language-server/src/plugins/typescript-go/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript-go/features/DiagnosticsProvider.ts
@@ -1223,9 +1223,16 @@ function expectedTransitionThirdArgument(
     const callExpression = node.parent;
     const signature = callExpression && project.checker.getResolvedSignature(callExpression);
 
+    if (!signature) {
+        return false;
+    }
+
+    // TypeScript 7 rc and older nightly have parameters field instead of getParameters method
+    const parameters: tsApiSync.Symbol[] =
+        'getParameters' in signature ? signature.getParameters() : (signature as any).parameters;
+
     return (
-        signature?.parameters.filter((parameter) => !(parameter.flags & ts.SymbolFlags.Optional))
-            .length === 3
+        parameters.filter((parameter) => !(parameter.flags & ts.SymbolFlags.Optional)).length === 3
     );
 }
 function getDiagnosticTag(tsDiag: tsApiSync.Diagnostic): DiagnosticTag[] | undefined {

--- a/packages/svelte-check/package.json
+++ b/packages/svelte-check/package.json
@@ -51,7 +51,7 @@
         "@rollup/plugin-replace": "5.0.2",
         "@rollup/plugin-typescript": "^10.0.0",
         "@types/sade": "^1.7.2",
-        "@typescript/native-preview": "~7.0.0-dev.20260614.1",
+        "@typescript/native-preview": "~7.0.0-dev.20260703.1",
         "rollup": "3.7.5",
         "rollup-plugin-cleanup": "^3.2.0",
         "rollup-plugin-copy": "^3.4.0",

--- a/packages/svelte-check/src/incremental.ts
+++ b/packages/svelte-check/src/incremental.ts
@@ -13,6 +13,7 @@ import {
 } from 'svelte-language-server';
 import { loadConfig } from '@sveltejs/load-config';
 import { findFiles } from './utils';
+import { tryParseTsGoVersion } from './tsgo';
 
 type ManifestEntry = {
     sourcePath: string;
@@ -461,19 +462,13 @@ export function runTypeScriptDiagnostics(
     incremental: boolean,
     cwd: string
 ): Promise<ParsedDiagnostic[]> {
-    const args = [
-        useTsgo
-            ? path.join(
-                  path.dirname(require.resolve('@typescript/native-preview/package.json')),
-                  'bin/tsgo.js'
-              )
-            : require.resolve('typescript/bin/tsc'),
-        '-p',
-        tsconfigPath,
-        '--pretty',
-        'true',
-        '--noErrorTruncation'
-    ];
+    const binPath = useTsgo ? getTsGoBinPath(tsconfigPath) : require.resolve('typescript/bin/tsc');
+
+    if (!binPath || !fs.existsSync(binPath) || !fs.statSync(binPath).isFile()) {
+        throw new Error('Failed to locate TypeScript command-line executable.');
+    }
+
+    const args = [binPath, '-p', tsconfigPath, '--pretty', 'true', '--noErrorTruncation'];
 
     if (incremental) {
         args.push('--incremental');
@@ -516,6 +511,20 @@ export function runTypeScriptDiagnostics(
             }
         });
     });
+}
+
+function getTsGoBinPath(tsconfigPath: string): string | undefined {
+    const pkg = tryParseTsGoVersion(tsconfigPath);
+    if (!pkg) {
+        throw new Error(
+            '--tsgo requires @typescript/native-preview to be installed in the workspace'
+        );
+    }
+
+    const binPathRelative =
+        pkg.bin[pkg.moduleName === '@typescript/native-preview' ? 'tsgo' : 'tsc'];
+
+    return binPathRelative ? path.join(path.dirname(pkg.path), binPathRelative) : undefined;
 }
 
 /**

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -630,7 +630,7 @@ parseOptions(async (opts) => {
             const astModule = await tryLoadTsAst(opts.tsconfig, version);
             if (!apiModule || !astModule) {
                 throw new Error(
-                    `Unsupported ${version.name} version. Please ensure you have the latest version installed.` +
+                    `Unsupported ${version.moduleName} version. Please ensure you have the latest version installed.` +
                         'If the problem persists, please report an issue in https://github.com/sveltejs/language-tools/issues.'
                 );
             }

--- a/packages/svelte-check/src/tsgo.ts
+++ b/packages/svelte-check/src/tsgo.ts
@@ -3,11 +3,14 @@ import * as syncAst from '@typescript/native-preview/unstable/ast';
 import { pathToFileURL } from 'url';
 
 interface PkgInfo {
-    name: string;
+    pkgJsonName: string;
+    moduleName: string;
     major: number;
     minor: number;
     patch: number;
     preRelease: string | null;
+    path: string;
+    bin: Record<string, string>;
 }
 
 export function tryParseTsGoVersion(tsconfigPath: string): PkgInfo | null {
@@ -19,10 +22,10 @@ export function tryParseTsGoVersion(tsconfigPath: string): PkgInfo | null {
 
 function tryParsePkg(tsconfigPath: string, name: string): PkgInfo | null {
     try {
-        const apiPath = require.resolve(name + '/package.json', {
+        const pkgPath = require.resolve(name + '/package.json', {
             paths: [tsconfigPath, __dirname]
         });
-        const pkg = require(apiPath);
+        const pkg = require(pkgPath);
         const version: string = pkg.version || '';
 
         const parts = version.split('.');
@@ -32,7 +35,16 @@ function tryParsePkg(tsconfigPath: string, name: string): PkgInfo | null {
         const [major, minor] = parts.slice(0, 2).map((part) => parseInt(part, 10));
         const patch = parseInt(parts[2].split('-')[0], 10);
         const preRelease = version.includes('-') ? version.split('-')[1] : null;
-        return { major, minor, patch, preRelease, name: pkg.name };
+        return {
+            major,
+            minor,
+            patch,
+            preRelease,
+            pkgJsonName: pkg.name,
+            moduleName: name,
+            path: pkgPath,
+            bin: pkg.bin || {}
+        };
     } catch (e) {
         return null;
     }
@@ -43,8 +55,8 @@ export async function tryLoadApi(
     info: PkgInfo
 ): Promise<typeof syncApi | null> {
     return (
-        (await tryImport(info.name + '/unstable/sync', tsconfigPath)) ??
-        (await tryImport(info.name + '/sync', tsconfigPath))
+        (await tryImport(info.moduleName + '/unstable/sync', tsconfigPath)) ??
+        (await tryImport(info.moduleName + '/sync', tsconfigPath))
     );
 }
 
@@ -53,8 +65,8 @@ export async function tryLoadAst(
     info: PkgInfo
 ): Promise<typeof syncAst | null> {
     return (
-        (await tryImport(info.name + '/unstable/ast', tsconfigPath)) ??
-        (await tryImport(info.name + '/ast', tsconfigPath))
+        (await tryImport(info.moduleName + '/unstable/ast', tsconfigPath)) ??
+        (await tryImport(info.moduleName + '/ast', tsconfigPath))
     );
 }
 

--- a/packages/svelte-check/test-sanity.js
+++ b/packages/svelte-check/test-sanity.js
@@ -30,6 +30,7 @@ let failed = 0;
  * @param {string} opts.tsconfig
  * @param {boolean} [opts.incremental]
  * @param {boolean} [opts.tsgoExp]
+ * @param {boolean} [opts.tsgo]
  * @param {ExpectedError[]} [opts.errors]
  */
 function test(name, opts) {
@@ -47,6 +48,9 @@ function test(name, opts) {
     }
     if (opts.tsgoExp) {
         args.push('--tsgo-experimental-api');
+    }
+    if (opts.tsgo) {
+        args.push('--tsgo');
     }
 
     let stdout;
@@ -146,6 +150,12 @@ test('clean project (incremental, warm cache)', {
     incremental: true
 });
 
+test('clean project --tsgo', {
+    workspace: './test-success',
+    tsconfig: './tsconfig.json',
+    tsgo: true
+});
+
 const errors = [
     {
         file: 'Index.svelte',
@@ -216,6 +226,13 @@ test('project with errors (incremental, warm cache)', {
     workspace: './test-error',
     tsconfig: './tsconfig.json',
     incremental: true,
+    errors
+});
+
+test('project with errors --tsgo', {
+    workspace: './test-error',
+    tsconfig: './tsconfig.json',
+    tsgo: true,
     errors
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ importers:
         specifier: ^7.5.2
         version: 7.5.2
       '@typescript/native-preview':
-        specifier: ~7.0.0-dev.20260614.1
-        version: 7.0.0-dev.20260614.1
+        specifier: ~7.0.0-dev.20260703.1
+        version: 7.0.0-dev.20260703.1
       cross-env:
         specifier: ^7.0.2
         version: 7.0.3
@@ -171,8 +171,8 @@ importers:
         specifier: ^1.7.2
         version: 1.7.4
       '@typescript/native-preview':
-        specifier: ~7.0.0-dev.20260614.1
-        version: 7.0.0-dev.20260614.1
+        specifier: ~7.0.0-dev.20260703.1
+        version: 7.0.0-dev.20260703.1
       rollup:
         specifier: 3.7.5
         version: 3.7.5
@@ -896,50 +896,50 @@ packages:
   '@types/vscode@1.78.0':
     resolution: {integrity: sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-2JHbdJ00FKTKDR1+NL4zhQBDlFZfZHEXaAarV6kbEjV0P47qKnSrAzzKHuponG0B9FqkPEMHOgu7WGJTBW2rHw==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260703.1':
+    resolution: {integrity: sha512-EwJEd6hfaHrrbSLat6+xX8fZiAvG+/Ae1gqvJEayTNdDbkrZxmeLS23YdjUmDMIOKI2wa7zXQDid8WtrvDfMTQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-/8enyEb1tDsVvUp4rDeA5DernrvWgD6cQ4rY6O6PH6BQK8fqwY+CcHEHmw2xgwfqoswHNYjznLvmQmHBOjHqLw==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260703.1':
+    resolution: {integrity: sha512-tcS3gpivMq+BAiaupFqM5vuERykogJlfD4CjoxkSCksmmsKgWV96S2U/LjrKgll8R6/OEkg2VL2ycRG9+tIuHw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-jqhqAXqyEUxJpno/wRfWGa72R3VTt7p2LRTOFJ0C1bx5dEKrVosQSOdr2m9+2VhjXFXNvorXsGZPIWqxLOo28Q==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260703.1':
+    resolution: {integrity: sha512-m8IJTOneLXRtq6prLz8uuhp463kEt+AHV5Ceqp7G0o3eAvbKP059OwzK6WXCS5J0B3ZxX+BwBf9wDXSNidWJCw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-zYrUKq5oC6fUoHpOmT3B65hFMhbdIlLp7T9RW1/6a+wSYoq9xTRAeFufQ2XZ9cpTJ1tfIvlUmtgJJ5CGE/cOrg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260703.1':
+    resolution: {integrity: sha512-nluwnKcdGo6laWWYtWF3zFUDfi7nNrcD5S/T5382fVmtKmNqIdzFm9ANgSSGAavuzfdu9YJLaVWpx72Oe40AEQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-K2c/DN7Q3a6Z+KIl7bq45xByuuGjacqWO/UPCa/iTBA/m6GDzoMJ/Q/DBLtLRHyROBRiy5kjgEZfyLy3Tp8ygw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260703.1':
+    resolution: {integrity: sha512-5ga94rso68kaxJUzaufDVhka1zPaSbPgNXaemQO8faPW0crvRIkbv0g8bpG4pdWMV0tTylmluDles4ZcAzOprg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-C+C25Grr4sCbQIYPT5WfKYIL613ZIN9aGcUwDGMSTmIQ3azIR5MtdkSF4l4vsOC4lF8HwFV83MDa28JuQYhQFg==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260703.1':
+    resolution: {integrity: sha512-YeRqOUuSyhbtryBSUE073OLpReIQXWJVyjP45gPLJ+0KAGvkd1VFz2FY1JEo++LyHoqXsGD2+qvdPpnTfSAIJg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-nJBR61NGiCMBJOpdzJ4ZgA/HEd+fqIb99ur39UljSH9xvFKFlRwDosyAQFD8UEwrZsUbXN0VPLJY5MDknug3GA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260703.1':
+    resolution: {integrity: sha512-WYNcbTaxCPgiDLrL2aPJ3BJA05nJU8DK0fUFGkGAER0oM+KcJcQUBeUkXg/7A4HBTNYcj7zIxqNgkJU1TRa/Kw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-4N1ZBHJUcsjKJQnUCxKUemV3jnm0PKZIZ4xh7dXN/3/AfmckE8Z1llyqOFfDwGOf8oQpdgkwQ6JUm7pqI3bGPg==}
+  '@typescript/native-preview@7.0.0-dev.20260703.1':
+    resolution: {integrity: sha512-qyEHkEeRWCSGLa6a8oArnMPdn3Vcl1AZj8YHLO7lK0VjEEF/YJfz1FvxmpEeuhy0ZDfvJ7GtgXbvbjcU3zpPjQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -2756,36 +2756,36 @@ snapshots:
 
   '@types/vscode@1.78.0': {}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260703.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260703.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260703.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260703.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260703.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260703.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260703.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
+  '@typescript/native-preview@7.0.0-dev.20260703.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260614.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260703.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260703.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260703.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260703.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260703.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260703.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260703.1
 
   '@vitest/expect@3.2.4':
     dependencies:


### PR DESCRIPTION
The tsgo bin path has been renamed from `bin/tsgo.js` to `bin/tsgo`. This caused a module-not-found error that isn't caught by svelte-check. Instead, svelte-check will report 0 diagnostics. 

I extracted some of the changes from #3073, so this could be merged separately. 