### PR TITLE
feat: zero-config `+error.svelte` props

### DIFF
--- a/.changeset/grumpy-rabbits-chew.md
+++ b/.changeset/grumpy-rabbits-chew.md
@@ -1,5 +1,6 @@
 ---
-'svelte2tsx': minor
+'svelte2tsx': patch
+'svelte-check': patch
 ---
 
 feat: zero-config `+error.svelte` props

--- a/.changeset/grumpy-rabbits-chew.md
+++ b/.changeset/grumpy-rabbits-chew.md
@@ -1,0 +1,5 @@
+---
+'svelte2tsx': minor
+---
+
+feat: zero-config `+error.svelte` props

--- a/packages/svelte2tsx/src/helpers/sveltekit.ts
+++ b/packages/svelte2tsx/src/helpers/sveltekit.ts
@@ -54,6 +54,13 @@ export function isKitRouteFile(basename: string): boolean {
 }
 
 /**
+ * Determines whether or not a given file is a SvelteKit +error.svelte file
+ */
+export function isKitErrorFile(basename: string): boolean {
+    return basename.slice(0, -path.extname(basename).length) === '+error';
+}
+
+/**
  * Determines whether or not a given file is a SvelteKit-specific hooks file
  */
 export function isHooksFile(fileName: string, basename: string, hooksPath: string): boolean {

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -5,6 +5,7 @@ import { surroundWithIgnoreComments } from '../../utils/ignore';
 import { preprendStr, overwriteStr } from '../../utils/magic-string';
 import { findExportKeyword, getLastLeadingDoc, isInterfaceOrTypeDeclaration } from '../utils/tsAst';
 import { HoistableInterfaces } from './HoistableInterfaces';
+import { isKitErrorFile } from '../../helpers/sveltekit';
 
 export function is$$PropsDeclaration(
     node: ts.Node
@@ -323,6 +324,10 @@ export class ExportedNames {
                                     isKitLayoutFile ? 'LayoutProps' : 'PageProps'
                                 }['params']`
                             );
+                        }
+                    } else if (isKitErrorFile(this.basename)) {
+                        if (name === 'error') {
+                            props.push(`error: App.Error`);
                         }
                     } else if (element.initializer) {
                         const initializer =


### PR DESCRIPTION
No idea if I'm doing this right, but: this should allow zero-config types for the `error` prop passed to an `+error.svelte` file:

```svelte
<script>
  let { error } = $props(); // error is typed as `App.Error`
</script>

<h1>oops: {error.message}</h1>
```

I thought we'd need to do https://github.com/sveltejs/kit/pull/16272 first, but I'm not sure it's all that helpful since we'd need to be careful about the version. As it stands, this would allow someone to create the above props declaration with a version of SvelteKit that _didn't_ pass `error` to the component, but that's probably fine?