### PR TITLE
fix: align default tsconfig "include" logic with tsc/tsserver

### DIFF
--- a/.changeset/common-tips-give.md
+++ b/.changeset/common-tips-give.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+fix: prevent errors in language service reduced mode

--- a/.changeset/metal-sites-fail.md
+++ b/.changeset/metal-sites-fail.md
@@ -1,0 +1,6 @@
+---
+'svelte-check': patch
+'svelte-language-server': patch
+---
+
+fix: align default tsconfig "include" logic with tsc/tsserver

--- a/packages/language-server/src/plugins/typescript/SnapshotManager.ts
+++ b/packages/language-server/src/plugins/typescript/SnapshotManager.ts
@@ -88,12 +88,6 @@ export class GlobalSnapshotsManager {
         this.emitter.off('change', listener);
     }
 }
-
-export interface TsFilesSpec {
-    include?: readonly string[];
-    exclude?: readonly string[];
-}
-
 /**
  * Should only be used by `service.ts`
  */
@@ -123,7 +117,7 @@ export class SnapshotManager {
 
     constructor(
         private globalSnapshotsManager: GlobalSnapshotsManager,
-        private fileSpec: TsFilesSpec,
+        private fileSpec: ts.ConfigFileSpecs,
         private workspaceRoot: string,
         private tsSystem: ts.System,
         projectFiles: string[],
@@ -165,11 +159,11 @@ export class SnapshotManager {
     }
 
     areIgnoredFromNewFileWatch(watcherNewFiles: string[]): boolean {
-        const { include } = this.fileSpec;
+        const { validatedExcludeSpecs } = this.fileSpec;
 
         // Since we default to not include anything,
         //  just don't waste time on this
-        if (include?.length === 0 || !this.watchingCanonicalDirectories) {
+        if (validatedExcludeSpecs?.length === 0 || !this.watchingCanonicalDirectories) {
             return true;
         }
 
@@ -196,14 +190,19 @@ export class SnapshotManager {
     }
 
     updateProjectFiles(): void {
-        const { include, exclude } = this.fileSpec;
+        const { validatedExcludeSpecs, validatedIncludeSpecs } = this.fileSpec;
 
-        if (include?.length === 0) {
+        if (validatedIncludeSpecs?.length === 0) {
             return;
         }
 
         const projectFiles = this.tsSystem
-            .readDirectory(this.workspaceRoot, this.watchExtensions, exclude, include)
+            .readDirectory(
+                this.workspaceRoot,
+                this.watchExtensions,
+                validatedExcludeSpecs,
+                validatedIncludeSpecs
+            )
             .map(normalizePath);
 
         projectFiles.forEach((projectFile) =>
@@ -264,6 +263,10 @@ export class SnapshotManager {
 
     getProjectFileNames(): string[] {
         return Array.from(this.projectFileToOriginalCasing.values());
+    }
+
+    getProjectFileToOriginalCasingMap(): ReadonlyMap<string, string> {
+        return this.projectFileToOriginalCasing;
     }
 
     isProjectFile(fileName: string): boolean {

--- a/packages/language-server/src/plugins/typescript/service.ts
+++ b/packages/language-server/src/plugins/typescript/service.ts
@@ -96,6 +96,16 @@ declare module 'typescript' {
          */
         alternateResult?: string;
     }
+
+    interface TsConfigSourceFile {
+        /** @internal */ configFileSpecs?: ConfigFileSpecs;
+    }
+
+    interface ConfigFileSpecs {
+        validatedFilesSpec: readonly string[] | undefined;
+        validatedIncludeSpecs: readonly string[] | undefined;
+        validatedExcludeSpecs: readonly string[] | undefined;
+    }
 }
 
 export interface TsConfigInfo {
@@ -344,7 +354,7 @@ async function createLanguageService(
     const getCanonicalFileName = createGetCanonicalFileName(tsSystem.useCaseSensitiveFileNames);
     watchWildCardDirectories(projectConfig);
 
-    const snapshotManager = createSnapshotManager(projectConfig, tsconfigPath);
+    const snapshotManager = projectConfig.snapshotManager;
 
     // Load all configs within the tsconfig scope and the one above so that they are all loaded
     // by the time they need to be accessed synchronously by DocumentSnapshots.
@@ -471,17 +481,16 @@ async function createLanguageService(
 
     function createSnapshotManager(
         parsedCommandLine: ts.ParsedCommandLine,
-        configFileName: string
+        configFileName: string,
+        spec?: ts.ConfigFileSpecs
     ) {
-        const cached = configFileName ? parsedTsConfigInfo.get(configFileName) : undefined;
-        if (cached?.snapshotManager) {
-            return cached.snapshotManager;
-        }
-        // raw is the tsconfig merged with extending config
-        // see: https://github.com/microsoft/TypeScript/blob/08e4f369fbb2a5f0c30dee973618d65e6f7f09f8/src/compiler/commandLineParser.ts#L2537
         return new SnapshotManager(
             docContext.globalSnapshotsManager,
-            parsedCommandLine.raw,
+            spec ?? {
+                validatedIncludeSpecs: [],
+                validatedExcludeSpecs: undefined,
+                validatedFilesSpec: undefined
+            },
             configFileName ? dirname(configFileName) : workspacePath,
             tsSystem,
             parsedCommandLine.fileNames.map(normalizePath),
@@ -683,37 +692,59 @@ async function createLanguageService(
         if (!info.pendingProjectFileUpdate) {
             return;
         }
-        const projectFileCountBefore = snapshotManager.getProjectFileNames().length;
+        const projectFileCountBefore = snapshotManager.getProjectFileToOriginalCasingMap().size;
         ensureFilesForConfigUpdates(info);
-        const projectFileCountAfter = snapshotManager.getProjectFileNames().length;
+        const projectFileCountAfter = snapshotManager.getProjectFileToOriginalCasingMap().size;
 
-        if (projectFileCountAfter > projectFileCountBefore) {
+        if (
+            projectFileCountAfter > projectFileCountBefore ||
+            (languageServiceReducedMode && projectFileCountAfter < projectFileCountBefore)
+        ) {
             reduceLanguageServiceCapabilityIfFileSizeTooBig();
         }
     }
 
     function getScriptFileNames() {
-        const projectFiles = languageServiceReducedMode
-            ? []
-            : snapshotManager.getProjectFileNames();
-        const canonicalProjectFileNames = new Set(projectFiles.map(getCanonicalFileName));
+        if (!tsconfigPath) {
+            return Array.from(
+                new Set([
+                    ...snapshotManager.getClientFileNames(),
+                    ...svelteTsxFilesToOriginalCasing.values()
+                ])
+            );
+        }
+
+        const projectFiles = snapshotManager.getProjectFileToOriginalCasingMap();
+        const resultFiles = new Set<string>();
 
         // We only assign project files (i.e. those found through includes config) and virtual files to getScriptFileNames.
-        // We don't to include other client files otherwise they stay in the program and are never removed
-        const clientFiles = tsconfigPath
-            ? Array.from(virtualDocuments.values())
-                  .map((v) => v.getFilePath())
-                  .filter(isNotNullOrUndefined)
-            : snapshotManager.getClientFileNames();
+        // We don't want to include other client files otherwise they stay in the program and are never removed
+
+        for (const [_, doc] of virtualDocuments) {
+            const pathOriginalCasing = doc.getFilePath();
+            if (pathOriginalCasing) {
+                resultFiles.add(pathOriginalCasing);
+            }
+        }
+
+        if (languageServiceReducedMode) {
+            const canonicalProjectFileNames = new Set(
+                snapshotManager.getProjectFileToOriginalCasingMap().keys()
+            );
+            for (const client of snapshotManager.getClientFileNames()) {
+                if (canonicalProjectFileNames.has(getCanonicalFileName(client))) {
+                    resultFiles.add(client);
+                }
+            }
+        } else {
+            for (const doc of projectFiles.values()) {
+                resultFiles.add(doc);
+            }
+        }
 
         return Array.from(
             new Set([
-                ...projectFiles,
-                // project file is read from the file system so it's more likely to have
-                // the correct casing
-                ...clientFiles.filter(
-                    (file) => !canonicalProjectFileNames.has(getCanonicalFileName(file))
-                ),
+                ...resultFiles,
                 // Use original casing here, too: people could have their VS Code extensions in a case insensitive
                 // folder but their project in a case sensitive one; and if we copy the shims into the case sensitive
                 // part it would break when canonicalizing it.
@@ -749,6 +780,7 @@ async function createLanguageService(
         let compilerOptions: ts.CompilerOptions;
         let parsedConfig: ts.ParsedCommandLine;
         let extendedConfigPaths: Set<string> | undefined;
+        let snapshotManager: SnapshotManager;
 
         if (tsconfigPath) {
             const info = ensureTsConfigInfoUpToDate(tsconfigPath);
@@ -760,10 +792,12 @@ async function createLanguageService(
             compilerOptions = info.parsedCommandLine.options;
             parsedConfig = info.parsedCommandLine;
             extendedConfigPaths = info.extendedConfigPaths;
+            snapshotManager = info.snapshotManager;
         } else {
             const config = parseDefaultCompilerOptions();
             compilerOptions = config.compilerOptions;
             parsedConfig = config.parsedConfig;
+            snapshotManager = createSnapshotManager(parsedConfig, tsconfigPath);
         }
 
         if (
@@ -818,7 +852,8 @@ async function createLanguageService(
             ...parsedConfig,
             fileNames: parsedConfig.fileNames.map(normalizePath),
             options: compilerOptions,
-            extendedConfigPaths
+            extendedConfigPaths,
+            snapshotManager
         };
     }
 
@@ -890,22 +925,30 @@ async function createLanguageService(
     }
 
     /**
-     * Disable usage of project files.
+     * Toggle usage of project files.
      * running language service in a reduced mode for
      * large projects with improperly excluded tsconfig.
      */
     function reduceLanguageServiceCapabilityIfFileSizeTooBig() {
-        if (
-            exceedsTotalSizeLimitForNonTsFiles(
-                compilerOptions,
-                tsconfigPath,
-                snapshotManager,
-                tsSystem
-            )
-        ) {
+        const shouldDisabled = exceedsTotalSizeLimitForNonTsFiles(
+            compilerOptions,
+            tsconfigPath,
+            snapshotManager,
+            tsSystem
+        );
+        if (!shouldDisabled) {
+            languageServiceReducedMode = false;
+            return;
+        }
+
+        if (!languageServiceReducedMode) {
             languageService.cleanupSemanticCache();
             languageServiceReducedMode = true;
             if (project) {
+                if (project.autoImportProviderHost) {
+                    project.autoImportProviderHost.close();
+                }
+                project.autoImportProviderHost = undefined;
                 project.languageServiceEnabled = false;
             }
             docContext.notifyExceedSizeLimit?.();
@@ -1154,7 +1197,7 @@ async function createLanguageService(
             return null;
         }
 
-        const json = ts.parseJsonText(configFilePath, content);
+        const json = ts.parseJsonText(configFilePath, content) as ts.TsConfigSourceFile;
 
         const extendedConfigPaths = new Set<string>();
         const { extendedConfigCache } = docContext;
@@ -1198,7 +1241,11 @@ async function createLanguageService(
 
         parsedCommandLine.options.allowNonTsExtensions = true;
 
-        const snapshotManager = createSnapshotManager(parsedCommandLine, configFilePath);
+        const snapshotManager = createSnapshotManager(
+            parsedCommandLine,
+            configFilePath,
+            json.configFileSpecs
+        );
 
         const tsconfigInfo: TsConfigInfo = {
             parsedCommandLine,
@@ -1282,7 +1329,7 @@ function exceedsTotalSizeLimitForNonTsFiles(
     snapshotManager: SnapshotManager,
     tsSystem: ts.System
 ): boolean {
-    if (compilerOptions.disableSizeLimit) {
+    if (compilerOptions.disableSizeLimit || tsSystem.getFileSize === undefined) {
         return false;
     }
 
@@ -1296,17 +1343,18 @@ function exceedsTotalSizeLimitForNonTsFiles(
     let totalNonTsFileSize = 0;
 
     const fileNames = snapshotManager.getProjectFileNames();
+    const getFileSize = tsSystem.getFileSize;
     for (const fileName of fileNames) {
         if (hasTsExtensions(fileName)) {
             continue;
         }
 
-        totalNonTsFileSize += tsSystem.getFileSize?.(fileName) ?? 0;
+        totalNonTsFileSize += getFileSize(fileName);
 
         if (totalNonTsFileSize > availableSpace) {
             const top5LargestFiles = fileNames
                 .filter((name) => !hasTsExtensions(name))
-                .map((name) => ({ name, size: tsSystem.getFileSize?.(name) ?? 0 }))
+                .map((name) => ({ name, size: getFileSize(name) }))
                 .sort((a, b) => b.size - a.size)
                 .slice(0, 5);
 

--- a/packages/language-server/test/plugins/typescript/service.test.ts
+++ b/packages/language-server/test/plugins/typescript/service.test.ts
@@ -790,6 +790,62 @@ describe('service', () => {
         assert.equal(normalizePath(ls2.tsconfigPath), normalizePath(tsconfigPath));
     });
 
+    it('enters reduced mode', async () => {
+        const dirPath = getRandomVirtualDirPath(testDir);
+        const { virtualSystem, lsDocumentContext, rootUris } = setup();
+
+        let notified = false;
+        lsDocumentContext.notifyExceedSizeLimit = () => {
+            notified = true;
+        };
+
+        const tsconfigPath = path.join(dirPath, 'tsconfig.json');
+        const name = 'very-large.js';
+        const largeFilePath = path.join(dirPath, name);
+        const svelteFileName = 'newFile.svelte';
+        const svelteFilePath = path.join(dirPath, svelteFileName);
+
+        virtualSystem.writeFile(
+            tsconfigPath,
+            JSON.stringify({
+                compilerOptions: {
+                    strict: true
+                }
+            })
+        );
+        virtualSystem.writeFile(largeFilePath, '');
+
+        const getFileSize = virtualSystem.getFileSize!;
+        virtualSystem.getFileSize = (fileName) => {
+            if (fileName.endsWith(name)) {
+                return 21 * 1024 * 1024; // 21 MiB
+            }
+            return getFileSize(fileName);
+        };
+
+        let ls = await getService(largeFilePath, rootUris, lsDocumentContext);
+        assert.ok(notified, 'expected to notifyExceedSizeLimit');
+        ls.getService();
+        console.log(ls.snapshotManager.getProjectFileNames());
+
+        // adding after reduced mode is enabled
+        const newFileSvelte = path.join(dirPath, 'newFile.svelte');
+        virtualSystem.writeFile(newFileSvelte, '');
+        ls.scheduleProjectFileUpdate([svelteFilePath]);
+
+        ls = await getService(newFileSvelte, rootUris, lsDocumentContext);
+        assert.equal(normalizePath(ls.tsconfigPath), normalizePath(tsconfigPath));
+        const snapshot = Document.createForTest(pathToUrl(svelteFilePath), '');
+        snapshot.openedByClient = true;
+        ls.updateSnapshot(snapshot);
+        ls.getService();
+
+        const semanticDiagnostics = getSemanticDiagnosticsMessages(ls, svelteFilePath);
+        assert.deepStrictEqual(semanticDiagnostics, [
+            "Cannot find type definition file for 'svelte'."
+        ]);
+    });
+
     function getSemanticDiagnosticsMessages(ls: LanguageServiceContainer, filePath: string) {
         return ls
             .getService()

--- a/packages/language-server/test/plugins/typescript/testfiles/tsconfig.json
+++ b/packages/language-server/test/plugins/typescript/testfiles/tsconfig.json
@@ -12,7 +12,7 @@
         "resolveJsonModule": true
     },
     "include": [
-        "**/*", 
+        "**/*",
         // This is needed because "**" doesn't include dot folders
         "./.svelte-kit/**/*"
     ],

--- a/packages/language-server/test/plugins/typescript/testfiles/tsconfig.json
+++ b/packages/language-server/test/plugins/typescript/testfiles/tsconfig.json
@@ -11,7 +11,11 @@
         /**For testing import json file*/
         "resolveJsonModule": true
     },
-    "include": ["**/*", "./.svelte-kit/**/*"],
+    "include": [
+        "**/*", 
+        // This is needed because "**" doesn't include dot folders
+        "./.svelte-kit/**/*"
+    ],
     "exclude": [
         /**For testing exclude */
         "./dist"

--- a/packages/language-server/test/plugins/typescript/testfiles/tsconfig.json
+++ b/packages/language-server/test/plugins/typescript/testfiles/tsconfig.json
@@ -11,6 +11,7 @@
         /**For testing import json file*/
         "resolveJsonModule": true
     },
+    "include": ["**/*", "./.svelte-kit/**/*"],
     "exclude": [
         /**For testing exclude */
         "./dist"


### PR DESCRIPTION
#3108

Two fixes in this PR. One is to align the default tsconfig "include" logic with tsc/tsserver. While debugging #3108, I found that TypeScript actually excludes "dot folders" and node_modules from the `**/*` pattern. The problem that triggers the "large amount of files" warning is mainly our project files update logic.

The other fix is about the reduced mode; the problem is that we don't return any files in `getScriptFileNames`. Thus, the language service throws an error if any features were requested with the file.