### PR TITLE
fix: hide imports from document symbols

### DIFF
--- a/.changeset/hide-import-document-symbols.md
+++ b/.changeset/hide-import-document-symbols.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+Hide imports from document symbols so they do not appear in the editor outline.

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -108,6 +108,22 @@ import { CallHierarchyProviderImpl } from './features/CallHierarchyProvider';
 import { CodeLensProviderImpl } from './features/CodeLensProvider';
 import { WorkspaceSymbolsProviderImpl } from './features/WorkspaceSymbolProvider';
 
+function getImportSpans(sourceFile: ts.SourceFile) {
+    const spans: Array<{ start: number; end: number }> = [];
+    collectImportSpans(sourceFile);
+    return spans;
+
+    function collectImportSpans(node: ts.Node) {
+        if (ts.isImportDeclaration(node) || ts.isImportEqualsDeclaration(node)) {
+            spans.push({ start: node.getStart(sourceFile), end: node.getEnd() });
+            return;
+        }
+
+        // svelte2tsx can place instance-script declarations inside generated render code, so inspect nested nodes too.
+        node.forEachChild(collectImportSpans);
+    }
+}
+
 export class TypeScriptPlugin
     implements
         DiagnosticsProvider,
@@ -279,9 +295,12 @@ export class TypeScriptPlugin
         }
 
         const navTree = lang.getNavigationTree(tsDoc.filePath);
+        const sourceFile = lang.getProgram()?.getSourceFile(tsDoc.filePath);
+        // Keep the fallback so document symbols continue to work if source is unavailable.
+        const importSpans = sourceFile ? getImportSpans(sourceFile) : [];
 
         const symbols: SymbolInformation[] = [];
-        collectSymbols(navTree, undefined, (symbol) => symbols.push(symbol));
+        collectSymbols(navTree, undefined);
 
         const topContainerName = symbols[0].name;
         const result: SymbolInformation[] = [];
@@ -346,15 +365,11 @@ export class TypeScriptPlugin
 
         return result;
 
-        function collectSymbols(
-            tree: NavigationTree,
-            container: string | undefined,
-            cb: (symbol: SymbolInformation) => void
-        ) {
+        function collectSymbols(tree: NavigationTree, container: string | undefined) {
             const start = tree.spans[0];
             const end = tree.spans[tree.spans.length - 1];
-            if (start && end) {
-                cb(
+            if (start && end && !isImportSymbol(start)) {
+                symbols.push(
                     SymbolInformation.create(
                         tree.text,
                         symbolKindFromString(tree.kind),
@@ -369,9 +384,18 @@ export class TypeScriptPlugin
             }
             if (tree.childItems) {
                 for (const child of tree.childItems) {
-                    collectSymbols(child, tree.text, cb);
+                    collectSymbols(child, tree.text);
                 }
             }
+        }
+
+        function isImportSymbol(span: { start: number; length: number }) {
+            // Navigation tree entries for imported bindings cover only their name, so check
+            // whether that smaller span is contained by an import declaration.
+            return importSpans.some(
+                (importSpan) =>
+                    importSpan.start <= span.start && importSpan.end >= span.start + span.length
+            );
         }
     }
 

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -312,6 +312,14 @@ describe('TypescriptPlugin', function () {
         ]);
     });
 
+    it('does not provide document symbols for imports', async () => {
+        const { plugin, document } = setup('documentsymbols-imports.svelte');
+        const symbols = await plugin.getDocumentSymbols(document);
+        const names = symbols.map((symbol) => symbol.name).sort();
+
+        assert.deepStrictEqual(names, ['answer', 'local', 'run']);
+    });
+
     it('can cancel document symbols before promise resolved', async () => {
         const { plugin, document } = setup('documentsymbols.svelte');
         const cancellationTokenSource = new CancellationTokenSource();

--- a/packages/language-server/test/plugins/typescript/testfiles/documentsymbols-imports.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/documentsymbols-imports.svelte
@@ -1,0 +1,21 @@
+<script context="module" lang="ts">
+  import { moduleValue } from './documentsymbols-imports-module';
+
+  export const answer = moduleValue;
+</script>
+
+<script lang="ts">
+  import DefaultComponent from './documentsymbols-imports-component.svelte';
+  import * as utils from './documentsymbols-imports-utils';
+  import { value, original as renamed } from './documentsymbols-imports-values';
+  import type { Options } from './documentsymbols-imports-types';
+  import type * as Types from './documentsymbols-imports-types';
+  import legacy = require('./documentsymbols-imports-legacy');
+
+  const local = value;
+  function run(): Options | Types.Options | undefined {
+    return undefined;
+  }
+</script>
+
+<DefaultComponent>{local}{renamed}{utils.value}{legacy.value}</DefaultComponent>


### PR DESCRIPTION
While not explicitly outlined, VSCode's current behavior for the TS LSP is to omit top-level imports from document symbols (see [#50829](https://github.com/microsoft/vscode/issues/50829) and [f1efd11](https://github.com/microsoft/vscode/commit/f1efd11c2a6da4533f65d66bf7921c552270ca4e)). This has the nice side effect of reducing clutter in the "Outline" view.

**Before**:
<img width="300" height="253" alt="image" src="https://github.com/user-attachments/assets/13943df0-018a-457d-abf2-968c8e597b54" />

**After**:
<img width="263" height="155" alt="image" src="https://github.com/user-attachments/assets/b36148cd-28ca-4d03-b712-32dde53fecd0" />

Expanded tests to cover default, namespace, named, renamed, type-only, and `import = require` imports, while preserving other symbols.