### PR TITLE
fix: config discovery under dot directories

### DIFF
--- a/.changeset/fix-config-crawl-dot-ancestor.md
+++ b/.changeset/fix-config-crawl-dot-ancestor.md
@@ -1,0 +1,5 @@
+---
+'svelte-language-server': patch
+---
+
+Fix config discovery when the workspace sits under a dot directory.

--- a/packages/language-server/src/lib/documents/configLoader.ts
+++ b/packages/language-server/src/lib/documents/configLoader.ts
@@ -132,9 +132,8 @@ export class ConfigLoader {
 
             const pathResults = new this.globSync({})
                 .withPathSeparator('/')
-                .exclude((_, path) => {
-                    // no / at the start, path could start with node_modules
-                    return path.includes('node_modules/') || path.includes('/.') || path[0] === '.';
+                .exclude((dirName) => {
+                    return dirName === 'node_modules' || dirName.startsWith('.');
                 })
                 .filter((path, isDir) => {
                     return !isDir && targetRegex.test(path);


### PR DESCRIPTION
Config discovery pruned every subdirectory when the workspace sat under a dot directory. The fdir exclude matched '/.' against the full path, so it also hit things like `~/.cache/builddir`. This narrows it to the directory name, same as #3037.