### PR TITLE
fix: hide generated template functions from document symbols

### DIFF
--- a/.changeset/hide-generated-snippet-document-symbols.md
+++ b/.changeset/hide-generated-snippet-document-symbols.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+Hide generated snippet functions from document symbols so they do not appear in the editor outline.

--- a/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
+++ b/packages/language-server/src/plugins/typescript/TypeScriptPlugin.ts
@@ -107,6 +107,7 @@ import {
 import { CallHierarchyProviderImpl } from './features/CallHierarchyProvider';
 import { CodeLensProviderImpl } from './features/CodeLensProvider';
 import { WorkspaceSymbolsProviderImpl } from './features/WorkspaceSymbolProvider';
+import type { SvelteDocumentSnapshot } from './DocumentSnapshot';
 
 export class TypeScriptPlugin
     implements
@@ -326,6 +327,23 @@ export class TypeScriptPlugin
             }
 
             if (symbol.name === '<function>') {
+                // Generated functions in the template can cover arbitrary template text, which
+                // results in malformed entries. Keep functions that map to an expression the user
+                // actually wrote.
+                const symbolStartOffset = document.offsetAt(symbol.location.range.start);
+                // svelte2tsx replaces the instance script's end tag with the generated template
+                // callback. Its start therefore maps to scriptInfo.end, which is also considered
+                // inside the script by isInScript. Treat this boundary as template code here so the
+                // generated callback is filtered out.
+                const startsAtScriptEnd = symbolStartOffset === document.scriptInfo?.end;
+                if (
+                    startsAtScriptEnd ||
+                    (!isInScript(symbol.location.range.start, document) &&
+                        !this.isInUserWrittenTemplateFunction(tsDoc, symbolStartOffset))
+                ) {
+                    continue;
+                }
+
                 let name = getTextInRange(symbol.location.range, document.getText()).trimLeft();
                 if (name.length > 50) {
                     name = name.substring(0, 50) + '...';
@@ -373,6 +391,29 @@ export class TypeScriptPlugin
                 }
             }
         }
+    }
+
+    private isInUserWrittenTemplateFunction(
+        tsDoc: SvelteDocumentSnapshot,
+        offset: number
+    ): boolean {
+        let result = false;
+
+        tsDoc.walkSvelteAst({
+            enter(node) {
+                if (offset < node.start || offset > node.end) {
+                    this.skip();
+                    return;
+                }
+
+                if (node.type === 'ArrowFunctionExpression' || node.type === 'FunctionExpression') {
+                    result = true;
+                    this.skip();
+                }
+            }
+        });
+
+        return result;
     }
 
     async getCompletions(

--- a/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
+++ b/packages/language-server/test/plugins/typescript/TypescriptPlugin.test.ts
@@ -34,14 +34,14 @@ describe('TypescriptPlugin', function () {
         return input.replace(/\r\n/g, '~:~').replace(/\n/g, '~:~').replace(/~:~/g, '\n');
     }
 
-    function setup(filename: string) {
+    function setup(filename: string, text?: string) {
         const docManager = new DocumentManager((args) =>
             args.uri.includes('.svelte')
                 ? new Document(args.uri, harmonizeNewLines(args.text))
                 : document
         );
         const filePath = path.join(testDir, filename);
-        const document = new Document(pathToUrl(filePath), ts.sys.readFile(filePath) || '');
+        const document = new Document(pathToUrl(filePath), text ?? ts.sys.readFile(filePath) ?? '');
         const lsConfigManager = new LSConfigManager();
         const workspaceUris = [pathToUrl(testDir)];
         const lsAndTsDocResolver = new LSAndTSDocResolver(
@@ -320,6 +320,32 @@ describe('TypescriptPlugin', function () {
         cancellationTokenSource.cancel();
         assert.deepStrictEqual(await symbolsPromise, []);
     });
+
+    for (const finalNewline of ['', '\n']) {
+        it(`filters the generated template function ${finalNewline ? 'with' : 'without'} a final newline`, async () => {
+            // Keep this source inline because formatters add a final newline to fixture files.
+            const text = [
+                '<script>',
+                '  import Test1 from "./Test1.svelte";',
+                '  (function () { return true; })();',
+                '</script>',
+                '',
+                '<Test1></Test1>'
+            ].join('\n');
+            assert.ok(!text.endsWith('\n'));
+
+            const { plugin, document } = setup(
+                'documentsymbols-no-final-newline.svelte',
+                text + finalNewline
+            );
+            const symbols = await plugin.getDocumentSymbols(document);
+
+            assert.deepStrictEqual(symbols.map((symbol) => symbol.name).sort(), [
+                'Test1',
+                'function () { return true; }'
+            ]);
+        });
+    }
 
     it('provides definitions within svelte doc', async () => {
         const { plugin, document } = setup('definitions.svelte');
@@ -824,6 +850,25 @@ describe('TypescriptPlugin', function () {
     if (!isSvelte5Plus) {
         return;
     }
+
+    it('filters generated snippet functions without hiding source-authored template symbols', async () => {
+        const { plugin, document } = setup('documentsymbols-snippets.v5/input.svelte');
+
+        const symbols = await plugin.getDocumentSymbols(document);
+        const names = symbols.map((symbol) => symbol.name).sort();
+
+        assert.ok(names.includes('items.map() callback'));
+        assert.deepStrictEqual(names, [
+            'children',
+            'children',
+            'data',
+            'getter',
+            'item',
+            'items',
+            'items.map() callback',
+            'value'
+        ]);
+    });
 
     it('provides definitions from svelte to rune-mode svelte doc', async () => {
         const { plugin, document } = setup('definition/definition-rune.svelte');

--- a/packages/language-server/test/plugins/typescript/testfiles/documentsymbols-no-final-newline.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/documentsymbols-no-final-newline.svelte
@@ -1,0 +1,5 @@
+<script>
+    import Test1 from './Test1.svelte';
+</script>
+
+<Test1></Test1>

--- a/packages/language-server/test/plugins/typescript/testfiles/documentsymbols-snippets.v5/input.svelte
+++ b/packages/language-server/test/plugins/typescript/testfiles/documentsymbols-snippets.v5/input.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+    const value = true;
+    const items = [1, 2, 3];
+</script>
+
+{items.map((item) => item)}
+
+{#each items as item}
+    {@const getter = () => item}
+    {getter()}
+{/each}
+
+<Component>
+    {#snippet children()}
+        <Child {value} />
+    {/snippet}
+</Component>
+
+<Component>
+    {#snippet children({ data })}
+        <Child {data} />
+    {/snippet}
+</Component>


### PR DESCRIPTION
Multi-line snippets currently generate garbage output. Detect generated anonymous functions by first checking if they are in a template & checking if they were written by the user, then skip those symbols.

**Before**:
<img width="357" height="299" alt="image" src="https://github.com/user-attachments/assets/1550c8c3-266b-4780-82e7-f391da6d4369" />

**After**:
<img width="439" height="257" alt="image" src="https://github.com/user-attachments/assets/42716c0a-4df9-4469-9d56-eeb8443fc763" />

Tests cases include parametrized and non-parametrized snippets, as well as user-defined anonymous functions.