### PR TITLE
fix: ensure config loading happens sequentially

### DIFF
--- a/.changeset/silent-dots-roll.md
+++ b/.changeset/silent-dots-roll.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/load-config': patch
+---
+
+fix: ensure config loading happens sequentially

--- a/packages/load-config/src/index.ts
+++ b/packages/load-config/src/index.ts
@@ -176,10 +176,11 @@ async function loadSvelteConfigFromVite(
 
     // Make sure that only one Vite config is resolved at a time, to prevent race conditions with multiple
     // calls to `loadConfig` ending up with changing the process' current working directory mid-resolution.
-    await resolving;
-
+    const previous = resolving;
     let resolve;
     resolving = new Promise((r) => (resolve = r));
+    await previous;
+
     const cwd = process.cwd();
 
     try {


### PR DESCRIPTION
The current mechanism for ensuring that config loading is sequential is buggy — it's possible for multiple invocations to await the same `resolving` promise. This, in turn, causes module-level state in the SvelteKit Vite plugin to get corrupted. That bug should be fixed as well as this one