### PR TITLE
feat: looseAttributePrefixes option to exempt prefixed attributes from type checking

### DIFF
--- a/.changeset/loose-attribute-prefixes.md
+++ b/.changeset/loose-attribute-prefixes.md
@@ -1,0 +1,8 @@
+---
+'svelte2tsx': minor
+'svelte-language-server': minor
+'svelte-check': minor
+'typescript-svelte-plugin': minor
+---
+
+feat: `svelteOptions.looseAttributePrefixes` tsconfig option to exempt prefixed attributes from type checking. Attributes matching a configured prefix (e.g. `mystuff:`) are treated like `data-*` attributes — accepted on any element or component, but untyped. Useful when a preprocessor removes such attributes before the Svelte compiler sees them.

--- a/packages/language-server/src/plugins/typescript-go/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript-go/features/DiagnosticsProvider.ts
@@ -37,7 +37,6 @@ import { DiagnosticsProvider } from '../../interfaces';
 import {
     DocumentSnapshot,
     JSOrTSDocumentSnapshot,
-    sanitizeLooseAttributePrefixes,
     SvelteDocumentSnapshot,
     SvelteSnapshotOptions
 } from '../../typescript/DocumentSnapshot';
@@ -120,9 +119,10 @@ export class SvelteCheckTSGoDiagnosticsProvider implements DiagnosticsProvider {
         if (this.projectConfig?.raw.svelteOptions?.namespace) {
             this.snapshotOptions.typingsNamespace = this.projectConfig.raw.svelteOptions.namespace;
         }
-        this.snapshotOptions.looseAttributePrefixes = sanitizeLooseAttributePrefixes(
-            this.projectConfig?.raw.svelteOptions?.looseAttributePrefixes
-        );
+        this.snapshotOptions.looseAttributePrefixes =
+            internalHelpers.sanitizeLooseAttributePrefixes(
+                this.projectConfig?.raw.svelteOptions?.looseAttributePrefixes
+            );
         this.pendingConfigLoading = configLoader.loadConfigs(path.dirname(tsconfigPath));
         this.writeVirtualTsconfig();
     }

--- a/packages/language-server/src/plugins/typescript-go/features/DiagnosticsProvider.ts
+++ b/packages/language-server/src/plugins/typescript-go/features/DiagnosticsProvider.ts
@@ -37,6 +37,7 @@ import { DiagnosticsProvider } from '../../interfaces';
 import {
     DocumentSnapshot,
     JSOrTSDocumentSnapshot,
+    sanitizeLooseAttributePrefixes,
     SvelteDocumentSnapshot,
     SvelteSnapshotOptions
 } from '../../typescript/DocumentSnapshot';
@@ -119,6 +120,9 @@ export class SvelteCheckTSGoDiagnosticsProvider implements DiagnosticsProvider {
         if (this.projectConfig?.raw.svelteOptions?.namespace) {
             this.snapshotOptions.typingsNamespace = this.projectConfig.raw.svelteOptions.namespace;
         }
+        this.snapshotOptions.looseAttributePrefixes = sanitizeLooseAttributePrefixes(
+            this.projectConfig?.raw.svelteOptions?.looseAttributePrefixes
+        );
         this.pendingConfigLoading = configLoader.loadConfigs(path.dirname(tsconfigPath));
         this.writeVirtualTsconfig();
     }

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -111,20 +111,6 @@ export interface SvelteSnapshotOptions {
     looseAttributePrefixes?: string[];
 }
 
-/**
- * Validates the `svelteOptions.looseAttributePrefixes` tsconfig value, which is
- * unchecked user input.
- */
-export function sanitizeLooseAttributePrefixes(prefixes: unknown): string[] | undefined {
-    if (!Array.isArray(prefixes)) {
-        return undefined;
-    }
-    const sanitized = prefixes.filter(
-        (prefix): prefix is string => typeof prefix === 'string' && prefix.length > 0
-    );
-    return sanitized.length > 0 ? sanitized : undefined;
-}
-
 const ambientPathPattern = /node_modules[\/\\]svelte[\/\\]types[\/\\]ambient\.d\.ts$/;
 const svelteTypesPattern = /node_modules[\/\\]svelte[\/\\]types[\/\\]index\.d\.ts$/;
 const shimsPattern =

--- a/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
+++ b/packages/language-server/src/plugins/typescript/DocumentSnapshot.ts
@@ -108,6 +108,21 @@ export interface SvelteSnapshotOptions {
         workspacePath: string;
         generatedPath: string;
     };
+    looseAttributePrefixes?: string[];
+}
+
+/**
+ * Validates the `svelteOptions.looseAttributePrefixes` tsconfig value, which is
+ * unchecked user input.
+ */
+export function sanitizeLooseAttributePrefixes(prefixes: unknown): string[] | undefined {
+    if (!Array.isArray(prefixes)) {
+        return undefined;
+    }
+    const sanitized = prefixes.filter(
+        (prefix): prefix is string => typeof prefix === 'string' && prefix.length > 0
+    );
+    return sanitized.length > 0 ? sanitized : undefined;
 }
 
 const ambientPathPattern = /node_modules[\/\\]svelte[\/\\]types[\/\\]ambient\.d\.ts$/;
@@ -255,7 +270,8 @@ function preprocessSvelteFile(document: Document, options: SvelteSnapshotOptions
                       })
                     : document.config?.compilerOptions?.customElement),
             emitJsDoc: options.emitJsDoc,
-            rewriteExternalImports: options.rewriteExternalImports
+            rewriteExternalImports: options.rewriteExternalImports,
+            looseAttributePrefixes: options.looseAttributePrefixes
         });
         text = tsx.code;
         tsxMap = tsx.map as EncodedSourceMap;

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -18,7 +18,11 @@ import {
     pathToUrl,
     urlToPath
 } from '../../utils';
-import { DocumentSnapshot, SvelteSnapshotOptions } from './DocumentSnapshot';
+import {
+    DocumentSnapshot,
+    sanitizeLooseAttributePrefixes,
+    SvelteSnapshotOptions
+} from './DocumentSnapshot';
 import { createSvelteModuleLoader } from './module-loader';
 import { GlobalSnapshotsManager, SnapshotManager } from './SnapshotManager';
 import {
@@ -429,7 +433,10 @@ async function createLanguageService(
         parse: svelteCompiler?.parse,
         version: svelteCompiler?.VERSION,
         transformOnTemplateError: docContext.transformOnTemplateError,
-        typingsNamespace: raw?.svelteOptions?.namespace || 'svelteHTML'
+        typingsNamespace: raw?.svelteOptions?.namespace || 'svelteHTML',
+        looseAttributePrefixes: sanitizeLooseAttributePrefixes(
+            raw?.svelteOptions?.looseAttributePrefixes
+        )
     };
 
     const project = initLsCacheProject();

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -18,11 +18,7 @@ import {
     pathToUrl,
     urlToPath
 } from '../../utils';
-import {
-    DocumentSnapshot,
-    sanitizeLooseAttributePrefixes,
-    SvelteSnapshotOptions
-} from './DocumentSnapshot';
+import { DocumentSnapshot, SvelteSnapshotOptions } from './DocumentSnapshot';
 import { createSvelteModuleLoader } from './module-loader';
 import { GlobalSnapshotsManager, SnapshotManager } from './SnapshotManager';
 import {
@@ -434,7 +430,7 @@ async function createLanguageService(
         version: svelteCompiler?.VERSION,
         transformOnTemplateError: docContext.transformOnTemplateError,
         typingsNamespace: raw?.svelteOptions?.namespace || 'svelteHTML',
-        looseAttributePrefixes: sanitizeLooseAttributePrefixes(
+        looseAttributePrefixes: internalHelpers.sanitizeLooseAttributePrefixes(
             raw?.svelteOptions?.looseAttributePrefixes
         )
     };

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -104,6 +104,8 @@ If a preprocessor consumes attributes with a common prefix (for example custom t
 
 Matching attributes are then treated like `data-*` attributes: accepted on any element or component, but untyped. This also applies to the language server / VS Code extension.
 
+Note that `svelteOptions` must be defined in the project's own `tsconfig.json`/`jsconfig.json` — it is not picked up from a config referenced via `extends`.
+
 ### More docs, preprocessor setup and troubleshooting
 
 [See here](/docs/README.md).

--- a/packages/svelte-check/README.md
+++ b/packages/svelte-check/README.md
@@ -87,6 +87,23 @@ npm install --save-dev typescript@~6 @typescript/native@npm:typescript@7
 
 `svelte-check` needs to know the whole project to do valid checks. Imagine you alter a component property `export let foo` to `export let bar`, but you don't update any of the component usages. They all have errors now but you would not catch them if you only run checks on changed files.
 
+#### My preprocessor removes certain attributes before the Svelte compiler runs — how do I stop errors about them?
+
+If a preprocessor consumes attributes with a common prefix (for example custom template directives like `mystuff:foo`), the type checker would flag them as unknown attributes/props because it operates on the unpreprocessed source. You can exempt such prefixes via `svelteOptions.looseAttributePrefixes` in your `tsconfig.json`/`jsconfig.json`:
+
+```jsonc
+{
+    "compilerOptions": {
+        // ...
+    },
+    "svelteOptions": {
+        "looseAttributePrefixes": ["mystuff:"]
+    }
+}
+```
+
+Matching attributes are then treated like `data-*` attributes: accepted on any element or component, but untyped. This also applies to the language server / VS Code extension.
+
 ### More docs, preprocessor setup and troubleshooting
 
 [See here](/docs/README.md).

--- a/packages/svelte-check/src/incremental.ts
+++ b/packages/svelte-check/src/incremental.ts
@@ -33,6 +33,8 @@ type ManifestEntry = {
 type Manifest = {
     version: number;
     entries: Record<string, ManifestEntry>;
+    /** The emitted files depend on this option, so a change to it needs to invalidate the cache */
+    looseAttributePrefixes?: string[];
 };
 
 export type EmitResult = {
@@ -93,6 +95,25 @@ const defaultKitFilesSettings: InternalHelpers.KitFilesSettings = {
     universalHooksPath: 'src/hooks'
 };
 
+/**
+ * Reads and validates `svelteOptions.looseAttributePrefixes` from the tsconfig/jsconfig,
+ * which is unchecked user input.
+ */
+function getLooseAttributePrefixes(tsconfigPath: string | undefined): string[] | undefined {
+    if (!tsconfigPath) {
+        return undefined;
+    }
+    const prefixes = ts.readConfigFile(tsconfigPath, ts.sys.readFile).config?.svelteOptions
+        ?.looseAttributePrefixes;
+    if (!Array.isArray(prefixes)) {
+        return undefined;
+    }
+    const sanitized = prefixes.filter(
+        (prefix): prefix is string => typeof prefix === 'string' && prefix.length > 0
+    );
+    return sanitized.length > 0 ? sanitized : undefined;
+}
+
 function kitFilesSettingsFromConfig(config: any): InternalHelpers.KitFilesSettings {
     if (!config?.files) {
         return defaultKitFilesSettings;
@@ -139,16 +160,26 @@ export async function emitSvelteFiles(
     workspacePath: string,
     filePathsToIgnore: string[],
     incremental: boolean,
-    config?: string
+    config?: string,
+    tsconfigPath?: string
 ): Promise<EmitResult> {
     const cacheDir = getCacheDir(workspacePath);
     const emitDir = path.join(cacheDir, EMIT_SUBDIR);
     const manifestPath = path.join(cacheDir, 'manifest.json');
     fs.mkdirSync(emitDir, { recursive: true });
 
-    const manifest = incremental
+    const manifest: Manifest = incremental
         ? loadManifest(manifestPath, workspacePath)
         : { version: MANIFEST_VERSION, entries: {} as Record<string, ManifestEntry> };
+    const looseAttributePrefixes = getLooseAttributePrefixes(tsconfigPath);
+    if (
+        JSON.stringify(manifest.looseAttributePrefixes ?? null) !==
+        JSON.stringify(looseAttributePrefixes ?? null)
+    ) {
+        // The emitted files were generated with different options, redo them all
+        manifest.entries = {};
+    }
+    manifest.looseAttributePrefixes = looseAttributePrefixes;
     const kitFilesSettings = await loadKitFilesSettings(workspacePath, config);
     const isJsOrTsFile = (filePath: string) => filePath.endsWith('.ts') || filePath.endsWith('.js');
     const allRelevantFiles = await findFiles(
@@ -235,7 +266,8 @@ export async function emitSvelteFiles(
                 rewriteExternalImports: {
                     workspacePath,
                     generatedPath: outPath
-                }
+                },
+                looseAttributePrefixes
             });
 
             fs.writeFileSync(outPath, tsx.code, 'utf-8');
@@ -1026,7 +1058,11 @@ function loadManifest(manifestPath: string, workspacePath: string): Manifest {
                     : undefined
             };
         }
-        return { version: data.version, entries: resolvedEntries };
+        return {
+            version: data.version,
+            entries: resolvedEntries,
+            looseAttributePrefixes: data.looseAttributePrefixes
+        };
     } catch {
         return { version: MANIFEST_VERSION, entries: {} };
     }
@@ -1055,7 +1091,8 @@ function writeManifest(manifestPath: string, manifest: Manifest, workspacePath: 
     }
     const data: Manifest = {
         version: MANIFEST_VERSION,
-        entries: relativeEntries
+        entries: relativeEntries,
+        looseAttributePrefixes: manifest.looseAttributePrefixes
     };
     fs.writeFileSync(manifestPath, JSON.stringify(data, null, 2), 'utf-8');
 }

--- a/packages/svelte-check/src/incremental.ts
+++ b/packages/svelte-check/src/incremental.ts
@@ -103,15 +103,10 @@ function getLooseAttributePrefixes(tsconfigPath: string | undefined): string[] |
     if (!tsconfigPath) {
         return undefined;
     }
-    const prefixes = ts.readConfigFile(tsconfigPath, ts.sys.readFile).config?.svelteOptions
-        ?.looseAttributePrefixes;
-    if (!Array.isArray(prefixes)) {
-        return undefined;
-    }
-    const sanitized = prefixes.filter(
-        (prefix): prefix is string => typeof prefix === 'string' && prefix.length > 0
+    return internalHelpers.sanitizeLooseAttributePrefixes(
+        ts.readConfigFile(tsconfigPath, ts.sys.readFile).config?.svelteOptions
+            ?.looseAttributePrefixes
     );
-    return sanitized.length > 0 ? sanitized : undefined;
 }
 
 function kitFilesSettingsFromConfig(config: any): InternalHelpers.KitFilesSettings {

--- a/packages/svelte-check/src/index.ts
+++ b/packages/svelte-check/src/index.ts
@@ -453,7 +453,8 @@ async function runWithVirtualFiles(
         opts.workspaceUri.fsPath,
         opts.filePathsToIgnore,
         opts.incremental,
-        opts.config
+        opts.config,
+        opts.tsconfig
     );
     const overlayTsconfig = writeOverlayTsconfig(
         opts.tsconfig,

--- a/packages/svelte2tsx/index.d.ts
+++ b/packages/svelte2tsx/index.d.ts
@@ -95,6 +95,13 @@ export function svelte2tsx(
          * from the generated file location.
          */
         rewriteExternalImports?: InternalHelpers.RewriteExternalImportsConfig;
+        /**
+         * Attribute name prefixes (e.g. `['mochi:']`) whose attributes should not be
+         * type-checked against element attribute / component prop types. Useful when
+         * a preprocessor removes such attributes before the Svelte compiler sees them.
+         * Matching attributes are treated like `data-*` attributes: accepted, but untyped.
+         */
+        looseAttributePrefixes?: string[];
     }
 ): SvelteCompiledToTsx
 

--- a/packages/svelte2tsx/index.d.ts
+++ b/packages/svelte2tsx/index.d.ts
@@ -180,6 +180,7 @@ export const internalHelpers: {
     ) => { text: string; addedCode: InternalHelpers.AddedCode[] } | undefined,
     toVirtualPos: (pos: number, addedCode: InternalHelpers.AddedCode[]) => number,
     toOriginalPos: (pos: number, addedCode: InternalHelpers.AddedCode[]) => {pos: number; inGenerated: boolean},
+    sanitizeLooseAttributePrefixes: (prefixes: unknown) => string[] | undefined,
     findExports: (_ts: typeof ts, source: ts.SourceFile, isTsFile: boolean) => Map<
         string,
         | {

--- a/packages/svelte2tsx/src/helpers/index.ts
+++ b/packages/svelte2tsx/src/helpers/index.ts
@@ -9,6 +9,7 @@ import {
     upsertKitFile
 } from './sveltekit';
 import { findExports } from './typescript';
+import { sanitizeLooseAttributePrefixes } from './looseAttributePrefixes';
 
 /**
  * ## Internal, do not use! This is subject to change at any time.
@@ -26,5 +27,6 @@ export const internalHelpers = {
     toOriginalPos,
     findExports,
     get_global_types,
+    sanitizeLooseAttributePrefixes,
     renderName: '$$render'
 };

--- a/packages/svelte2tsx/src/helpers/looseAttributePrefixes.ts
+++ b/packages/svelte2tsx/src/helpers/looseAttributePrefixes.ts
@@ -1,0 +1,14 @@
+/**
+ * Validates the `svelteOptions.looseAttributePrefixes` tsconfig value, which is
+ * unchecked user input. Non-string and empty-string entries are dropped (an empty
+ * string would match every attribute and silently disable attribute checking).
+ */
+export function sanitizeLooseAttributePrefixes(prefixes: unknown): string[] | undefined {
+    if (!Array.isArray(prefixes)) {
+        return undefined;
+    }
+    const sanitized = prefixes.filter(
+        (prefix): prefix is string => typeof prefix === 'string' && prefix.length > 0
+    );
+    return sanitized.length > 0 ? sanitized : undefined;
+}

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
@@ -103,6 +103,7 @@ export function convertHtmlxToJsx(
         emitJsDoc?: boolean;
         isTsFile?: boolean;
         rewriteExternalImports?: RewriteExternalImportsOptions;
+        looseAttributePrefixes?: string[];
     } = { svelte5Plus: false }
 ): TemplateProcessResult {
     options.typingsNamespace = options.typingsNamespace || 'svelteHTML';
@@ -498,6 +499,7 @@ export function convertHtmlxToJsx(
                             parent,
                             preserveAttributeCase,
                             options.svelte5Plus,
+                            options.looseAttributePrefixes,
                             element
                         );
                         break;
@@ -675,6 +677,7 @@ export function htmlx2jsx(
         preserveAttributeCase: boolean;
         typingsNamespace: string;
         svelte5Plus: boolean;
+        looseAttributePrefixes?: string[];
     }
 ) {
     const { htmlxAst, tags } = parseHtmlx(htmlx, parse, { ...options });

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/index.ts
@@ -11,6 +11,7 @@ import {
     DeclarationTag
 } from '../interfaces';
 import { parseHtmlx } from '../utils/htmlxparser';
+import { sanitizeLooseAttributePrefixes } from '../helpers/looseAttributePrefixes';
 import { handleActionDirective } from './nodes/Action';
 import { handleAnimateDirective } from './nodes/Animation';
 import { handleAttribute } from './nodes/Attribute';
@@ -107,6 +108,9 @@ export function convertHtmlxToJsx(
     } = { svelte5Plus: false }
 ): TemplateProcessResult {
     options.typingsNamespace = options.typingsNamespace || 'svelteHTML';
+    // The value may come straight from an unvalidated tsconfig, so sanitize it here
+    // to guard all entry points at once
+    options.looseAttributePrefixes = sanitizeLooseAttributePrefixes(options.looseAttributePrefixes);
     const preserveAttributeCase = options.namespace === 'foreign';
     const emitJsDoc = options.emitJsDoc ?? false;
     const isTsFile = options.isTsFile ?? false;

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
@@ -81,9 +81,7 @@ export function handleAttribute(
         return;
     }
 
-    const isLooseAttribute = looseAttributePrefixes?.some((prefix) =>
-        attr.name.startsWith(prefix)
-    );
+    const isLooseAttribute = looseAttributePrefixes?.some((prefix) => attr.name.startsWith(prefix));
     const addAttribute =
         element instanceof Element
             ? (name: TransformationArray, value?: TransformationArray) => {

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Attribute.ts
@@ -57,6 +57,7 @@ export function handleAttribute(
     parent: BaseNode,
     preserveCase: boolean,
     svelte5Plus: boolean,
+    looseAttributePrefixes: string[] | undefined,
     element: Element | InlineComponent
 ): void {
     if (
@@ -80,10 +81,16 @@ export function handleAttribute(
         return;
     }
 
+    const isLooseAttribute = looseAttributePrefixes?.some((prefix) =>
+        attr.name.startsWith(prefix)
+    );
     const addAttribute =
         element instanceof Element
             ? (name: TransformationArray, value?: TransformationArray) => {
-                  if (attr.name.startsWith('data-') && !attr.name.startsWith('data-sveltekit-')) {
+                  if (
+                      isLooseAttribute ||
+                      (attr.name.startsWith('data-') && !attr.name.startsWith('data-sveltekit-'))
+                  ) {
                       // any attribute prefixed with data- is valid, but we can't
                       // type that statically, so we need this workaround
                       name.unshift('...__sveltets_2_empty({');
@@ -95,7 +102,15 @@ export function handleAttribute(
                   element.addAttribute(name, value);
               }
             : (name: TransformationArray, value?: TransformationArray) => {
-                  if (attr.name.startsWith('--')) {
+                  if (isLooseAttribute) {
+                      // configured as not part of the props definition (e.g. removed
+                      // by a preprocessor), so wrap it to not get "invalid prop" errors
+                      name.unshift('...__sveltets_2_empty({');
+                      if (!value) {
+                          value = ['__sveltets_2_any()'];
+                      }
+                      value.push('})');
+                  } else if (attr.name.startsWith('--')) {
                       // CSS custom properties are not part of the props
                       // definition, so wrap them to not get "--xx is invalid prop" errors
                       name.unshift('...__sveltets_2_cssProp({');

--- a/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Let.ts
+++ b/packages/svelte2tsx/src/htmlxtojsx_v2/nodes/Let.ts
@@ -52,6 +52,7 @@ export function handleLet(
                 parent,
                 preserveCase,
                 svelte5Plus,
+                undefined,
                 element
             );
         }

--- a/packages/svelte2tsx/src/svelte2tsx/index.ts
+++ b/packages/svelte2tsx/src/svelte2tsx/index.ts
@@ -26,6 +26,7 @@ function processSvelteTemplate(
         emitJsDoc?: boolean;
         isTsFile?: boolean;
         rewriteExternalImports?: RewriteExternalImportsOptions;
+        looseAttributePrefixes?: string[];
     }
 ): TemplateProcessResult {
     const { htmlxAst, tags } = parseHtmlx(str.original, parse, options);
@@ -55,6 +56,13 @@ export function svelte2tsx(
             workspacePath: string;
             generatedPath: string;
         };
+        /**
+         * Attribute name prefixes (e.g. `['mochi:']`) whose attributes should not be
+         * type-checked against element attribute / component prop types. Useful when
+         * a preprocessor removes such attributes before the Svelte compiler sees them.
+         * Matching attributes are treated like `data-*` attributes: accepted, but untyped.
+         */
+        looseAttributePrefixes?: string[];
     } = { parse }
 ) {
     options.mode = options.mode || 'ts';

--- a/packages/svelte2tsx/test/helpers.ts
+++ b/packages/svelte2tsx/test/helpers.ts
@@ -215,6 +215,7 @@ type TransformSampleFn = (
         sampleName: string;
         emitOnTemplateError: boolean;
         preserveAttributeCase: boolean;
+        looseAttributePrefixes?: string[];
     }
 ) => ReturnType<typeof htmlx2jsx | typeof svelte2tsx>;
 
@@ -372,6 +373,7 @@ type BaseConfig = {
     emitOnTemplateError?: boolean;
     filename?: string;
     rewriteExternalImports?: Svelte2TsxConfig['rewriteExternalImports'];
+    looseAttributePrefixes?: string[];
 };
 type Svelte2TsxConfig = Required<Parameters<typeof svelte2tsx>[1]>;
 
@@ -386,7 +388,8 @@ export function get_svelte2tsx_config(base: BaseConfig, sampleName: string): Sve
         accessors: sampleName.startsWith('accessors-config'),
         emitJsDoc: sampleName.startsWith('jsdoc-'),
         version: VERSION,
-        rewriteExternalImports: base.rewriteExternalImports
+        rewriteExternalImports: base.rewriteExternalImports,
+        looseAttributePrefixes: base.looseAttributePrefixes
     };
 }
 

--- a/packages/svelte2tsx/test/htmlx2jsx/index.ts
+++ b/packages/svelte2tsx/test/htmlx2jsx/index.ts
@@ -5,12 +5,13 @@ import { test_samples } from '../helpers';
 describe('htmlx2jsx', () => {
     test_samples(
         __dirname,
-        (input, { emitOnTemplateError, preserveAttributeCase }) => {
+        (input, { emitOnTemplateError, preserveAttributeCase, looseAttributePrefixes }) => {
             return htmlx2jsx(input, parse, {
                 emitOnTemplateError,
                 preserveAttributeCase,
                 typingsNamespace: 'svelteHTML',
-                svelte5Plus: Number(VERSION[0]) >= 5
+                svelte5Plus: Number(VERSION[0]) >= 5,
+                looseAttributePrefixes
             });
         },
         'js'

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-loose-prefix/config.json
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-loose-prefix/config.json
@@ -1,0 +1,3 @@
+{
+    "looseAttributePrefixes": ["mochi:"]
+}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-loose-prefix/expectedv2.js
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-loose-prefix/expectedv2.js
@@ -1,0 +1,1 @@
+ { svelteHTML.createElement("div", {      ...__sveltets_2_empty({"mochi:hydrate":true}),...__sveltets_2_empty({"mochi:defer":true}),...__sveltets_2_empty({"mochi:hydrate:visible":`200px`}),"class":`a`,});}

--- a/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-loose-prefix/input.svelte
+++ b/packages/svelte2tsx/test/htmlx2jsx/samples/attribute-loose-prefix/input.svelte
@@ -1,0 +1,1 @@
+<div mochi:hydrate={true} mochi:defer mochi:hydrate:visible="200px" class="a" />

--- a/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/config.json
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/config.json
@@ -1,0 +1,3 @@
+{
+    "looseAttributePrefixes": ["mochi:"]
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/expected-svelte5.ts
@@ -9,8 +9,7 @@ function $$render() {
 async () => {
 
  { const $$_ooF0C = __sveltets_2_ensureComponent(Foo); new $$_ooF0C({ target: __sveltets_2_any(), props: {    ...__sveltets_2_empty({"mochi:hydrate":x}),...__sveltets_2_empty({"mochi:defer":true}),"prop":`a`,}});}
- { svelteHTML.createElement("div", { ...__sveltets_2_empty({"mochi:hydrate":x}),}); }
-};
+ { svelteHTML.createElement("div", { ...__sveltets_2_empty({"mochi:hydrate":x}),}); }};
 return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
 const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event($$render())));
 /*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/expected-svelte5.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/expected-svelte5.ts
@@ -1,0 +1,17 @@
+///<reference types="svelte" />
+;
+import Foo from './Foo.svelte';
+function $$render() {
+
+    
+    let x = true;
+;
+async () => {
+
+ { const $$_ooF0C = __sveltets_2_ensureComponent(Foo); new $$_ooF0C({ target: __sveltets_2_any(), props: {    ...__sveltets_2_empty({"mochi:hydrate":x}),...__sveltets_2_empty({"mochi:defer":true}),"prop":`a`,}});}
+ { svelteHTML.createElement("div", { ...__sveltets_2_empty({"mochi:hydrate":x}),}); }
+};
+return { props: /** @type {Record<string, never>} */ ({}), exports: {}, bindings: "", slots: {}, events: {} }}
+const Input__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event($$render())));
+/*Ωignore_startΩ*/type Input__SvelteComponent_ = InstanceType<typeof Input__SvelteComponent_>;
+/*Ωignore_endΩ*/export default Input__SvelteComponent_;

--- a/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/expectedv2.ts
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/expectedv2.ts
@@ -1,0 +1,16 @@
+///<reference types="svelte" />
+;
+import Foo from './Foo.svelte';
+function $$render() {
+
+    
+    let x = true;
+;
+async () => {
+
+ { const $$_ooF0C = __sveltets_2_ensureComponent(Foo); new $$_ooF0C({ target: __sveltets_2_any(), props: {    ...__sveltets_2_empty({"mochi:hydrate":x}),...__sveltets_2_empty({"mochi:defer":true}),"prop":`a`,}});}
+ { svelteHTML.createElement("div", { ...__sveltets_2_empty({"mochi:hydrate":x}),}); }};
+return { props: /** @type {Record<string, never>} */ ({}), slots: {}, events: {} }}
+
+export default class Input__SvelteComponent_ extends __sveltets_2_createSvelte2TsxComponent(__sveltets_2_partial(__sveltets_2_with_any_event($$render()))) {
+}

--- a/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/input.svelte
+++ b/packages/svelte2tsx/test/svelte2tsx/samples/attribute-loose-prefix/input.svelte
@@ -1,0 +1,7 @@
+<script>
+    import Foo from './Foo.svelte';
+    let x = true;
+</script>
+
+<Foo mochi:hydrate={x} mochi:defer prop="a" />
+<div mochi:hydrate={x}></div>

--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -274,7 +274,7 @@ export class SvelteSnapshotManager {
     constructor(
         private typescript: typeof ts,
         private projectService: ts.server.ProjectService,
-        private svelteOptions: { namespace: string },
+        private svelteOptions: { namespace: string; looseAttributePrefixes?: string[] },
         private logger: Logger,
         private configManager: ConfigManager,
         /** undefined if no node_modules with Svelte next to tsconfig.json */
@@ -381,7 +381,12 @@ export class SvelteSnapshotManager {
                         typingsNamespace: this.svelteOptions.namespace,
                         // Don't search for compiler from current path - could be a different one from which we have loaded the svelte2tsx globals
                         parse: this.svelteCompiler?.parse,
-                        version: this.svelteCompiler?.VERSION
+                        version: this.svelteCompiler?.VERSION,
+                        looseAttributePrefixes: Array.isArray(
+                            this.svelteOptions.looseAttributePrefixes
+                        )
+                            ? this.svelteOptions.looseAttributePrefixes
+                            : undefined
                     });
                     code = result.code;
                     mapper = new SourceMapper(result.map.mappings);

--- a/packages/typescript-plugin/src/svelte-snapshots.ts
+++ b/packages/typescript-plugin/src/svelte-snapshots.ts
@@ -1,4 +1,4 @@
-import { svelte2tsx } from 'svelte2tsx';
+import { internalHelpers, svelte2tsx } from 'svelte2tsx';
 import type ts from 'typescript/lib/tsserverlibrary';
 import { ConfigManager } from './config-manager';
 import { Logger } from './logger';
@@ -382,11 +382,9 @@ export class SvelteSnapshotManager {
                         // Don't search for compiler from current path - could be a different one from which we have loaded the svelte2tsx globals
                         parse: this.svelteCompiler?.parse,
                         version: this.svelteCompiler?.VERSION,
-                        looseAttributePrefixes: Array.isArray(
+                        looseAttributePrefixes: internalHelpers.sanitizeLooseAttributePrefixes(
                             this.svelteOptions.looseAttributePrefixes
                         )
-                            ? this.svelteOptions.looseAttributePrefixes
-                            : undefined
                     });
                     code = result.code;
                     mapper = new SourceMapper(result.map.mappings);


### PR DESCRIPTION
Attributes whose names start with a prefix configured via svelteOptions.looseAttributePrefixes in tsconfig/jsconfig are treated like data-* attributes (spread into __sveltets_2_empty), on both elements and components. Useful for preprocessors that consume namespaced template directives before the Svelte compiler runs.

Plumbed through the language server (TS and tsgo paths), the typescript-plugin, and svelte-check's incremental mode (with cache invalidation when the option changes).

This is a small patch so we can avoid doing [this ugly svelte-check patch](https://github.com/khromov/mochi/blob/main/packages/minimal/patches/svelte-check%404.7.4.patch) in Mochi.