### PR TITLE
fix: allow transitions to return a function taking a direction argument

### DIFF
--- a/.changeset/transition-direction-return.md
+++ b/.changeset/transition-direction-return.md
@@ -1,0 +1,6 @@
+---
+'svelte-check': patch
+'svelte2tsx': patch
+---
+
+fix: allow transitions to return a function taking a `direction` argument

--- a/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/transition-options/input.svelte
+++ b/packages/language-server/test/plugins/typescript/features/diagnostics/fixtures/transition-options/input.svelte
@@ -6,6 +6,15 @@
     ) {
       return {};
     }
+
+    function deferredTransition(
+      _node: HTMLElement,
+      _params: { delay: number },
+      _context: { direction: 'in' | 'out' | 'both' }
+    ) {
+      return (_options: { direction: 'in' | 'out' }) => ({ delay: 100 });
+    }
 </script>
 
 <div in:myTransition={{ delay: 100 }} />
+<div in:deferredTransition={{ delay: 100 }} />

--- a/packages/svelte2tsx/svelte-shims-v4.d.ts
+++ b/packages/svelte2tsx/svelte-shims-v4.d.ts
@@ -22,7 +22,7 @@ type SvelteTransitionConfig = {
 }
 
 /** @internal PRIVATE API, DO NOT USE */
-type SvelteTransitionReturnType = SvelteTransitionConfig | (() => SvelteTransitionConfig)
+type SvelteTransitionReturnType = SvelteTransitionConfig | ((options: { direction: 'in' | 'out' }) => SvelteTransitionConfig)
 
 /** @internal PRIVATE API, DO NOT USE */
 type SvelteAnimationReturnType = {
@@ -173,7 +173,7 @@ type __sveltets_2_SvelteTransitionConfig = {
     tick?: (t: number, u: number) => void
 }
 /** @internal PRIVATE API, DO NOT USE */
-type __sveltets_2_SvelteTransitionReturnType = __sveltets_2_SvelteTransitionConfig | (() => __sveltets_2_SvelteTransitionConfig)
+type __sveltets_2_SvelteTransitionReturnType = __sveltets_2_SvelteTransitionConfig | ((options: { direction: 'in' | 'out' }) => __sveltets_2_SvelteTransitionConfig)
 declare function __sveltets_2_ensureTransition(transitionCall: __sveltets_2_SvelteTransitionReturnType): {};
 
 // Includes undefined and null for all types as all usages also allow these

--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -103,7 +103,7 @@ type SvelteTransitionConfig = {
 }
 
 /** @internal PRIVATE API, DO NOT USE */
-type SvelteTransitionReturnType = SvelteTransitionConfig | (() => SvelteTransitionConfig)
+type SvelteTransitionReturnType = SvelteTransitionConfig | ((options: { direction: 'in' | 'out' }) => SvelteTransitionConfig)
 
 /** @internal PRIVATE API, DO NOT USE */
 type SvelteAnimationReturnType = {
@@ -253,7 +253,7 @@ type __sveltets_2_SvelteTransitionConfig = {
     tick?: (t: number, u: number) => void
 }
 /** @internal PRIVATE API, DO NOT USE */
-type __sveltets_2_SvelteTransitionReturnType = __sveltets_2_SvelteTransitionConfig | (() => __sveltets_2_SvelteTransitionConfig)
+type __sveltets_2_SvelteTransitionReturnType = __sveltets_2_SvelteTransitionConfig | ((options: { direction: 'in' | 'out' }) => __sveltets_2_SvelteTransitionConfig)
 declare function __sveltets_2_ensureTransition(transitionCall: __sveltets_2_SvelteTransitionReturnType): {};
 
 // Includes undefined and null for all types as all usages also allow these


### PR DESCRIPTION
Fixes #2686.

Custom transitions may return a function taking a `direction` argument — Svelte always calls the deferred config with `{ direction: 'in' | 'out' }` ([Svelte 5](https://github.com/sveltejs/svelte/blob/svelte%405.20.0/packages/svelte/src/internal/client/dom/elements/transitions.js#L334), [Svelte 4](https://github.com/sveltejs/svelte/blob/svelte%404.2.19/packages/svelte/src/runtime/internal/transitions.js#L417)) — but the `__sveltets_2_SvelteTransitionReturnType` shim only allowed `TransitionConfig | (() => TransitionConfig)`. A function with a required parameter isn't assignable to `() => TransitionConfig`, so valid custom transitions were flagged as errors while the parameterless form was accepted.

This widens the shim's deferred form to `(options: { direction: 'in' | 'out' }) => TransitionConfig`, the same type [Svelte 5's runtime uses internally](https://github.com/sveltejs/svelte/blob/svelte%405.20.0/packages/svelte/src/internal/client/dom/elements/transitions.js#L315). Note that the public [`TransitionFn`](https://github.com/sveltejs/svelte/blob/svelte%405.20.0/packages/svelte/src/internal/client/types.d.ts#L131) type marks `direction` optional instead; the required form here is deliberate. Because function parameters are checked contravariantly, the required form accepts every shape users can write — `() => TransitionConfig` as well as callbacks declaring `direction` required, optional, or widened to `'in' | 'out' | 'both'` — whereas an optional-`direction` shim would still reject the issue's reproduction under `strictFunctionTypes` (a `{ direction?: 'in' | 'out' }` argument isn't assignable to a parameter typed `{ direction: 'in' | 'out' }`). Existing code is unaffected since `() => TransitionConfig` remains assignable.

I applied the same change to `svelte-shims.d.ts` since the v4 shim's header asks to consider backporting changes; happy to drop that hunk if you'd rather leave the Svelte-3-only shim untouched.

The `transition-options` diagnostics fixture is extended with a transition returning a `direction`-taking function; it fails without the shim change and passes with it.
