### PR TITLE
perf(svelte2tsx): use a module resolution cache in emitDts

### DIFF
--- a/.changeset/emit-dts-resolution-cache.md
+++ b/.changeset/emit-dts-resolution-cache.md
@@ -1,0 +1,5 @@
+---
+'svelte2tsx': patch
+---
+
+perf: use a module resolution cache in emitDts, avoiding a full module resolution walk for every import of every file in the program

--- a/packages/svelte2tsx/src/emitDts.ts
+++ b/packages/svelte2tsx/src/emitDts.ts
@@ -278,6 +278,20 @@ async function createTsCompilerHost(options: any, svelteMap: SvelteMap, absDecla
         });
     };
 
+    const getCanonicalFileName = createGetCanonicalFileName(ts.sys.useCaseSensitiveFileNames);
+    // Each resolution host gets its own cache: the two hosts disagree about
+    // whether virtual .svelte.ts/.svelte.js paths exist.
+    const tsModuleResolutionCache = ts.createModuleResolutionCache(
+        ts.sys.getCurrentDirectory(),
+        getCanonicalFileName,
+        options
+    );
+    const svelteModuleResolutionCache = ts.createModuleResolutionCache(
+        ts.sys.getCurrentDirectory(),
+        getCanonicalFileName,
+        options
+    );
+
     function resolveModuleName(name: string, containingFile: string, compilerOptions: any) {
         // Delegate to the TS resolver first.
         // If that does not bring up anything, try the Svelte Module loader
@@ -286,14 +300,20 @@ async function createTsCompilerHost(options: any, svelteMap: SvelteMap, absDecla
             name,
             containingFile,
             compilerOptions,
-            ts.sys
+            ts.sys,
+            tsModuleResolutionCache
         ).resolvedModule;
         if (tsResolvedModule && !isVirtualSvelteFilepath(tsResolvedModule.resolvedFileName)) {
             return tsResolvedModule;
         }
 
-        return ts.resolveModuleName(name, containingFile, compilerOptions, svelteSys)
-            .resolvedModule;
+        return ts.resolveModuleName(
+            name,
+            containingFile,
+            compilerOptions,
+            svelteSys,
+            svelteModuleResolutionCache
+        ).resolvedModule;
     }
 
     return host;
@@ -362,6 +382,31 @@ function toRealSvelteFilepath(filePath: string) {
 
 function ensureRealSvelteFilepath(filePath: string) {
     return isVirtualSvelteFilepath(filePath) ? toRealSvelteFilepath(filePath) : filePath;
+}
+
+const fileNameLowerCaseRegExp = /[^\u0130\u0131\u00DFa-z0-9\\/:\-_\. ]+/g;
+
+/**
+ * adopted from https://github.com/microsoft/TypeScript/blob/8192d550496d884263e292488e325ae96893dc78/src/compiler/core.ts#L1769-L1807
+ * see the comment there about why we can't just use String.prototype.toLowerCase() here
+ */
+function toFileNameLowerCase(x: string) {
+    return fileNameLowerCaseRegExp.test(x) ? x.replace(fileNameLowerCaseRegExp, toLowerCase) : x;
+}
+
+function toLowerCase(x: string) {
+    return x.toLowerCase();
+}
+
+/**
+ * adopted from https://github.com/microsoft/TypeScript/blob/8192d550496d884263e292488e325ae96893dc78/src/compiler/core.ts#L2312
+ */
+function createGetCanonicalFileName(useCaseSensitiveFileNames: boolean) {
+    return useCaseSensitiveFileNames ? identity : toFileNameLowerCase;
+}
+
+function identity<T>(x: T) {
+    return x;
 }
 
 function isSubpath(maybeParent: string, maybeChild: string) {


### PR DESCRIPTION
### perf(svelte2tsx): use a module resolution cache in emitDts

Fixes #3094.

#### Summary

`emitDts` resolves every import through its compiler host with bare `ts.resolveModuleName` calls, without a `ts.createModuleResolutionCache`. Nothing is cached across the program's files, so each of the (typically hundreds of) node_modules declaration files re-runs the full node_modules resolution walk (open/stat/realpath syscalls) for every import statement.

This PR creates a `ModuleResolutionCache` per resolution host in `createTsCompilerHost` and passes it to the two existing `ts.resolveModuleName` calls. Each of the two hosts (plain `ts.sys`, and the svelte-aware system) gets its own cache because they disagree about whether virtual `.svelte.ts`/`.svelte.js` paths exist, so their results must not be mixed.

This brings `emitDts` in line with the rest of the repo: the language server already maintains a deliberate module resolution cache in its `module-loader.ts` (see #2754, #2902); `emitDts` was the remaining resolution path without one. It is also complementary to #2963, which caches script-AST parsing on the language-server path; this PR addresses module resolution on the `emitDts`/`svelte-package` build path.

#### Benchmarks

Profiled in a pnpm + Turborepo design-system monorepo with 29 Svelte 5 component packages, each built with `svelte-package` (TypeScript 6.0.3, svelte2tsx 0.7.57, ~880 node_modules declaration files per program, macOS/arm64). V8 profiles showed ~82% of each `svelte-package` run inside `emitDts`, and ~52% of total build CPU in uncached module resolution.

With this change applied via a pnpm patch (identical diff):

| Cold build of the 29 packages | Before | After |
| --- | --- | --- |
| Sum of per-package build times | 173.0s | 113.2s |
| Process CPU (user+sys) | 133s | 99s |
| Wall time (14 cores) | 21.0s | 13.3s |

A representative single package dropped from ~10.9s to ~6.7s under parallel load, and to ~2s when built alone. The monorepo has been running this exact diff in CI since.

#### Correctness

- Within one `emitDts` call file contents do not change, so caching resolutions is sound.
- The svelteMap population is unaffected: the first resolution of each `(directory, specifier)` pair still goes through `svelteSys.fileExists`, which registers `.svelte` files; cache hits only replay results whose first resolution already did that work.
- Output verified byte-for-byte identical: recursive diff of every emitted `dist/` tree (d.ts + d.ts.map) across all 29 packages, patched vs unpatched, from both clean and warm starting states.

#### Test plan

- `pnpm test` in `packages/svelte2tsx`: 370 passing, including the `emitDts` suite (no new tests: the change is a pure caching pass-through with no observable behaviour, and byte-identical output is verified above).
- `pnpm lint` (prettier check): clean.
- `pnpm format`: no changes needed.
- Changeset included (`svelte2tsx`: patch).

#### A note on authorship

I use AI tooling in my workflow and it helped discover and author this change. If AI-assisted contributions are against the maintainers' stance, I am entirely happy for this to be closed.
