### PR TITLE
fix: remove type dependency on `magic-string`

### DIFF
--- a/.changeset/rotten-drinks-rhyme.md
+++ b/.changeset/rotten-drinks-rhyme.md
@@ -1,0 +1,5 @@
+---
+'svelte2tsx': patch
+---
+
+fix: remove type dependency on `magic-string`

--- a/packages/svelte2tsx/index.d.ts
+++ b/packages/svelte2tsx/index.d.ts
@@ -2,7 +2,15 @@ import ts from 'typescript';
 
 export interface SvelteCompiledToTsx {
     code: string;
-    map: import("magic-string").SourceMap;
+    map: {
+        version: number;
+        file: string;
+        sources: string[];
+        sourcesContent?: string[];
+        names: string[];
+        mappings: string;
+        x_google_ignoreList?: number[];
+    };
     exportedNames: IExportedNames;
     /**
      * @deprecated Use TypeScript's `TypeChecker` to get the type information instead. This only covers literal typings.


### PR DESCRIPTION
`svelte2tsx` does only list it as a dev dependency so you either get a type error if you don't have it or a weird "esm blabla cjs" error when you're using `magic-string` 1.x