### PR TITLE
fix(svelte2tsx): don't treat `<style>`-like text in a script comment as a real style tag

### DIFF
--- a/.changeset/fix-style-tag-in-script-comment.md
+++ b/.changeset/fix-style-tag-in-script-comment.md
@@ -1,0 +1,6 @@
+---
+'svelte2tsx': patch
+'svelte-check': patch
+---
+
+fix: don't treat `<style>`-like text inside a script comment as a real style tag when a separate `<style>` block exists

--- a/.changeset/fix-style-tag-in-script-comment.md
+++ b/.changeset/fix-style-tag-in-script-comment.md
@@ -3,4 +3,4 @@
 'svelte-check': patch
 ---
 
-fix: don't treat `<style>`-like text inside a script comment as a real style tag when a separate `<style>` block exists
+fix: recognise the real `<style>` start tag when a `<style>`-like token also appears inside a script

--- a/.changeset/fix-style-tag-in-script-comment.md
+++ b/.changeset/fix-style-tag-in-script-comment.md
@@ -3,4 +3,4 @@
 'svelte-check': patch
 ---
 
-fix: recognise the real `<style>` start tag when a `<style>`-like token also appears inside a script
+fix: recognise the real `<script>` and `<style>` start tags when a matching token also appears inside the other tag

--- a/packages/svelte2tsx/src/utils/htmlxparser.ts
+++ b/packages/svelte2tsx/src/utils/htmlxparser.ts
@@ -81,9 +81,13 @@ function findVerbatimElements(htmlx: string) {
     const styleTags = extractTag(htmlx, 'style');
     const tags = extractTag(htmlx, 'script');
     for (const styleTag of styleTags) {
-        // Could happen if someone has a `<style>...</style>` string in their script tag
+        // Could happen if someone has a `<style>` string in their script tag (e.g. in a
+        // comment or string literal). The non-greedy style regex can then start matching
+        // inside the script and run past the real `</script>` up to a later `</style>`, so
+        // the match is not fully nested — check whether the style tag merely *starts* inside
+        // a script tag rather than requiring strict containment.
         const insideScript = tags.some(
-            (tag) => tag.start < styleTag.start && tag.end > styleTag.end
+            (tag) => tag.start < styleTag.start && styleTag.start < tag.end
         );
         if (!insideScript) {
             tags.push(styleTag);

--- a/packages/svelte2tsx/src/utils/htmlxparser.ts
+++ b/packages/svelte2tsx/src/utils/htmlxparser.ts
@@ -78,21 +78,22 @@ function extractTag(htmlx: string, tag: 'script' | 'style') {
 }
 
 function findVerbatimElements(htmlx: string) {
-    const styleTags = extractTag(htmlx, 'style');
     const tags = extractTag(htmlx, 'script');
-    for (const styleTag of styleTags) {
-        // Could happen if someone has a `<style>` string in their script tag (e.g. in a
-        // comment or string literal). The non-greedy style regex can then start matching
-        // inside the script and run past the real `</script>` up to a later `</style>`, so
-        // the match is not fully nested — check whether the style tag merely *starts* inside
-        // a script tag rather than requiring strict containment.
-        const insideScript = tags.some(
-            (tag) => tag.start < styleTag.start && styleTag.start < tag.end
-        );
-        if (!insideScript) {
-            tags.push(styleTag);
-        }
+
+    // A literal `<style>` substring inside a script (for example in a comment or
+    // string) must not be mistaken for a real style start tag. Blank out the
+    // already-found script containers before searching for style tags so the
+    // style regex only ever sees text outside of scripts and matches the actual
+    // start tag. Whitespace replacement keeps every character offset intact.
+    let maskedForStyle = htmlx;
+    for (const tag of tags) {
+        maskedForStyle =
+            maskedForStyle.substring(0, tag.start) +
+            maskedForStyle.substring(tag.start, tag.end).replace(/[^\n]/g, ' ') +
+            maskedForStyle.substring(tag.end);
     }
+    tags.push(...extractTag(maskedForStyle, 'style'));
+
     return tags;
 }
 

--- a/packages/svelte2tsx/src/utils/htmlxparser.ts
+++ b/packages/svelte2tsx/src/utils/htmlxparser.ts
@@ -36,63 +36,78 @@ const scriptRegex =
 const styleRegex =
     /(<!--[^]*?-->)|(<style((?:\s+[^=>'"\/\s]+=(?:"[^"]*"|'[^']*'|[^>\s]+)|\s+[^=>'"\/\s]+)*\s*)>)([\S\s]*?)<\/style>/g;
 
-function extractTag(htmlx: string, tag: 'script' | 'style') {
-    const exp = tag === 'script' ? scriptRegex : styleRegex;
-    const matches: Node[] = [];
-
-    let match: RegExpExecArray | null = null;
-    while ((match = exp.exec(htmlx)) != null) {
-        if (match[0].startsWith('<!--')) {
-            // Tag is inside comment
-            continue;
-        }
-
-        let content = match[4];
-        if (!content) {
-            // Keep tag and transform it like a regular element
-            content = '';
-        }
-
-        const start = match.index + match[2].length;
-        const end = start + content.length;
-        const containerStart = match.index;
-        const containerEnd = match.index + match[0].length;
-
-        matches.push({
-            start: containerStart,
-            end: containerEnd,
-            name: tag,
-            type: tag === 'style' ? 'Style' : 'Script',
-            attributes: parseAttributes(match[3], containerStart + `<${tag}`.length),
-            content: {
-                type: 'Text',
-                start,
-                end,
-                value: content,
-                raw: content
-            }
-        });
+function toVerbatimNode(match: RegExpExecArray, tag: 'script' | 'style'): Node {
+    let content = match[4];
+    if (!content) {
+        // Keep tag and transform it like a regular element
+        content = '';
     }
 
-    return matches;
+    const start = match.index + match[2].length;
+    const end = start + content.length;
+    const containerStart = match.index;
+    const containerEnd = match.index + match[0].length;
+
+    return {
+        start: containerStart,
+        end: containerEnd,
+        name: tag,
+        type: tag === 'style' ? 'Style' : 'Script',
+        attributes: parseAttributes(match[3], containerStart + `<${tag}`.length),
+        content: {
+            type: 'Text',
+            start,
+            end,
+            value: content,
+            raw: content
+        }
+    };
+}
+
+/**
+ * Find the next real script or style element at or after `from`.
+ *
+ * Both tags are searched in the same pass and the earlier match wins, so a
+ * literal `<script>` or `<style>` substring inside the *other* kind of tag
+ * (for example in a comment or a string) can never be mistaken for a real
+ * start tag: whichever element actually opens first is matched first, and the
+ * search then resumes past its end.
+ */
+function findNextVerbatimElement(htmlx: string, from: number) {
+    let best: { node: Node; nextIndex: number } | null = null;
+
+    for (const [tag, exp] of [
+        ['script', scriptRegex],
+        ['style', styleRegex]
+    ] as const) {
+        exp.lastIndex = from;
+
+        let match: RegExpExecArray | null = null;
+        while ((match = exp.exec(htmlx)) != null) {
+            if (match[0].startsWith('<!--')) {
+                // Tag is inside comment
+                continue;
+            }
+
+            if (!best || match.index < best.node.start) {
+                best = { node: toVerbatimNode(match, tag), nextIndex: exp.lastIndex };
+            }
+            break;
+        }
+    }
+
+    return best;
 }
 
 function findVerbatimElements(htmlx: string) {
-    const tags = extractTag(htmlx, 'script');
+    const tags: Node[] = [];
 
-    // A literal `<style>` substring inside a script (for example in a comment or
-    // string) must not be mistaken for a real style start tag. Blank out the
-    // already-found script containers before searching for style tags so the
-    // style regex only ever sees text outside of scripts and matches the actual
-    // start tag. Whitespace replacement keeps every character offset intact.
-    let maskedForStyle = htmlx;
-    for (const tag of tags) {
-        maskedForStyle =
-            maskedForStyle.substring(0, tag.start) +
-            maskedForStyle.substring(tag.start, tag.end).replace(/[^\n]/g, ' ') +
-            maskedForStyle.substring(tag.end);
+    let from = 0;
+    let next: ReturnType<typeof findNextVerbatimElement>;
+    while ((next = findNextVerbatimElement(htmlx, from)) != null) {
+        tags.push(next.node);
+        from = next.nextIndex;
     }
-    tags.push(...extractTag(maskedForStyle, 'style'));
 
     return tags;
 }

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-tag-in-style-comment-with-real-script/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-tag-in-style-comment-with-real-script/expectedv2.ts
@@ -1,0 +1,12 @@
+///<reference types="svelte" />
+;function $$render() {
+
+	let a = 1;
+;
+async () => {
+
+};
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event($$render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/script-tag-in-style-comment-with-real-script/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/script-tag-in-style-comment-with-real-script/input.svelte
@@ -1,0 +1,7 @@
+<style>
+	/* see the <script> block */
+</style>
+
+<script lang="ts">
+	let a = 1;
+</script>

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-tag-in-script-comment-with-real-style/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-tag-in-script-comment-with-real-style/expectedv2.ts
@@ -1,0 +1,12 @@
+///<reference types="svelte" />
+;function $$render() {
+
+	// see the <style> block
+;
+async () => {
+
+<style>p{color:red}</style>};
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event($$render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-tag-in-script-comment-with-real-style/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-tag-in-script-comment-with-real-style/expectedv2.ts
@@ -5,7 +5,7 @@
 ;
 async () => {
 
-<style>p{color:red}</style>};
+};
 return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
 
 export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event($$render()))) {

--- a/packages/svelte2tsx/test/svelte2tsx/samples/style-tag-in-script-comment-with-real-style/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/style-tag-in-script-comment-with-real-style/input.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	// see the <style> block
+</script>
+
+<style>p{color:red}</style>


### PR DESCRIPTION
Fixes #3071

### Problem

`svelte-check` (and the VS Code extension, same engine) reports a false `element_unclosed: <script> was left open` for a file whose `<script>` is correctly closed. The trigger is the literal token `<style>` appearing inside the `<script>` (e.g. in a `//` comment) **when the file also contains a real `<style>` block**. `svelte/compiler`'s `compile()` accepts the exact same source without error, so this is a `svelte2tsx` false positive.

Minimal reproduction:

```svelte
<script lang="ts">
  // see the <style> block
</script>
<style>p{color:red}</style>
```

### Root cause

In `packages/svelte2tsx/src/utils/htmlxparser.ts`, `findVerbatimElements` uses a non-greedy `styleRegex` that can start matching at a `<style>` substring **inside** the script and run past the real `</script>` up to the next `</style>`.

The existing `insideScript` guard was meant to drop such false style matches, but it only skipped matches that are **strictly nested** inside a script tag (`tag.start < style.start && tag.end > style.end`). In the issue's case the false style match *ends after* the script tag, so the guard didn't fire. `blankVerbatimContent` then blanked out the real `</script>` along with the fake style content, and the compiler correctly complained about an unclosed `<script>` in the now-broken text.

### Fix

Relax the guard to also skip a style match that merely **starts** inside a script tag:

```diff
- (tag) => tag.start < styleTag.start && tag.end > styleTag.end
+ (tag) => tag.start < styleTag.start && styleTag.start < tag.end
```

### Test plan

- Added `test/svelte2tsx/samples/style-tag-in-script-comment-with-real-style` covering the exact reproduction (a `<style>` token in a script comment plus a real separate `<style>` block). It fails before the fix (`<script> must have a closing tag`) and passes after, emitting correct TSX with both the script comment and the real `<style>` preserved.
- Full `svelte2tsx` sample suite passes (371 tests), including the neighbouring `style-in-script` (a `<style>...</style>` string literal inside a script with **no** real style block — still correctly treated as inside-script) and `ts-style-and-script` (a normal script followed by a separate style block — unaffected).
- `pnpm lint` (Prettier) passes.
