### PR TITLE
fix: fallback to prettier-plugin-svelte version 4 for Svelte 5

### DIFF
--- a/.changeset/funny-beers-refuse.md
+++ b/.changeset/funny-beers-refuse.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+fix: fallback to prettier-plugin-svelte version 4 for Svelte 5

--- a/package.json
+++ b/package.json
@@ -24,5 +24,12 @@
         "prettier": "~3.3.3",
         "ts-node": "^10.0.0"
     },
-    "packageManager": "pnpm@9.3.0"
+    "packageManager": "pnpm@9.3.0",
+    "pnpm": {
+        "peerDependencyRules": {
+            "allowedVersions": {
+                "prettier-plugin-svelte4>svelte": "^4.2.19"
+            }
+        }
+    }
 }

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -62,6 +62,7 @@
         "globrex": "^0.1.2",
         "prettier": "~3.3.3",
         "prettier-plugin-svelte": "^3.5.0",
+        "prettier-plugin-svelte4": "npm:prettier-plugin-svelte@^4.0.0",
         "svelte": "^4.2.19",
         "svelte2tsx": "workspace:~",
         "typescript-auto-import-cache": "^0.3.6",

--- a/packages/language-server/src/plugins/svelte/SveltePlugin.ts
+++ b/packages/language-server/src/plugins/svelte/SveltePlugin.ts
@@ -275,9 +275,17 @@ export class SveltePlugin
             // the workspace already. If we did it, Prettier would - for some reason - use
             // the workspace version for parsing and the extension version for printing,
             // which could crash if the contract of the parser output changed.
-            return !isFallback && (await hasSveltePluginLoaded(prettier, plugins))
-                ? []
-                : [require.resolve('prettier-plugin-svelte')];
+            if (!isFallback && (await hasSveltePluginLoaded(prettier, plugins))) {
+                return [];
+            }
+            // In the fallback case, use the plugin version that fits the Svelte version
+            // of the component that should be formatted. Version 4 of the plugin
+            // only supports Svelte 5.
+            return [
+                require.resolve(
+                    document.isSvelte5 ? 'prettier-plugin-svelte4' : 'prettier-plugin-svelte'
+                )
+            ];
         }
 
         async function hasSveltePluginLoaded(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       prettier-plugin-svelte:
         specifier: ^3.5.0
         version: 3.5.0(prettier@3.3.3)(svelte@4.2.20)
+      prettier-plugin-svelte4:
+        specifier: npm:prettier-plugin-svelte@^4.0.0
+        version: prettier-plugin-svelte@4.1.1(prettier@3.3.3)(svelte@4.2.20)
       svelte:
         specifier: ^4.2.19
         version: 4.2.20
@@ -1751,6 +1754,13 @@ packages:
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+
+  prettier-plugin-svelte@4.1.1:
+    resolution: {integrity: sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^5.0.0
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -3555,6 +3565,11 @@ snapshots:
       source-map-js: 1.2.1
 
   prettier-plugin-svelte@3.5.0(prettier@3.3.3)(svelte@4.2.20):
+    dependencies:
+      prettier: 3.3.3
+      svelte: 4.2.20
+
+  prettier-plugin-svelte@4.1.1(prettier@3.3.3)(svelte@4.2.20):
     dependencies:
       prettier: 3.3.3
       svelte: 4.2.20


### PR DESCRIPTION
Fixes #3064

We add an npm alias, detect if the Svelte file in question uses Svelte 5, if so load the corresponding prettier plugin.