### PR TITLE
fix: don't emit invalid `export` on type/interface declarations in the instance script

### DIFF
--- a/.changeset/tidy-experts-cheer.md
+++ b/.changeset/tidy-experts-cheer.md
@@ -1,0 +1,5 @@
+---
+'svelte2tsx': patch
+---
+
+fix: don't emit invalid `export` on type/interface declarations in the instance script

--- a/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
@@ -54,6 +54,8 @@ export class ExportedNames {
     >();
     private doneDeclarationTransformation = new Set<ts.VariableDeclarationList>();
     private getters = new Set<string>();
+    private exportedTypesAndInterfaces: Array<ts.TypeAliasDeclaration | ts.InterfaceDeclaration> =
+        [];
 
     constructor(
         private str: MagicString,
@@ -143,6 +145,34 @@ export class ExportedNames {
         // Can't export default here
         if (node.name) {
             this.addExport(node.name, false);
+        }
+    }
+
+    /**
+     * Collects top-level `export type`/`export interface` declarations of the instance script.
+     * Their `export` keyword is removed later for the ones that don't get hoisted to the module
+     * scope, because `export` is not valid inside the render function.
+     */
+    handleExportedTypeOrInterface(node: ts.TypeAliasDeclaration | ts.InterfaceDeclaration): void {
+        if (findExportKeyword(node)) {
+            this.exportedTypesAndInterfaces.push(node);
+        }
+    }
+
+    /**
+     * Removes the `export` keyword from top-level type/interface declarations that stay inside
+     * the render function (i.e. that weren't hoisted to the module scope), mirroring the handling
+     * of exported functions and classes.
+     */
+    removeExportsFromNonHoistedTypes(hoisted: Map<string, ts.Node> | undefined): void {
+        for (const node of this.exportedTypesAndInterfaces) {
+            if (hoisted?.has(node.name.text)) {
+                continue;
+            }
+            const exportModifier = findExportKeyword(node);
+            if (exportModifier) {
+                this.removeExport(exportModifier.getStart(), exportModifier.end);
+            }
         }
     }
 

--- a/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/processInstanceScriptContent.ts
@@ -217,6 +217,10 @@ export function processInstanceScriptContent(
 
         if (parent === tsAst) {
             exportedNames.hoistableInterfaces.analyzeInstanceScriptNode(node);
+
+            if (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node)) {
+                exportedNames.handleExportedTypeOrInterface(node);
+            }
         }
 
         generics.addIfIsGeneric(node);
@@ -380,6 +384,9 @@ export function processInstanceScriptContent(
         script.start + 1, // +1 because imports are also moved at that position, and we want to move interfaces after imports
         generics.getReferences()
     );
+
+    // `export` is not valid on type/interface declarations that stay inside the render function
+    exportedNames.removeExportsFromNonHoistedTypes(hoisted);
 
     if (mode === 'dts') {
         // Transform interface declarations to type declarations because indirectly

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-type-instance-script.v5/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-type-instance-script.v5/expectedv2.ts
@@ -1,0 +1,14 @@
+///<reference types="svelte" />
+;function $$render() {
+
+	 type A = 'a' | 'b';
+
+	 interface B {
+		value: A;
+	}
+;
+async () => {};
+return { props: {} as Record<string, never>, exports: {}, bindings: "", slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event($$render()));
+/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-type-instance-script.v5/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/ts-export-type-instance-script.v5/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	export type A = 'a' | 'b';
+
+	export interface B {
+		value: A;
+	}
+</script>


### PR DESCRIPTION
Fixes #2832

`export type`/`export interface` in the instance script keep their `export` keyword inside the generated render function when they aren't hoisted to the module scope, e.g. when `$props()` has no explicit type or there are no props at all. `export` isn't valid on a declaration inside a function body, so TypeScript reports "Modifiers cannot appear here." on an otherwise valid component.

Repro:

```svelte
<script lang="ts">
	export type ExampleType = 'A' | 'B' | 'C';
</script>
```

Adding a typed `const {}: Props = $props()` makes the error disappear, because the hoisting path then moves the type out to the module scope — which is why this is easy to miss.

Fix: strip the `export` keyword from top-level type/interface declarations that stay inside the render function (the ones that don't get hoisted), mirroring the existing handling for exported functions and classes in `handleExportFunctionOrClass`. Hoisted declarations are left untouched so they remain importable from other components.

Adds a regression test.
