### PR TITLE
fix: don't double-nest kit options when loading from a vite config

### DIFF
--- a/.changeset/tall-hats-shake.md
+++ b/.changeset/tall-hats-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/load-config': patch
+---
+
+fix: don't double-nest kit options when loading from a vite config

--- a/packages/load-config/src/index.ts
+++ b/packages/load-config/src/index.ts
@@ -192,11 +192,11 @@ async function loadSvelteConfigFromVite(
         const kitPlugin = resolved.plugins.find(
             (plugin) => plugin.name === 'vite-plugin-sveltekit-setup'
         );
+        // `api.options` is already the split config shape with kit options under `kit`
         const kitOptions = kitPlugin?.api?.options;
         if (kitOptions) {
-            const { preprocess, compilerOptions, extensions, vitePlugin, ...kit } = kitOptions;
             return {
-                config: { preprocess, compilerOptions, extensions, vitePlugin, kit },
+                config: kitOptions,
                 configFilePath,
                 configSource: 'vite'
             };


### PR DESCRIPTION
`api.options` on the `vite-plugin-sveltekit-setup` plugin has been the already-split config (`{ compilerOptions, preprocess, extensions, kit }`) since sveltejs/kit#15944, so the flat destructure here picked the existing `kit` key up into the rest spread and consumers got `config.kit.kit.files` and so on. Top-level fields were unaffected, which is why the eslint recipe from sveltejs/eslint-plugin-svelte#1550 still worked.

Repro before the fix, with options passed to `sveltekit()` in `vite.config.js`:

```js
const result = await loadConfig('./', { traverse: false });
result.config.kit; // { kit: { files: {...}, ... } }
```
